### PR TITLE
feat: 관심사 등록

### DIFF
--- a/src/main/java/com/team3/monew/controller/InterestController.java
+++ b/src/main/java/com/team3/monew/controller/InterestController.java
@@ -1,0 +1,29 @@
+package com.team3.monew.controller;
+
+import com.team3.monew.controller.api.InterestApi;
+import com.team3.monew.dto.interest.InterestDto;
+import com.team3.monew.dto.interest.InterestResisterRequest;
+import com.team3.monew.service.InterestService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class InterestController implements InterestApi {
+
+  private final InterestService interestService;
+
+  @Override
+  public ResponseEntity<InterestDto> create(
+      @Valid @RequestBody InterestResisterRequest dto
+  ) {
+    InterestDto response = interestService.create(dto);
+
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(response);
+  }
+}

--- a/src/main/java/com/team3/monew/controller/InterestController.java
+++ b/src/main/java/com/team3/monew/controller/InterestController.java
@@ -2,7 +2,7 @@ package com.team3.monew.controller;
 
 import com.team3.monew.controller.api.InterestApi;
 import com.team3.monew.dto.interest.InterestDto;
-import com.team3.monew.dto.interest.InterestResisterRequest;
+import com.team3.monew.dto.interest.InterestRegisterRequest;
 import com.team3.monew.service.InterestService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +19,7 @@ public class InterestController implements InterestApi {
 
   @Override
   public ResponseEntity<InterestDto> create(
-      @Valid @RequestBody InterestResisterRequest dto
+      @Valid @RequestBody InterestRegisterRequest dto
   ) {
     InterestDto response = interestService.create(dto);
 

--- a/src/main/java/com/team3/monew/controller/api/InterestApi.java
+++ b/src/main/java/com/team3/monew/controller/api/InterestApi.java
@@ -1,7 +1,7 @@
 package com.team3.monew.controller.api;
 
 import com.team3.monew.dto.interest.InterestDto;
-import com.team3.monew.dto.interest.InterestResisterRequest;
+import com.team3.monew.dto.interest.InterestRegisterRequest;
 import com.team3.monew.global.response.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -54,9 +54,9 @@ public interface InterestApi {
           required = true,
           content = @Content(
               mediaType = "application/json",
-              schema = @Schema(implementation = InterestResisterRequest.class)
+              schema = @Schema(implementation = InterestRegisterRequest.class)
           )
       )
-      @RequestBody @Valid InterestResisterRequest dto
+      @RequestBody @Valid InterestRegisterRequest dto
   );
 }

--- a/src/main/java/com/team3/monew/controller/api/InterestApi.java
+++ b/src/main/java/com/team3/monew/controller/api/InterestApi.java
@@ -1,0 +1,62 @@
+package com.team3.monew.controller.api;
+
+import com.team3.monew.dto.interest.InterestDto;
+import com.team3.monew.dto.interest.InterestResisterRequest;
+import com.team3.monew.global.response.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Interest", description = "관심사 API")
+@RequestMapping("/api/interests")
+public interface InterestApi {
+
+  @Operation(
+      summary = "관심사 등록",
+      description = "관심사 이름과 키워드를 입력받아 새로운 관심사를 등록합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "201",
+          description = "관심사 등록 성공",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = InterestDto.class)
+          )
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = "잘못된 요청값입니다. (예: 키워드 없음, 형식 오류)",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class)
+          )
+      ),
+      @ApiResponse(
+          responseCode = "409",
+          description = "중복되거나 유사한 관심사 이름입니다.",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class)
+          )
+      )
+  })
+  @PostMapping
+  ResponseEntity<InterestDto> create(
+      @io.swagger.v3.oas.annotations.parameters.RequestBody(
+          description = "등록할 관심사 정보",
+          required = true,
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = InterestResisterRequest.class)
+          )
+      )
+      @RequestBody @Valid InterestResisterRequest dto
+  );
+}

--- a/src/main/java/com/team3/monew/dto/interest/InterestDto.java
+++ b/src/main/java/com/team3/monew/dto/interest/InterestDto.java
@@ -1,0 +1,13 @@
+package com.team3.monew.dto.interest;
+
+import java.util.List;
+import java.util.UUID;
+
+public record InterestDto(
+        UUID id,
+        String name,
+        List<String> keywords,
+        int subscriberCount,
+        boolean subscribedByMe
+) {
+}

