### PR TITLE
feat: 관심사 키워드 수정

### DIFF
--- a/src/main/java/com/team3/monew/controller/InterestController.java
+++ b/src/main/java/com/team3/monew/controller/InterestController.java
@@ -3,8 +3,10 @@ package com.team3.monew.controller;
 import com.team3.monew.controller.api.InterestApi;
 import com.team3.monew.dto.interest.InterestDto;
 import com.team3.monew.dto.interest.InterestRegisterRequest;
+import com.team3.monew.dto.interest.InterestUpdateRequest;
 import com.team3.monew.service.InterestService;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,5 +27,16 @@ public class InterestController implements InterestApi {
 
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(response);
+  }
+
+  @Override
+  public ResponseEntity<InterestDto> update(
+      UUID userId,
+      UUID interestId,
+      @Valid @RequestBody InterestUpdateRequest dto
+  ) {
+    InterestDto response = interestService.updateKeyword(userId, interestId, dto);
+
+    return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/team3/monew/controller/api/InterestApi.java
+++ b/src/main/java/com/team3/monew/controller/api/InterestApi.java
@@ -2,14 +2,17 @@ package com.team3.monew.controller.api;
 
 import com.team3.monew.dto.interest.InterestDto;
 import com.team3.monew.dto.interest.InterestRegisterRequest;
+import com.team3.monew.dto.interest.InterestUpdateRequest;
 import com.team3.monew.global.response.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -58,5 +61,30 @@ public interface InterestApi {
           )
       )
       @RequestBody @Valid InterestRegisterRequest dto
+  );
+
+  @Operation(
+      summary = "관심사 키워드 수정",
+      description = "관심사의 키워드를 수정합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "수정 성공",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = InterestDto.class)
+          )
+      )
+  })
+  @PatchMapping("/{interestId}")
+  ResponseEntity<InterestDto> update(
+      @Parameter(
+          description = "요청 사용자 ID",
+          required = true
+      )
+      @RequestHeader("Monew-Request-User-Id") UUID userId,
+      @PathVariable UUID interestId,
+      @RequestBody @Valid InterestUpdateRequest dto
   );
 }