--- a/src/main/java/com/team3/monew/dto/interest/InterestRegisterRequest.java
+++ b/src/main/java/com/team3/monew/dto/interest/InterestRegisterRequest.java
@@ -4,11 +4,11 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 
-public record InterestResisterRequest(
+public record InterestRegisterRequest(
     @NotBlank
     String name,
     @NotEmpty
-    List<String> keywords
+    List<@NotBlank String> keywords
 ) {
 
 }

--- a/src/main/java/com/team3/monew/dto/interest/InterestResisterRequest.java
+++ b/src/main/java/com/team3/monew/dto/interest/InterestResisterRequest.java
@@ -1,0 +1,14 @@
+package com.team3.monew.dto.interest;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record InterestResisterRequest(
+    @NotBlank
+    String name,
+    @NotEmpty
+    List<String> keywords
+) {
+
+}

--- a/src/main/java/com/team3/monew/entity/Interest.java
+++ b/src/main/java/com/team3/monew/entity/Interest.java
@@ -37,4 +37,10 @@ public class Interest extends BaseEntity {
 
         return interest;
     }
+
+    // keyword는 해당 메서드를 통해 서비스에서 따로 붙임 -> entity에 책임이 몰리는 것을 방지하기 위함
+    public void addKeyword(String keyword) {
+        InterestKeyword interestKeyword = InterestKeyword.create(this, keyword);
+        this.keywords.add(interestKeyword);
+    }
 }

--- a/src/main/java/com/team3/monew/entity/InterestKeyword.java
+++ b/src/main/java/com/team3/monew/entity/InterestKeyword.java
@@ -8,27 +8,32 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(
-        name = "interest_keywords",
-        uniqueConstraints = {
-                @UniqueConstraint(name = "uk_interest_keywords_interest_id_keyword", columnNames = {"interest_id", "keyword"})
-        }
+    name = "interest_keywords",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_interest_keywords_interest_id_keyword", columnNames = {
+            "interest_id", "keyword"})
+    }
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class InterestKeyword extends BaseEntity {
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "interest_id", nullable = false)
-    private Interest interest;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "interest_id", nullable = false)
+  private Interest interest;
 
-    @Column(nullable = false, length = 100)
-    private String keyword;
+  @Column(nullable = false, length = 100)
+  private String keyword;
 
-    public static InterestKeyword create(Interest interest, String keyword) {
-        InterestKeyword interestKeyword = new InterestKeyword();
-        interestKeyword.interest = interest;
-        interestKeyword.keyword = keyword;
+  public static InterestKeyword create(Interest interest, String keyword) {
+    InterestKeyword interestKeyword = new InterestKeyword();
+    interestKeyword.interest = interest;
+    interestKeyword.keyword = keyword;
 
-        return interestKeyword;
-    }
+    return interestKeyword;
+  }
+
+  public void assignInterest(Interest interest) {
+    this.interest = interest;
+  }
 }

--- a/src/main/java/com/team3/monew/exception/interest/InterestDuplicateNameException.java
+++ b/src/main/java/com/team3/monew/exception/interest/InterestDuplicateNameException.java
@@ -1,0 +1,12 @@
+package com.team3.monew.exception.interest;
+
+import com.team3.monew.global.enums.ErrorCode;
+
+import java.util.Map;
+
+public class InterestDuplicateNameException extends InterestException {
+
+  public InterestDuplicateNameException() {
+    super(ErrorCode.INTEREST_NAME_DUPLICATE);
+  }
+}

--- a/src/main/java/com/team3/monew/exception/interest/InterestException.java
+++ b/src/main/java/com/team3/monew/exception/interest/InterestException.java
@@ -1,0 +1,17 @@
+package com.team3.monew.exception.interest;
+
+import com.team3.monew.global.enums.ErrorCode;
+import com.team3.monew.global.exception.BusinessException;
+
+import java.util.Map;
+
+public class InterestException extends BusinessException {
+
+  public InterestException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  public InterestException(ErrorCode errorCode, Map<String, Object> details) {
+    super(errorCode, details);
+  }
+}

--- a/src/main/java/com/team3/monew/exception/interest/InterestNotFoundException.java
+++ b/src/main/java/com/team3/monew/exception/interest/InterestNotFoundException.java
@@ -1,0 +1,12 @@
+package com.team3.monew.exception.interest;
+
+import com.team3.monew.global.enums.ErrorCode;
+
+import java.util.Map;
+
+public class InterestNotFoundException extends InterestException {
+
+  public InterestNotFoundException() {
+    super(ErrorCode.INTEREST_NOT_FOUND);
+  }
+}

--- a/src/main/java/com/team3/monew/global/enums/ErrorCode.java
+++ b/src/main/java/com/team3/monew/global/enums/ErrorCode.java
@@ -9,7 +9,12 @@ public enum ErrorCode {
   EMAIL_DUPLICATION(HttpStatus.CONFLICT, "해당 이메일이 이미 존재합니다."),
   INVALID_PARAMETER_TYPE(HttpStatus.BAD_REQUEST, "해당 파라미터가 유효하지 않습니다."),
   INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "입력 형식이 올바르지 않습니다."),