--- a/src/main/java/com/team3/monew/dto/interest/InterestUpdateRequest.java
+++ b/src/main/java/com/team3/monew/dto/interest/InterestUpdateRequest.java
@@ -1,8 +1,12 @@
 package com.team3.monew.dto.interest;
 
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record InterestUpdateRequest(
+    @NotNull
+    @NotEmpty
     List<String> keywords
 ) {
 

--- a/src/main/java/com/team3/monew/dto/interest/InterestUpdateRequest.java
+++ b/src/main/java/com/team3/monew/dto/interest/InterestUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.team3.monew.dto.interest;
+
+import java.util.List;
+
+public record InterestUpdateRequest(
+    List<String> keywords
+) {
+
+}

--- a/src/main/java/com/team3/monew/entity/Interest.java
+++ b/src/main/java/com/team3/monew/entity/Interest.java
@@ -15,32 +15,39 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Interest extends BaseEntity {
 
-    @Column(nullable = false, unique = true, length = 100)
-    private String name;
+  @Column(nullable = false, unique = true, length = 100)
+  private String name;
 
-    @Column(nullable = false)
-    private int subscriberCount;
+  @Column(nullable = false)
+  private int subscriberCount;
 
-    @OneToMany(mappedBy = "interest", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<InterestKeyword> keywords = new ArrayList<>();
+  @OneToMany(mappedBy = "interest", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<InterestKeyword> keywords = new ArrayList<>();
 
-    @OneToMany(mappedBy = "interest")
-    private List<Subscription> subscriptions = new ArrayList<>();
+  @OneToMany(mappedBy = "interest")
+  private List<Subscription> subscriptions = new ArrayList<>();
 
-    @OneToMany(mappedBy = "interest")
-    private List<ArticleInterest> articleInterests = new ArrayList<>();
+  @OneToMany(mappedBy = "interest")
+  private List<ArticleInterest> articleInterests = new ArrayList<>();
 
-    public static Interest create(String name) {
-        Interest interest = new Interest();
-        interest.name = name;
-        interest.subscriberCount = 0;
+  public static Interest create(String name) {
+    Interest interest = new Interest();
+    interest.name = name;
+    interest.subscriberCount = 0;
 
-        return interest;
+    return interest;
+  }
+
+  // keyword는 해당 메서드를 통해 서비스에서 따로 붙임 -> entity에 책임이 몰리는 것을 방지하기 위함
+  public void addKeyword(String keyword) {
+    InterestKeyword interestKeyword = InterestKeyword.create(this, keyword);
+    this.keywords.add(interestKeyword);
+  }
+
+  public void updateKeywords(List<String> newKeywords) {
+    this.keywords.clear();
+    for (String keyword : newKeywords) {
+      addKeyword(keyword);
     }
-
-    // keyword는 해당 메서드를 통해 서비스에서 따로 붙임 -> entity에 책임이 몰리는 것을 방지하기 위함
-    public void addKeyword(String keyword) {
-        InterestKeyword interestKeyword = InterestKeyword.create(this, keyword);
-        this.keywords.add(interestKeyword);
-    }
+  }
 }

--- a/src/main/java/com/team3/monew/global/enums/ErrorCode.java
+++ b/src/main/java/com/team3/monew/global/enums/ErrorCode.java
@@ -19,11 +19,14 @@ public enum ErrorCode {
   // INTEREST EXCEPTION
   INTEREST_NAME_DUPLICATE(HttpStatus.CONFLICT, "중복된 관심사 이름입니다."),
   INTEREST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 관심사를 찾을 수 없습니다."),
+  INTEREST_KEYWORD_LIST_IS_BLANK(HttpStatus.BAD_REQUEST, "관심사 키워드가 비어있습니다."),
+  INTEREST_KEYWORD_DUPLICATED(HttpStatus.BAD_REQUEST, "중복된 관심사 키워드가 존재합니다."),
 
   //COMMON
   INVALID_PARAMETER_TYPE(HttpStatus.BAD_REQUEST, "해당 파라미터가 유효하지 않습니다."),
   INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "입력 형식이 올바르지 않습니다."),
-  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."),
+  ;
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/com/team3/monew/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/team3/monew/global/exception/GlobalExceptionHandler.java
@@ -7,7 +7,9 @@ import java.util.Map;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -71,6 +73,22 @@ public class GlobalExceptionHandler {
     ErrorResponse response = ErrorResponse.of(e);
     logError(response, e);
     return ResponseEntity.status(response.status()).body(response);
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<ErrorResponse> handle(
+      HttpMessageNotReadableException e) {
+    ErrorResponse response = ErrorResponse.of(e);
+    logError(response, e);
+    return ResponseEntity.badRequest().body(response);
+  }
+
+  @ExceptionHandler(MissingRequestHeaderException.class)
+  public ResponseEntity<ErrorResponse> handle(
+      MissingRequestHeaderException e) {
+    ErrorResponse response = ErrorResponse.of(e);
+    logError(response, e);
+    return ResponseEntity.badRequest().body(response);
   }
 
   private void logWarn(ErrorResponse response) {

--- a/src/main/java/com/team3/monew/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/team3/monew/global/exception/GlobalExceptionHandler.java
@@ -78,7 +78,7 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(HttpMessageNotReadableException.class)
   public ResponseEntity<ErrorResponse> handle(
       HttpMessageNotReadableException e) {
-    ErrorResponse response = ErrorResponse.of(e);
+    ErrorResponse response = badRequestResponse();
     logError(response, e);
     return ResponseEntity.badRequest().body(response);
   }
@@ -86,7 +86,7 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(MissingRequestHeaderException.class)
   public ResponseEntity<ErrorResponse> handle(
       MissingRequestHeaderException e) {
-    ErrorResponse response = ErrorResponse.of(e);
+    ErrorResponse response = badRequestResponse();
     logError(response, e);
     return ResponseEntity.badRequest().body(response);
   }
@@ -187,5 +187,15 @@ public class GlobalExceptionHandler {
       return value;
     }
     return value.substring(0, maxLength) + "...(truncated)";
+  }
+
+  private ErrorResponse badRequestResponse() {
+    return new ErrorResponse(
+        java.time.Instant.now(),
+        com.team3.monew.global.enums.ErrorCode.INVALID_INPUT_VALUE.name(),
+        com.team3.monew.global.enums.ErrorCode.INVALID_INPUT_VALUE.getMessage(),
+        Map.of(),
+        400
+    );
   }
 }

--- a/src/main/java/com/team3/monew/repository/InterestKeywordRepository.java
+++ b/src/main/java/com/team3/monew/repository/InterestKeywordRepository.java
@@ -1,0 +1,11 @@
+package com.team3.monew.repository;
+
+import com.team3.monew.entity.InterestKeyword;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InterestKeywordRepository extends JpaRepository<InterestKeyword, UUID> {
+
+  List<InterestKeyword> findInterestKeywordsByInterestId(UUID interestId);
+}

--- a/src/main/java/com/team3/monew/repository/SubscriptionRepository.java
+++ b/src/main/java/com/team3/monew/repository/SubscriptionRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SubscriptionRepository extends JpaRepository<Subscription, UUID> {
 
-  boolean existsByUserIdAndInterestId(UUID userid, UUID interestId);
+  boolean existsByUserIdAndInterestId(UUID userId, UUID interestId);
 }

--- a/src/main/java/com/team3/monew/repository/SubscriptionRepository.java
+++ b/src/main/java/com/team3/monew/repository/SubscriptionRepository.java
@@ -1,0 +1,10 @@
+package com.team3.monew.repository;
+
+import com.team3.monew.entity.Subscription;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubscriptionRepository extends JpaRepository<Subscription, UUID> {
+
+  boolean existsByUserIdAndInterestId(UUID userid, UUID interestId);
+}

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -16,6 +16,7 @@ import com.team3.monew.repository.InterestKeywordRepository;
 import com.team3.monew.repository.InterestRepository;
 import com.team3.monew.repository.SubscriptionRepository;
 import com.team3.monew.repository.UserRepository;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -72,8 +73,8 @@ public class InterestService {
   }
 
   public InterestDto updateKeyword(UUID userId, UUID interestId, InterestUpdateRequest dto) {
-    log.debug("관심사 키워드 수정 요청 - interestId={}, userId={}, keywordCount={}",
-        interestId, userId, dto.keywords() == null ? 0 : dto.keywords().size());
+    log.debug("관심사 키워드 수정 요청 - interestId={}, keywordCount={}",
+        interestId, dto.keywords() == null ? 0 : dto.keywords().size());
 
     Interest interest = findInterestOrElseThrow(interestId);
 
@@ -83,21 +84,27 @@ public class InterestService {
       throw new InterestException(ErrorCode.INTEREST_KEYWORD_LIST_IS_BLANK);
     }
 
+    // NPE 방지
+    if (dto.keywords().stream().anyMatch(Objects::isNull)) {
+      log.warn("관심사 키워드 수정 실패 - null 키워드 포함, interestId={}", interestId);
+      throw new InterestException(ErrorCode.INTEREST_KEYWORD_LIST_IS_BLANK);
+    }
+
     List<String> keywords = dto.keywords().stream()
         .map(String::trim)
         .toList();
 
     // 공백 키워드
     if (keywords.stream().anyMatch(String::isBlank)) {
-      log.warn("관심사 키워드 수정 실패 - 공백 키워드 포함, interestId={}, keywords={}",
-          interestId, keywords);
+      log.warn("관심사 키워드 수정 실패 - 공백 키워드 포함, interestId={}, keywordsCount={}",
+          interestId, keywords.size());
       throw new InterestException(ErrorCode.INTEREST_KEYWORD_LIST_IS_BLANK);
     }
 
     // 중복 키워드
     if (keywords.stream().distinct().count() != keywords.size()) {
-      log.warn("관심사 키워드 수정 실패 - 중복 키워드 존재, interestId={}, keywords={}",
-          interestId, keywords);
+      log.warn("관심사 키워드 수정 실패 - 중복 키워드 존재, interestId={}, keywordsCount={}",
+          interestId, keywords.size());
       throw new InterestException(ErrorCode.INTEREST_KEYWORD_DUPLICATED);
     }
 
@@ -106,8 +113,8 @@ public class InterestService {
 
     interest.updateKeywords(keywords);
 
-    log.debug("관심사 키워드 수정 성공 - interestId={}, updatedKeywords={}, subscribedByMe={}",
-        interestId, keywords, subscribedByMe);
+    log.debug("관심사 키워드 수정 성공 - interestId={}, updatedKeywordsCount={}, subscribedByMe={}",
+        interestId, keywords.size(), subscribedByMe);
 
     return interestMapper.toDto(interest, subscribedByMe);
   }

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -111,6 +111,10 @@ public class InterestService {
     boolean subscribedByMe =
         subscriptionRepository.existsByUserIdAndInterestId(userId, interestId);
 
+    // 기존 키워드와 dto의 키워드중 중복되는게 있을 경우 지워지지 않는 경우를 대비
+    interest.getKeywords().clear();
+    interestRepository.flush();
+
     interest.updateKeywords(keywords);
 
     log.debug("관심사 키워드 수정 성공 - interestId={}, updatedKeywordsCount={}, subscribedByMe={}",

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -36,7 +36,7 @@ public class InterestService {
   private final InterestMapper interestMapper;
 
   public InterestDto create(InterestRegisterRequest dto) {
-    log.info("관심사 등록 요청 - name={}, keywordCount={}",
+    log.debug("관심사 등록 요청 - name={}, keywordCount={}",
         dto.name(), dto.keywords().size());
 
     if (interestRepository.existsByName(dto.name())) {
@@ -65,17 +65,21 @@ public class InterestService {
       throw new InterestDuplicateNameException();
     }
 
-    log.info("관심사 등록 성공 - interestId={}, name={}",
+    log.debug("관심사 등록 성공 - interestId={}, name={}",
         savedInterest.getId(), savedInterest.getName());
 
     return interestMapper.toDto(savedInterest, false);
   }
 
   public InterestDto updateKeyword(UUID userId, UUID interestId, InterestUpdateRequest dto) {
+    log.debug("관심사 키워드 수정 요청 - interestId={}, userId={}, keywordCount={}",
+        interestId, userId, dto.keywords() == null ? 0 : dto.keywords().size());
+
     Interest interest = findInterestOrElseThrow(interestId);
 
-    // 빈 리스트가 왔을 경우 예외처리
+    // 빈 리스트
     if (dto.keywords() == null || dto.keywords().isEmpty()) {
+      log.warn("관심사 키워드 수정 실패 - 키워드 리스트 비어있음, interestId={}", interestId);
       throw new InterestException(ErrorCode.INTEREST_KEYWORD_LIST_IS_BLANK);
     }
 
@@ -83,19 +87,27 @@ public class InterestService {
         .map(String::trim)
         .toList();
 
+    // 공백 키워드
     if (keywords.stream().anyMatch(String::isBlank)) {
+      log.warn("관심사 키워드 수정 실패 - 공백 키워드 포함, interestId={}, keywords={}",
+          interestId, keywords);
       throw new InterestException(ErrorCode.INTEREST_KEYWORD_LIST_IS_BLANK);
     }
 
-    // 중복 키워드가 있을 경우 예외처리
+    // 중복 키워드
     if (keywords.stream().distinct().count() != keywords.size()) {
+      log.warn("관심사 키워드 수정 실패 - 중복 키워드 존재, interestId={}, keywords={}",
+          interestId, keywords);
       throw new InterestException(ErrorCode.INTEREST_KEYWORD_DUPLICATED);
     }
 
     boolean subscribedByMe =
         subscriptionRepository.existsByUserIdAndInterestId(userId, interestId);
 
-    interest.updateKeywords(dto.keywords());
+    interest.updateKeywords(keywords);
+
+    log.debug("관심사 키워드 수정 성공 - interestId={}, updatedKeywords={}, subscribedByMe={}",
+        interestId, keywords, subscribedByMe);
 
     return interestMapper.toDto(interest, subscribedByMe);
   }

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -2,11 +2,20 @@ package com.team3.monew.service;
 
 import com.team3.monew.dto.interest.InterestDto;
 import com.team3.monew.dto.interest.InterestRegisterRequest;
+import com.team3.monew.dto.interest.InterestUpdateRequest;
 import com.team3.monew.entity.Interest;
+import com.team3.monew.entity.InterestKeyword;
+import com.team3.monew.entity.Subscription;
+import com.team3.monew.entity.User;
 import com.team3.monew.exception.interest.InterestDuplicateNameException;
+import com.team3.monew.exception.interest.InterestException;
 import com.team3.monew.exception.interest.InterestNotFoundException;
+import com.team3.monew.global.enums.ErrorCode;
 import com.team3.monew.mapper.InterestMapper;
+import com.team3.monew.repository.InterestKeywordRepository;
 import com.team3.monew.repository.InterestRepository;
+import com.team3.monew.repository.SubscriptionRepository;
+import com.team3.monew.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -23,6 +32,7 @@ import java.util.UUID;
 public class InterestService {
 
   private final InterestRepository interestRepository;
+  private final SubscriptionRepository subscriptionRepository;
   private final InterestMapper interestMapper;
 
   public InterestDto create(InterestRegisterRequest dto) {
@@ -59,6 +69,35 @@ public class InterestService {
         savedInterest.getId(), savedInterest.getName());
 
     return interestMapper.toDto(savedInterest, false);
+  }
+
+  public InterestDto updateKeyword(UUID userId, UUID interestId, InterestUpdateRequest dto) {
+    Interest interest = findInterestOrElseThrow(interestId);
+
+    // 빈 리스트가 왔을 경우 예외처리
+    if (dto.keywords() == null || dto.keywords().isEmpty()) {
+      throw new InterestException(ErrorCode.INTEREST_KEYWORD_LIST_IS_BLANK);
+    }
+
+    List<String> keywords = dto.keywords().stream()
+        .map(String::trim)
+        .toList();
+
+    if (keywords.stream().anyMatch(String::isBlank)) {
+      throw new InterestException(ErrorCode.INTEREST_KEYWORD_LIST_IS_BLANK);
+    }
+
+    // 중복 키워드가 있을 경우 예외처리
+    if (keywords.stream().distinct().count() != keywords.size()) {
+      throw new InterestException(ErrorCode.INTEREST_KEYWORD_DUPLICATED);
+    }
+
+    boolean subscribedByMe =
+        subscriptionRepository.existsByUserIdAndInterestId(userId, interestId);
+
+    interest.updateKeywords(dto.keywords());
+
+    return interestMapper.toDto(interest, subscribedByMe);
   }
 
   private Interest findInterestOrElseThrow(UUID interestId) {

--- a/src/test/java/com/team3/monew/controller/InterestControllerTest.java
+++ b/src/test/java/com/team3/monew/controller/InterestControllerTest.java
@@ -3,6 +3,7 @@ package com.team3.monew.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.team3.monew.dto.interest.InterestDto;
 import com.team3.monew.dto.interest.InterestRegisterRequest;
+import com.team3.monew.dto.interest.InterestUpdateRequest;
 import com.team3.monew.exception.interest.InterestDuplicateNameException;
 import com.team3.monew.service.InterestService;
 import org.junit.jupiter.api.DisplayName;
@@ -18,7 +19,9 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -94,6 +97,99 @@ class InterestControllerTest {
 
     // when & then
     mockMvc.perform(post("/api/interests")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("관심사 키워드를 수정할 수 있다")
+  void shouldUpdateInterestKeywords_whenValidRequest() throws Exception {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+
+    InterestUpdateRequest request = new InterestUpdateRequest(
+        List.of("나스닥", "애플")
+    );
+
+    InterestDto response = new InterestDto(
+        interestId,
+        "주식",
+        List.of("나스닥", "애플"),
+        0,
+        true
+    );
+
+    given(interestService.updateKeyword(
+        eq(userId),
+        eq(interestId),
+        any(InterestUpdateRequest.class)
+    )).willReturn(response);
+
+    // when & then
+    mockMvc.perform(patch("/api/interests/{interestId}", interestId)
+            .header("Monew-Request-User-Id", userId.toString())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.id").value(interestId.toString()))
+        .andExpect(jsonPath("$.name").value("주식"))
+        .andExpect(jsonPath("$.keywords[0]").value("나스닥"))
+        .andExpect(jsonPath("$.keywords[1]").value("애플"))
+        .andExpect(jsonPath("$.subscriberCount").value(0))
+        .andExpect(jsonPath("$.subscribedByMe").value(true));
+  }
+
+  @Test
+  @DisplayName("관심사 등록 요청 본문이 없으면 실패한다")
+  void shouldFailCreate_whenRequestBodyMissing() throws Exception {
+    mockMvc.perform(post("/api/interests")
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("관심사 수정 요청 본문이 없으면 실패한다")
+  void shouldFailUpdate_whenRequestBodyMissing() throws Exception {
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+
+    mockMvc.perform(patch("/api/interests/{interestId}", interestId)
+            .header("Monew-Request-User-Id", userId.toString())
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("관심사 수정 요청 시 사용자 헤더가 없으면 실패한다")
+  void shouldFailUpdate_whenUserIdHeaderMissing() throws Exception {
+    // given
+    UUID interestId = UUID.randomUUID();
+    InterestUpdateRequest request = new InterestUpdateRequest(
+        List.of("나스닥", "애플")
+    );
+
+    // when & then
+    mockMvc.perform(patch("/api/interests/{interestId}", interestId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("관심사 수정 요청 시 헤더의 UUID 형식이 올바르지 않으면 실패한다")
+  void shouldFailUpdate_whenUserIdHeaderInvalidFormat() throws Exception {
+    // given
+    UUID interestId = UUID.randomUUID();
+    InterestUpdateRequest request = new InterestUpdateRequest(
+        List.of("나스닥", "애플")
+    );
+
+    // when & then
+    mockMvc.perform(patch("/api/interests/{interestId}", interestId)
+            .header("Monew-Request-User-Id", "not-uuid")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objMapper.writeValueAsString(request)))
         .andExpect(status().isBadRequest());

--- a/src/test/java/com/team3/monew/integration/InterestServiceIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/InterestServiceIntegrationTest.java
@@ -2,11 +2,14 @@ package com.team3.monew.integration;
 
 import com.team3.monew.dto.interest.InterestDto;
 import com.team3.monew.dto.interest.InterestRegisterRequest;
+import com.team3.monew.dto.interest.InterestUpdateRequest;
 import com.team3.monew.entity.Interest;
 import com.team3.monew.entity.InterestKeyword;
 import com.team3.monew.exception.interest.InterestDuplicateNameException;
+import com.team3.monew.exception.interest.InterestException;
 import com.team3.monew.repository.InterestRepository;
 import com.team3.monew.service.InterestService;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -92,5 +95,141 @@ public class InterestServiceIntegrationTest {
     // when & then
     assertThatThrownBy(() -> interestService.create(request2))
         .isInstanceOf(InterestDuplicateNameException.class);
+  }
+
+  @Test
+  @DisplayName("관심사 키워드를 수정하면 기존 키워드는 삭제되고 새 키워드로 교체된다")
+  void shouldUpdateKeywords_andReplaceOldKeywords() {
+    // given
+    InterestRegisterRequest createRequest = new InterestRegisterRequest(
+        "주식",
+        List.of("코스피", "삼성전자")
+    );
+
+    InterestDto saved = interestService.create(createRequest);
+
+    // when
+    interestService.updateKeyword(
+        UUID.randomUUID(), // userId는 의미 없음 (existsBy는 false로 처리됨)
+        saved.id(),
+        new InterestUpdateRequest(List.of("나스닥", "애플"))
+    );
+
+    // then
+    Interest updated = interestRepository.findById(saved.id()).orElseThrow();
+
+    assertThat(updated.getKeywords())
+        .extracting(InterestKeyword::getKeyword)
+        .containsExactlyInAnyOrder("나스닥", "애플");
+  }
+
+  @Test
+  @DisplayName("키워드 수정 시 기존 키워드는 orphanRemoval로 삭제된다")
+  void shouldDeleteOldKeywords_whenUpdatingKeywords() {
+    // given
+    InterestRegisterRequest request = new InterestRegisterRequest(
+        "경제",
+        List.of("금리", "환율")
+    );
+
+    InterestDto saved = interestService.create(request);
+
+    // when
+    interestService.updateKeyword(
+        UUID.randomUUID(),
+        saved.id(),
+        new InterestUpdateRequest(List.of("물가"))
+    );
+
+    // then
+    Interest updated = interestRepository.findById(saved.id()).orElseThrow();
+
+    assertThat(updated.getKeywords())
+        .extracting(InterestKeyword::getKeyword)
+        .containsExactly("물가");
+  }
+
+  @Test
+  @DisplayName("키워드가 null이면 수정에 실패한다")
+  void shouldFail_whenKeywordsIsNull() {
+    // given
+    InterestRegisterRequest request = new InterestRegisterRequest(
+        "부동산",
+        List.of("아파트")
+    );
+
+    InterestDto saved = interestService.create(request);
+
+    // when & then
+    assertThatThrownBy(() ->
+        interestService.updateKeyword(
+            UUID.randomUUID(),
+            saved.id(),
+            new InterestUpdateRequest(null)
+        )
+    ).isInstanceOf(InterestException.class);
+  }
+
+  @Test
+  @DisplayName("키워드가 비어있으면 수정에 실패한다")
+  void shouldFail_whenKeywordsIsEmpty() {
+    // given
+    InterestRegisterRequest request = new InterestRegisterRequest(
+        "코인",
+        List.of("비트코인")
+    );
+
+    InterestDto saved = interestService.create(request);
+
+    // when & then
+    assertThatThrownBy(() ->
+        interestService.updateKeyword(
+            UUID.randomUUID(),
+            saved.id(),
+            new InterestUpdateRequest(List.of())
+        )
+    ).isInstanceOf(InterestException.class);
+  }
+
+  @Test
+  @DisplayName("공백 키워드가 포함되면 수정에 실패한다")
+  void shouldFail_whenKeywordContainsBlank() {
+    // given
+    InterestRegisterRequest request = new InterestRegisterRequest(
+        "IT",
+        List.of("개발")
+    );
+
+    InterestDto saved = interestService.create(request);
+
+    // when & then
+    assertThatThrownBy(() ->
+        interestService.updateKeyword(
+            UUID.randomUUID(),
+            saved.id(),
+            new InterestUpdateRequest(List.of("정상", "   "))
+        )
+    ).isInstanceOf(InterestException.class);
+  }
+
+  @Test
+  @DisplayName("중복 키워드가 있으면 수정에 실패한다")
+  void shouldFail_whenDuplicateKeywords() {
+    // given
+    InterestRegisterRequest request = new InterestRegisterRequest(
+        "뉴스",
+        List.of("정치")
+    );
+
+    InterestDto saved = interestService.create(request);
+
+    // when & then
+    assertThatThrownBy(() ->
+        interestService.updateKeyword(
+            UUID.randomUUID(),
+            saved.id(),
+            new InterestUpdateRequest(List.of("경제", "경제"))
+        )
+    ).isInstanceOf(InterestException.class);
   }
 }

--- a/src/test/java/com/team3/monew/service/InterestServiceTest.java
+++ b/src/test/java/com/team3/monew/service/InterestServiceTest.java
@@ -2,10 +2,14 @@ package com.team3.monew.service;
 
 import com.team3.monew.dto.interest.InterestDto;
 import com.team3.monew.dto.interest.InterestRegisterRequest;
+import com.team3.monew.dto.interest.InterestUpdateRequest;
 import com.team3.monew.entity.Interest;
+import com.team3.monew.entity.InterestKeyword;
 import com.team3.monew.exception.interest.InterestDuplicateNameException;
 import com.team3.monew.mapper.InterestMapper;
 import com.team3.monew.repository.InterestRepository;
+import com.team3.monew.repository.SubscriptionRepository;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -24,6 +28,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
+@Tag("unit")
 @ExtendWith(MockitoExtension.class)
 class InterestServiceTest {
 
@@ -31,12 +36,14 @@ class InterestServiceTest {
   private InterestRepository interestRepository;
 
   @Mock
+  private SubscriptionRepository subscriptionRepository;
+
+  @Mock
   private InterestMapper interestMapper;
 
   @InjectMocks
   private InterestService interestService;
 
-  @Tag("unit")
   @Test
   @DisplayName("관심사를 등록할 수 있다")
   void shouldRegisterInterest_whenCreateRequest() {
@@ -71,7 +78,6 @@ class InterestServiceTest {
     assertThat(result.keywords()).containsExactlyInAnyOrder("코스피", "삼성전자");
   }
 
-  @Tag("unit")
   @Test
   @DisplayName("중복된 관심사 이름은 등록에 실패한다")
   void shouldFailToRegister_whenDuplicateNameExists() {
@@ -90,7 +96,6 @@ class InterestServiceTest {
     then(interestRepository).should(never()).saveAndFlush(any());
   }
 
-  @Tag("unit")
   @Test
   @DisplayName("관심사 이름의 유사도가 80% 이상이면 등록에 실패한다")
   void shouldFailToRegisterInterest_whenNameSimilar80percentOver() {
@@ -110,5 +115,49 @@ class InterestServiceTest {
         .isInstanceOf(InterestDuplicateNameException.class);
 
     then(interestRepository).should(never()).saveAndFlush(any());
+  }
+
+  @Test
+  @DisplayName("관심사 키워드를 수정할 수 있다")
+  void shouldUpdateInterestKeyword_whenUpdateRequest() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+
+    InterestUpdateRequest request = new InterestUpdateRequest(
+        List.of("수정", "키워드수정")
+    );
+
+    Interest interest = Interest.create("주식");
+    interest.addKeyword("기존키워드");
+    interest.addKeyword("기존키워드2");
+
+    InterestDto response = new InterestDto(
+        interestId,
+        "주식",
+        List.of("수정", "키워드수정"),
+        0,
+        true
+    );
+
+    given(interestRepository.findById(interestId)).willReturn((Optional.of(interest)));
+    given(subscriptionRepository.existsByUserIdAndInterestId(userId, interestId)).willReturn(true);
+    given(interestMapper.toDto(interest, true)).willReturn(response);
+
+    // when
+    InterestDto result = interestService.updateKeyword(userId, interestId, request);
+
+    // then
+    assertThat(result.name()).isEqualTo("주식");
+    assertThat(result.keywords()).containsExactly("수정", "키워드수정");
+    assertThat(result.subscribedByMe()).isTrue();
+
+    assertThat(interest.getKeywords())
+        .extracting(InterestKeyword::getKeyword)
+        .containsExactly("수정", "키워드수정");
+
+    then(interestRepository).should().findById(interestId);
+    then(subscriptionRepository).should().existsByUserIdAndInterestId(userId, interestId);
+    then(interestMapper).should().toDto(interest, true);
   }
 }

--- a/src/test/java/com/team3/monew/service/InterestServiceTest.java
+++ b/src/test/java/com/team3/monew/service/InterestServiceTest.java
@@ -6,6 +6,8 @@ import com.team3.monew.dto.interest.InterestUpdateRequest;
 import com.team3.monew.entity.Interest;
 import com.team3.monew.entity.InterestKeyword;
 import com.team3.monew.exception.interest.InterestDuplicateNameException;
+import com.team3.monew.exception.interest.InterestException;
+import com.team3.monew.exception.interest.InterestNotFoundException;
 import com.team3.monew.mapper.InterestMapper;
 import com.team3.monew.repository.InterestRepository;
 import com.team3.monew.repository.SubscriptionRepository;
@@ -159,5 +161,118 @@ class InterestServiceTest {
     then(interestRepository).should().findById(interestId);
     then(subscriptionRepository).should().existsByUserIdAndInterestId(userId, interestId);
     then(interestMapper).should().toDto(interest, true);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 관심사는 키워드를 수정할 수 없다")
+  void shouldFailToUpdateKeyword_whenInterestNotFound() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+
+    InterestUpdateRequest request = new InterestUpdateRequest(
+        List.of("수정", "키워드수정")
+    );
+
+    given(interestRepository.findById(interestId)).willReturn(java.util.Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> interestService.updateKeyword(userId, interestId, request))
+        .isInstanceOf(InterestNotFoundException.class);
+
+    then(subscriptionRepository).should(never()).existsByUserIdAndInterestId(any(), any());
+    then(interestMapper).should(never()).toDto(any(), any(Boolean.class));
+  }
+
+  @Test
+  @DisplayName("키워드 목록이 null이면 관심사 키워드 수정에 실패한다")
+  void shouldFailToUpdateKeyword_whenKeywordsIsNull() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+
+    InterestUpdateRequest request = new InterestUpdateRequest(null);
+
+    Interest interest = Interest.create("주식");
+    interest.addKeyword("기존키워드");
+
+    given(interestRepository.findById(interestId)).willReturn(java.util.Optional.of(interest));
+
+    // when & then
+    assertThatThrownBy(() -> interestService.updateKeyword(userId, interestId, request))
+        .isInstanceOf(InterestException.class);
+
+    then(subscriptionRepository).should(never()).existsByUserIdAndInterestId(any(), any());
+    then(interestMapper).should(never()).toDto(any(), any(Boolean.class));
+  }
+
+  @Test
+  @DisplayName("키워드 목록이 비어 있으면 관심사 키워드 수정에 실패한다")
+  void shouldFailToUpdateKeyword_whenKeywordsIsEmpty() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+
+    InterestUpdateRequest request = new InterestUpdateRequest(List.of());
+
+    Interest interest = Interest.create("주식");
+    interest.addKeyword("기존키워드");
+
+    given(interestRepository.findById(interestId)).willReturn(java.util.Optional.of(interest));
+
+    // when & then
+    assertThatThrownBy(() -> interestService.updateKeyword(userId, interestId, request))
+        .isInstanceOf(InterestException.class);
+
+    then(subscriptionRepository).should(never()).existsByUserIdAndInterestId(any(), any());
+    then(interestMapper).should(never()).toDto(any(), any(Boolean.class));
+  }
+
+  @Test
+  @DisplayName("공백 문자열이 포함된 키워드가 있으면 관심사 키워드 수정에 실패한다")
+  void shouldFailToUpdateKeyword_whenKeywordContainsBlank() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+
+    InterestUpdateRequest request = new InterestUpdateRequest(
+        List.of("정상키워드", "   ")
+    );
+
+    Interest interest = Interest.create("주식");
+    interest.addKeyword("기존키워드");
+
+    given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+
+    // when & then
+    assertThatThrownBy(() -> interestService.updateKeyword(userId, interestId, request))
+        .isInstanceOf(InterestException.class);
+
+    then(subscriptionRepository).should(never()).existsByUserIdAndInterestId(any(), any());
+    then(interestMapper).should(never()).toDto(any(), any(Boolean.class));
+  }
+
+  @Test
+  @DisplayName("중복된 키워드가 있으면 관심사 키워드 수정에 실패한다")
+  void shouldFailToUpdateKeyword_whenKeywordsDuplicated() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+
+    InterestUpdateRequest request = new InterestUpdateRequest(
+        List.of("경제", "경제")
+    );
+
+    Interest interest = Interest.create("주식");
+    interest.addKeyword("기존키워드");
+
+    given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+
+    // when & then
+    assertThatThrownBy(() -> interestService.updateKeyword(userId, interestId, request))
+        .isInstanceOf(InterestException.class);
+
+    then(subscriptionRepository).should(never()).existsByUserIdAndInterestId(any(), any());
+    then(interestMapper).should(never()).toDto(any(), any(Boolean.class));
   }
 }


### PR DESCRIPTION
## 관련 이슈
- closes #15 #109 #110 #111 #112 

## 작업 내용
- feat: 관심사 키워드 수정 기능 구현
  - InterestService에 키워드 수정 메서드(updateKeyword) 구현
  - 기존 키워드를 제거하고 새로운 키워드로 교체하는 로직 구현
    - orphanRemoval 기반으로 기존 키워드 자동 삭제 처리
  - SubscriptionRepository를 활용하여 subscribedByMe 계산 로직 추가

- refactor: 관심사 키워드 처리 로직 개선
  - Interest 엔티티에 updateKeywords 메서드 추가
    - 키워드 컬렉션 교체 책임을 엔티티로 이동
  - 서비스에서 직접 컬렉션 조작하던 로직을 엔티티 메서드 호출 방식으로 변경
  - trim 처리된 키워드 리스트를 사용하도록 로직 개선

- feat: 관심사 키워드 유효성 검증 추가
  - 키워드 리스트 null 또는 empty 검증 추가
  - 공백 문자열(trim 후 blank) 검증 추가
  - 중복 키워드 검증 로직 추가
  - 예외 상황에 대해 InterestException 및 ErrorCode 활용

- test: 관심사 키워드 수정 단위 테스트 작성
  - 키워드 수정 성공 케이스
  - 관심사 존재하지 않을 경우 예외 발생 케이스
  - 키워드 null / empty 케이스
  - 공백 키워드 포함 케이스
  - 중복 키워드 케이스

- test: 관심사 키워드 수정 통합 테스트 작성
  - 키워드 수정 시 DB에 정상 반영되는지 검증
  - 기존 키워드가 삭제되고 새로운 키워드로 교체되는지 검증
  - orphanRemoval 기반 삭제 동작 확인
  - 유효성 검증 실패 케이스 테스트

- feat: 관심사 컨트롤러 키워드 수정 API 구현
  - PATCH /api/interests/{interestId} 엔드포인트 구현
  - Request Header(Monew-Request-User-Id)를 통해 사용자 식별 값 처리
  - InterestService와 연동하여 응답 반환

- test: 관심사 컨트롤러 슬라이스 테스트 작성
  - 키워드 수정 성공 케이스
  - 요청 바디 누락 시 400 응답 검증
  - 헤더 누락 시 400 응답 검증
  - 헤더 UUID 형식 오류 시 400 응답 검증

- refactor: 서비스 로깅 추가
  - 키워드 수정 요청/성공/실패에 대한 로그 추가
  - 실패 케이스에 warn 로그 적용
  - 성공 및 요청 흐름에 debug 로그 적용

## 변경 사항
- 주요 변경 사항을 작성해주세요.

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 변경 사항
- GlobalExceptionHandler에 HttpMessageNotReadableException, MissingRequestHeaderException에 대한 메서드를 추가했습니다.
  - status=400 으로 설정했습니다.

## 리뷰 포인트
- 프로토타입 페이지에서도 확인해보니 키워드는 수정 시, 기존 키워드에 덧대는 것이 아니라 새로 List 형태로 받아와서 적용하는 것을 확인하였습니다. 이에 맞춰 Entity에서도 clear 후 add 하는 방식으로 진행하였습니다.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 관심사 키워드를 수정하는 업데이트(PATCH) API를 추가했습니다.

* **개선사항**
  * 키워드 검증 강화: 빈 목록, null/공백 항목, 중복 키워드를 거부합니다.
  * 업데이트 시 기존 키워드를 완전히 교체하도록 동작을 명확히 했습니다.
  * 요청 헤더 누락·형식 오류 및 잘못된 본문에 대해 명확한 400 응답을 반환하도록 오류 처리를 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->