-  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."),
+
+  // INTEREST EXCEPTION
+  INTEREST_NAME_DUPLICATE(HttpStatus.CONFLICT, "중복된 관심사 이름입니다."),
+  INTEREST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 관심사를 찾을 수 없습니다."),
+  ;
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/com/team3/monew/mapper/InterestMapper.java
+++ b/src/main/java/com/team3/monew/mapper/InterestMapper.java
@@ -1,0 +1,23 @@
+package com.team3.monew.mapper;
+
+import com.team3.monew.dto.interest.InterestDto;
+import com.team3.monew.entity.Interest;
+import com.team3.monew.entity.InterestKeyword;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface InterestMapper {
+
+  @Mapping(target = "keywords", source = "interest.keywords")
+  @Mapping(target = "subscribedByMe", source = "subscribedByMe")
+  InterestDto toDto(Interest interest, boolean subscribedByMe);
+
+  default List<String> mapKeywords(List<InterestKeyword> keywords) {
+    return keywords.stream()
+        .map(InterestKeyword::getKeyword)
+        .toList();
+  }
+}

--- a/src/main/java/com/team3/monew/repository/InterestRepository.java
+++ b/src/main/java/com/team3/monew/repository/InterestRepository.java
@@ -1,0 +1,14 @@
+package com.team3.monew.repository;
+
+import com.team3.monew.entity.Interest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface InterestRepository extends JpaRepository<Interest, UUID> {
+
+    boolean existsByName(String name);
+
+    Optional<Interest> findInterestById(UUID interestId);
+}

--- a/src/main/java/com/team3/monew/repository/InterestRepository.java
+++ b/src/main/java/com/team3/monew/repository/InterestRepository.java
@@ -8,7 +8,5 @@ import java.util.UUID;
 
 public interface InterestRepository extends JpaRepository<Interest, UUID> {
 
-    boolean existsByName(String name);
-
-    Optional<Interest> findInterestById(UUID interestId);
+  boolean existsByName(String name);
 }

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -9,6 +9,7 @@ import com.team3.monew.mapper.InterestMapper;
 import com.team3.monew.repository.InterestRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,10 +35,8 @@ public class InterestService {
     }
 
     List<Interest> interests = interestRepository.findAll();
-
     for (Interest interest : interests) {
       double similarity = calculateSimilarity(interest.getName(), dto.name());
-
       if (similarity >= 0.8) {
         log.warn("관심사 등록 실패 - 유사한 이름 존재, requestName={}, existingName={}, similarity={}",
             dto.name(), interest.getName(), similarity);
@@ -48,7 +47,13 @@ public class InterestService {
     Interest interest = Interest.create(dto.name());
     dto.keywords().forEach(interest::addKeyword);
 
-    Interest savedInterest = interestRepository.save(interest);
+    Interest savedInterest;
+    try {
+      savedInterest = interestRepository.saveAndFlush(interest);
+    } catch (DataIntegrityViolationException e) {
+      log.warn("관심사 등록 실패 - DB unique 제약 위반, name={}", dto.name());
+      throw new InterestDuplicateNameException();
+    }
 
     log.info("관심사 등록 성공 - interestId={}, name={}",
         savedInterest.getId(), savedInterest.getName());

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -1,0 +1,103 @@
+package com.team3.monew.service;
+
+import com.team3.monew.dto.interest.InterestDto;
+import com.team3.monew.dto.interest.InterestResisterRequest;
+import com.team3.monew.entity.Interest;
+import com.team3.monew.exception.interest.InterestDuplicateNameException;
+import com.team3.monew.exception.interest.InterestNotFoundException;
+import com.team3.monew.mapper.InterestMapper;
+import com.team3.monew.repository.InterestRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+public class InterestService {
+
+  private final InterestRepository interestRepository;
+  private final InterestMapper interestMapper;
+
+  public InterestDto create(InterestResisterRequest dto) {
+    log.info("관심사 등록 요청 - name={}, keywordCount={}",
+        dto.name(), dto.keywords().size());
+
+    if (interestRepository.existsByName(dto.name())) {
+      log.warn("관심사 등록 실패 - 중복된 이름, name={}", dto.name());
+      throw new InterestDuplicateNameException();
+    }
+
+    List<Interest> interests = interestRepository.findAll();
+
+    for (Interest interest : interests) {
+      double similarity = calculateSimilarity(interest.getName(), dto.name());
+
+      if (similarity >= 0.8) {
+        log.warn("관심사 등록 실패 - 유사한 이름 존재, requestName={}, existingName={}, similarity={}",
+            dto.name(), interest.getName(), similarity);
+        throw new InterestDuplicateNameException();
+      }
+    }
+
+    Interest interest = Interest.create(dto.name());
+    dto.keywords().forEach(interest::addKeyword);
+
+    Interest savedInterest = interestRepository.save(interest);
+
+    log.info("관심사 등록 성공 - interestId={}, name={}",
+        savedInterest.getId(), savedInterest.getName());
+
+    return interestMapper.toDto(savedInterest, false);
+  }
+
+  private Interest findInterestOrElseThrow(UUID interestId) {
+    return interestRepository.findInterestById(interestId)
+        .orElseThrow(() -> new InterestNotFoundException());
+  }
+
+  // 유사도 계산 메서드
+  private double calculateSimilarity(String a, String b) {
+    String normalizedA = normalize(a);
+    String normalizedB = normalize(b);
+    int distance = levenshtein(normalizedA, normalizedB);
+    int maxLength = Math.max(normalizedA.length(), normalizedB.length());
+
+    return 1.0 - ((double) distance / maxLength);
+  }
+
+  // 문자열 정규화
+  private String normalize(String s) {
+    return s.trim().toLowerCase();
+  }
+
+  // 레벤슈타인 알고리즘
+  private int levenshtein(String a, String b) {
+    int[][] dp = new int[a.length() + 1][b.length() + 1];
+
+    for (int i = 0; i <= a.length(); i++) {
+      dp[i][0] = i;
+    }
+    for (int j = 0; j <= b.length(); j++) {
+      dp[0][j] = j;
+    }
+
+    for (int i = 1; i <= a.length(); i++) {
+      for (int j = 1; j <= b.length(); j++) {
+        int cost = a.charAt(i - 1) == b.charAt(j - 1) ? 0 : 1;
+
+        dp[i][j] = Math.min(
+            Math.min(dp[i - 1][j] + 1, dp[i][j - 1] + 1),
+            dp[i - 1][j - 1] + cost
+        );
+      }
+    }
+
+    return dp[a.length()][b.length()];
+  }
+}

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -1,7 +1,7 @@
 package com.team3.monew.service;
 
 import com.team3.monew.dto.interest.InterestDto;
-import com.team3.monew.dto.interest.InterestResisterRequest;
+import com.team3.monew.dto.interest.InterestRegisterRequest;
 import com.team3.monew.entity.Interest;
 import com.team3.monew.exception.interest.InterestDuplicateNameException;
 import com.team3.monew.exception.interest.InterestNotFoundException;
@@ -24,7 +24,7 @@ public class InterestService {
   private final InterestRepository interestRepository;
   private final InterestMapper interestMapper;
 
-  public InterestDto create(InterestResisterRequest dto) {
+  public InterestDto create(InterestRegisterRequest dto) {
     log.info("관심사 등록 요청 - name={}, keywordCount={}",
         dto.name(), dto.keywords().size());
 
@@ -57,8 +57,8 @@ public class InterestService {
   }
 
   private Interest findInterestOrElseThrow(UUID interestId) {
-    return interestRepository.findInterestById(interestId)
-        .orElseThrow(() -> new InterestNotFoundException());
+    return interestRepository.findById(interestId)
+        .orElseThrow(InterestNotFoundException::new);
   }
 
   // 유사도 계산 메서드
@@ -67,6 +67,11 @@ public class InterestService {
     String normalizedB = normalize(b);
     int distance = levenshtein(normalizedA, normalizedB);
     int maxLength = Math.max(normalizedA.length(), normalizedB.length());
+
+    if (maxLength == 0) {
+      // 둘 다 빈 문자열이면 동일한 것으로 간주함
+      return 1.0;
+    }
 
     return 1.0 - ((double) distance / maxLength);
   }

--- a/src/test/java/com/team3/monew/controller/InterestControllerTest.java
+++ b/src/test/java/com/team3/monew/controller/InterestControllerTest.java
@@ -1,0 +1,101 @@
+package com.team3.monew.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team3.monew.dto.interest.InterestDto;
+import com.team3.monew.dto.interest.InterestResisterRequest;
+import com.team3.monew.exception.interest.InterestDuplicateNameException;
+import com.team3.monew.service.InterestService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(InterestController.class)
+@Tag("unit")
+class InterestControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objMapper;
+
+  @MockitoBean
+  private InterestService interestService;
+
+  @Test
+  @DisplayName("내가 구독하지 않은 상태인 관심사를 등록할 수 있다")
+  void shouldResisterInterest_whenInterestNameDoesntDuplicate() throws Exception {
+    // given
+    InterestResisterRequest request = new InterestResisterRequest(
+        "주식",
+        List.of("코스피", "삼성전자")
+    );
+
+    InterestDto response = new InterestDto(
+        UUID.randomUUID(),
+        "주식",
+        List.of("코스피", "삼성전자"),
+        0,
+        false
+    );
+
+    given(interestService.create(any(InterestResisterRequest.class)))
+        .willReturn(response);
+
+    // when & then
+    mockMvc.perform(post("/api/interests")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objMapper.writeValueAsString(request)))
+        .andExpect(status().isCreated())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.name").value("주식"))
+        .andExpect(jsonPath("$.subscriberCount").value(0))
+        .andExpect(jsonPath("$.keywords[0]").value("코스피"))
+        .andExpect(jsonPath("$.keywords[1]").value("삼성전자"));
+  }
+
+  @Test
+  @DisplayName("중복된 관심사 이름이면 등록에 실패한다")
+  void shouldFailToResister_whenDuplicateNameExists() throws Exception {
+    // given
+    InterestResisterRequest request = new InterestResisterRequest(
+        "test",
+        List.of("keyword", "test")
+    );
+
+    given(interestService.create(any(InterestResisterRequest.class)))
+        .willThrow(new InterestDuplicateNameException());
+
+    // when & then
+    mockMvc.perform(post("/api/interests")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objMapper.writeValueAsString(request)))
+        .andExpect(status().isConflict());
+  }
+
+  @Test
+  @DisplayName("관심사 키워드가 비어 있으면 관심사 등록에 실패한다")
+  void shouldFailToResister_whenKeywordsAreEmpty() throws Exception {
+    // given
+    InterestResisterRequest request = new InterestResisterRequest("noKeyword", List.of());
+
+    // when & then
+    mockMvc.perform(post("/api/interests")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest());
+  }
+}

--- a/src/test/java/com/team3/monew/controller/InterestControllerTest.java
+++ b/src/test/java/com/team3/monew/controller/InterestControllerTest.java
@@ -2,7 +2,7 @@ package com.team3.monew.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.team3.monew.dto.interest.InterestDto;
-import com.team3.monew.dto.interest.InterestResisterRequest;
+import com.team3.monew.dto.interest.InterestRegisterRequest;
 import com.team3.monew.exception.interest.InterestDuplicateNameException;
 import com.team3.monew.service.InterestService;
 import org.junit.jupiter.api.DisplayName;
@@ -37,9 +37,9 @@ class InterestControllerTest {
 
   @Test
   @DisplayName("내가 구독하지 않은 상태인 관심사를 등록할 수 있다")
-  void shouldResisterInterest_whenInterestNameDoesntDuplicate() throws Exception {
+  void shouldRegisterInterest_whenInterestNameDoesntDuplicate() throws Exception {
     // given
-    InterestResisterRequest request = new InterestResisterRequest(
+    InterestRegisterRequest request = new InterestRegisterRequest(
         "주식",
         List.of("코스피", "삼성전자")
     );
@@ -52,7 +52,7 @@ class InterestControllerTest {
         false
     );
 
-    given(interestService.create(any(InterestResisterRequest.class)))
+    given(interestService.create(any(InterestRegisterRequest.class)))
         .willReturn(response);
 
     // when & then
@@ -69,14 +69,14 @@ class InterestControllerTest {
 
   @Test
   @DisplayName("중복된 관심사 이름이면 등록에 실패한다")
-  void shouldFailToResister_whenDuplicateNameExists() throws Exception {
+  void shouldFailToRegister_whenDuplicateNameExists() throws Exception {
     // given
-    InterestResisterRequest request = new InterestResisterRequest(
+    InterestRegisterRequest request = new InterestRegisterRequest(
         "test",
         List.of("keyword", "test")
     );
 
-    given(interestService.create(any(InterestResisterRequest.class)))
+    given(interestService.create(any(InterestRegisterRequest.class)))
         .willThrow(new InterestDuplicateNameException());
 
     // when & then
@@ -88,9 +88,9 @@ class InterestControllerTest {
 
   @Test
   @DisplayName("관심사 키워드가 비어 있으면 관심사 등록에 실패한다")
-  void shouldFailToResister_whenKeywordsAreEmpty() throws Exception {
+  void shouldFailToRegister_whenKeywordsAreEmpty() throws Exception {
     // given
-    InterestResisterRequest request = new InterestResisterRequest("noKeyword", List.of());
+    InterestRegisterRequest request = new InterestRegisterRequest("noKeyword", List.of());
 
     // when & then
     mockMvc.perform(post("/api/interests")

--- a/src/test/java/com/team3/monew/integration/InterestServiceIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/InterestServiceIntegrationTest.java
@@ -75,7 +75,7 @@ public class InterestServiceIntegrationTest {
 
   @Test
   @DisplayName("관심사 이름의 유사도가 80% 이상이면 등록에 실패한다")
-  void shouldFailToRegisterInterest_whenNameSimilar80percenOver() {
+  void shouldFailToRegisterInterest_whenNameSimilar80percentOver() {
     // given
     InterestRegisterRequest request = new InterestRegisterRequest(
         "apple",

--- a/src/test/java/com/team3/monew/integration/InterestServiceIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/InterestServiceIntegrationTest.java
@@ -43,7 +43,7 @@ public class InterestServiceIntegrationTest {
     InterestDto savedInterest = interestService.create(request);
 
     // then
-    Optional<Interest> found = interestRepository.findInterestById(savedInterest.id());
+    Optional<Interest> found = interestRepository.findById(savedInterest.id());
 
     assertThat(found).isPresent();
     assertThat(found.get().getName()).isEqualTo("주식");

--- a/src/test/java/com/team3/monew/integration/InterestServiceIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/InterestServiceIntegrationTest.java
@@ -1,7 +1,7 @@
 package com.team3.monew.integration;
 
 import com.team3.monew.dto.interest.InterestDto;
-import com.team3.monew.dto.interest.InterestResisterRequest;
+import com.team3.monew.dto.interest.InterestRegisterRequest;
 import com.team3.monew.entity.Interest;
 import com.team3.monew.entity.InterestKeyword;
 import com.team3.monew.exception.interest.InterestDuplicateNameException;
@@ -32,9 +32,9 @@ public class InterestServiceIntegrationTest {
 
   @Test
   @DisplayName("관심사를 등록하면 키워드와 함께 저장된다")
-  void shouldResisterInterest_whenCreateRequest() {
+  void shouldRegisterInterest_whenCreateRequest() {
     // given
-    InterestResisterRequest request = new InterestResisterRequest(
+    InterestRegisterRequest request = new InterestRegisterRequest(
         "주식",
         List.of("코스피", "삼성전자")
     );
@@ -56,12 +56,12 @@ public class InterestServiceIntegrationTest {
   @DisplayName("이미 같은 이름의 관심사가 존재하면 등록에 실패한다")
   void shouldThrowException_whenDuplicateNameExists() {
     // given
-    InterestResisterRequest request1 = new InterestResisterRequest(
+    InterestRegisterRequest request1 = new InterestRegisterRequest(
         "테스트",
         List.of("test", "keyword")
     );
 
-    InterestResisterRequest request2 = new InterestResisterRequest(
+    InterestRegisterRequest request2 = new InterestRegisterRequest(
         "테스트",
         List.of("asdf")
     );
@@ -75,14 +75,14 @@ public class InterestServiceIntegrationTest {
 
   @Test
   @DisplayName("관심사 이름의 유사도가 80% 이상이면 등록에 실패한다")
-  void shouldFailToResisterInterest_whenNameSimilar80percenOver() {
+  void shouldFailToRegisterInterest_whenNameSimilar80percenOver() {
     // given
-    InterestResisterRequest request = new InterestResisterRequest(
+    InterestRegisterRequest request = new InterestRegisterRequest(
         "apple",
         List.of("keyword")
     );
 
-    InterestResisterRequest request2 = new InterestResisterRequest(
+    InterestRegisterRequest request2 = new InterestRegisterRequest(
         "applf",
         List.of("keyword")
     );

--- a/src/test/java/com/team3/monew/integration/InterestServiceIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/InterestServiceIntegrationTest.java
@@ -1,0 +1,96 @@
+package com.team3.monew.integration;
+
+import com.team3.monew.dto.interest.InterestDto;
+import com.team3.monew.dto.interest.InterestResisterRequest;
+import com.team3.monew.entity.Interest;
+import com.team3.monew.entity.InterestKeyword;
+import com.team3.monew.exception.interest.InterestDuplicateNameException;
+import com.team3.monew.repository.InterestRepository;
+import com.team3.monew.service.InterestService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+@Tag("integration")
+public class InterestServiceIntegrationTest {
+
+  @Autowired
+  private InterestService interestService;
+  @Autowired
+  private InterestRepository interestRepository;
+
+  @Test
+  @DisplayName("관심사를 등록하면 키워드와 함께 저장된다")
+  void shouldResisterInterest_whenCreateRequest() {
+    // given
+    InterestResisterRequest request = new InterestResisterRequest(
+        "주식",
+        List.of("코스피", "삼성전자")
+    );
+
+    // when
+    InterestDto savedInterest = interestService.create(request);
+
+    // then
+    Optional<Interest> found = interestRepository.findInterestById(savedInterest.id());
+
+    assertThat(found).isPresent();
+    assertThat(found.get().getName()).isEqualTo("주식");
+    assertThat(found.get().getKeywords())
+        .extracting(InterestKeyword::getKeyword)
+        .containsExactlyInAnyOrder("코스피", "삼성전자");
+  }
+
+  @Test
+  @DisplayName("이미 같은 이름의 관심사가 존재하면 등록에 실패한다")
+  void shouldThrowException_whenDuplicateNameExists() {
+    // given
+    InterestResisterRequest request1 = new InterestResisterRequest(
+        "테스트",
+        List.of("test", "keyword")
+    );
+
+    InterestResisterRequest request2 = new InterestResisterRequest(
+        "테스트",
+        List.of("asdf")
+    );
+
+    interestService.create(request1);
+
+    // when & then
+    assertThatThrownBy(() -> interestService.create(request2))
+        .isInstanceOf(InterestDuplicateNameException.class);
+  }
+
+  @Test
+  @DisplayName("관심사 이름의 유사도가 80% 이상이면 등록에 실패한다")
+  void shouldFailToResisterInterest_whenNameSimilar80percenOver() {
+    // given
+    InterestResisterRequest request = new InterestResisterRequest(
+        "apple",
+        List.of("keyword")
+    );
+
+    InterestResisterRequest request2 = new InterestResisterRequest(
+        "applf",
+        List.of("keyword")
+    );
+
+    interestService.create(request);
+
+    // when & then
+    assertThatThrownBy(() -> interestService.create(request2))
+        .isInstanceOf(InterestDuplicateNameException.class);
+  }
+}

--- a/src/test/java/com/team3/monew/service/InterestServiceTest.java
+++ b/src/test/java/com/team3/monew/service/InterestServiceTest.java
@@ -60,7 +60,7 @@ class InterestServiceTest {
 
     given(interestRepository.existsByName("주식")).willReturn(false);
     given(interestRepository.findAll()).willReturn(List.of());
-    given(interestRepository.save(any(Interest.class))).willReturn(savedInterest);
+    given(interestRepository.saveAndFlush(any(Interest.class))).willReturn(savedInterest);
     given(interestMapper.toDto(savedInterest, false)).willReturn(response);
 
     // when
@@ -87,7 +87,7 @@ class InterestServiceTest {
     assertThatThrownBy(() -> interestService.create(request))
         .isInstanceOf(InterestDuplicateNameException.class);
 
-    then(interestRepository).should(never()).save(any());
+    then(interestRepository).should(never()).saveAndFlush(any());
   }
 
   @Tag("unit")
@@ -109,6 +109,6 @@ class InterestServiceTest {
     assertThatThrownBy(() -> interestService.create(request))
         .isInstanceOf(InterestDuplicateNameException.class);
 
-    then(interestRepository).should(never()).save(any());
+    then(interestRepository).should(never()).saveAndFlush(any());
   }
 }

--- a/src/test/java/com/team3/monew/service/InterestServiceTest.java
+++ b/src/test/java/com/team3/monew/service/InterestServiceTest.java
@@ -1,0 +1,97 @@
+package com.team3.monew.service;
+
+import com.team3.monew.dto.interest.InterestDto;
+import com.team3.monew.dto.interest.InterestResisterRequest;
+import com.team3.monew.entity.Interest;
+import com.team3.monew.exception.interest.InterestDuplicateNameException;
+import com.team3.monew.repository.InterestRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class InterestServiceTest {
+
+  @Mock
+  private InterestRepository interestRepository;
+
+  @InjectMocks
+  private InterestService interestService;
+
+  @Tag("unit")
+  @Test
+  @DisplayName("관심사를 등록할 수 있다")
+  void shouldResisterInterest_whenCreateRequest() {
+    // given
+    InterestResisterRequest request = new InterestResisterRequest(
+        "주식",
+        List.of("코스피", "삼성전자")
+    );
+
+    given(interestRepository.existsByName("주식")).willReturn(false);
+    given(interestRepository.save(any(Interest.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    // when
+    InterestDto result = interestService.create(request);
+
+    // then
+    assertThat(result.name()).isEqualTo("주식");
+    assertThat(result.keywords())
+        .containsExactlyInAnyOrder("코스피", "삼성전자");
+  }
+
+  @Tag("unit")
+  @Test
+  @DisplayName("중복된 관심사 이름은 등록에 실패한다")
+  void shouldFailToResister_whenDuplicateNameExists() {
+    // given
+    InterestResisterRequest request = new InterestResisterRequest(
+        "테스트",
+        List.of("test", "keyword")
+    );
+
+    given(interestRepository.existsByName("테스트")).willReturn(true);
+
+    // when & then
+    assertThatThrownBy(() -> interestService.create(request))
+        .isInstanceOf(InterestDuplicateNameException.class);
+
+    then(interestRepository).should(never()).save(any());
+  }
+
+  @Tag("unit")
+  @Test
+  @DisplayName("관심사 이름의 유사도가 80% 이상이면 등록에 실패한다")
+  void shouldFailToResisterInterest_whenNameSimilar80percenOver() {
+    // given
+    InterestResisterRequest request = new InterestResisterRequest(
+        "applf",
+        List.of("keyword")
+    );
+
+    Interest existingInterest = Interest.create("apple");
+
+    given(interestRepository.findAll()).willReturn(List.of(existingInterest));
+    given(interestRepository.existsByName("applf")).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(() -> interestService.create(request))
+        .isInstanceOf(InterestDuplicateNameException.class);
+
+    then(interestRepository).should(never()).save(any());
+  }
+}

--- a/src/test/java/com/team3/monew/service/InterestServiceTest.java
+++ b/src/test/java/com/team3/monew/service/InterestServiceTest.java
@@ -1,10 +1,12 @@
 package com.team3.monew.service;
 
 import com.team3.monew.dto.interest.InterestDto;
-import com.team3.monew.dto.interest.InterestResisterRequest;
+import com.team3.monew.dto.interest.InterestRegisterRequest;
 import com.team3.monew.entity.Interest;
 import com.team3.monew.exception.interest.InterestDuplicateNameException;
+import com.team3.monew.mapper.InterestMapper;
 import com.team3.monew.repository.InterestRepository;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -28,38 +30,53 @@ class InterestServiceTest {
   @Mock
   private InterestRepository interestRepository;
 
+  @Mock
+  private InterestMapper interestMapper;
+
   @InjectMocks
   private InterestService interestService;
 
   @Tag("unit")
   @Test
   @DisplayName("관심사를 등록할 수 있다")
-  void shouldResisterInterest_whenCreateRequest() {
+  void shouldRegisterInterest_whenCreateRequest() {
     // given
-    InterestResisterRequest request = new InterestResisterRequest(
+    InterestRegisterRequest request = new InterestRegisterRequest(
         "주식",
         List.of("코스피", "삼성전자")
     );
 
+    Interest savedInterest = Interest.create("주식");
+    savedInterest.addKeyword("코스피");
+    savedInterest.addKeyword("삼성전자");
+
+    InterestDto response = new InterestDto(
+        UUID.randomUUID(),
+        "주식",
+        List.of("코스피", "삼성전자"),
+        0,
+        false
+    );
+
     given(interestRepository.existsByName("주식")).willReturn(false);
-    given(interestRepository.save(any(Interest.class)))
-        .willAnswer(invocation -> invocation.getArgument(0));
+    given(interestRepository.findAll()).willReturn(List.of());
+    given(interestRepository.save(any(Interest.class))).willReturn(savedInterest);
+    given(interestMapper.toDto(savedInterest, false)).willReturn(response);
 
     // when
     InterestDto result = interestService.create(request);
 
     // then
     assertThat(result.name()).isEqualTo("주식");
-    assertThat(result.keywords())
-        .containsExactlyInAnyOrder("코스피", "삼성전자");
+    assertThat(result.keywords()).containsExactlyInAnyOrder("코스피", "삼성전자");
   }
 
   @Tag("unit")
   @Test
   @DisplayName("중복된 관심사 이름은 등록에 실패한다")
-  void shouldFailToResister_whenDuplicateNameExists() {
+  void shouldFailToRegister_whenDuplicateNameExists() {
     // given
-    InterestResisterRequest request = new InterestResisterRequest(
+    InterestRegisterRequest request = new InterestRegisterRequest(
         "테스트",
         List.of("test", "keyword")
     );
@@ -76,9 +93,9 @@ class InterestServiceTest {
   @Tag("unit")
   @Test
   @DisplayName("관심사 이름의 유사도가 80% 이상이면 등록에 실패한다")
-  void shouldFailToResisterInterest_whenNameSimilar80percenOver() {
+  void shouldFailToRegisterInterest_whenNameSimilar80percenOver() {
     // given
-    InterestResisterRequest request = new InterestResisterRequest(
+    InterestRegisterRequest request = new InterestRegisterRequest(
         "applf",
         List.of("keyword")
     );

--- a/src/test/java/com/team3/monew/service/InterestServiceTest.java
+++ b/src/test/java/com/team3/monew/service/InterestServiceTest.java
@@ -93,7 +93,7 @@ class InterestServiceTest {
   @Tag("unit")
   @Test
   @DisplayName("관심사 이름의 유사도가 80% 이상이면 등록에 실패한다")
-  void shouldFailToRegisterInterest_whenNameSimilar80percenOver() {
+  void shouldFailToRegisterInterest_whenNameSimilar80percentOver() {
     // given
     InterestRegisterRequest request = new InterestRegisterRequest(
         "applf",


### PR DESCRIPTION
## 관련 이슈
- closes #11 

## 작업 내용
- 관심사의 이름과 키워드를 통해 관심사를 등록
  - 관심사 이름이 80% 이상 유사할 경우 등록 불가 (간단히 구현)
- 등록 시, 키워드는 여러개를 가질 수 있음
  - 키워드는 뉴스 기사 검색에 활용

## 변경 사항
- Entity에 keyword를 연결하는 메서드를 추가로 작성함

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- levenshtein 알고리즘 메서드 부분은 추후에 따로 클래스로 분리하여 작성할 예정입니다.
  - 현재는 간단히 구현한 상태라 기본 기능이 동작하게끔 작성했습니다

## 스크린샷 / 참고 자료
- 해당 사항 없습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

## New Features
* 관심사 등록 API 추가 — 이름과 키워드로 새 관심사를 생성하고 성공 시 201 응답을 반환합니다.
* 응답 정보 확장 — 아이디, 이름, 키워드 목록, 구독자 수 및 내 구독 여부 제공.

## Improvements
* 중복 검증 강화 — 정확 일치 및 유사도(>=80%) 기반 중복 탐지로 중복 등록을 차단하고 적절한 오류(409)를 반환합니다.
* 입력 유효성 검사 적용(이름/키워드), 데이터 무결성 예외 처리 개선.

## Tests
* 컨트롤러 단위·서비스 단위·통합 테스트 추가 및 시나리오 검증(성공/중복/검증 실패).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->