### PR TITLE
feat: test Coverage 절대 기준으로 변경 및 리드미 추가

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,8 +2,8 @@ coverage:
   status:
     project:
       default:
-        target: auto  # 현재 커버리지 기준, 이후 기준 70% 추가 예정
-        threshold: 1%
+        target: 70 # 이후 기준 80% 추가 예정
+        threshold: 0%
         informational: false # 조건 불만족시 실패
     patch:
       default:

--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -36,8 +36,8 @@ jobs:
       - name: 실행권한 부여
         run: chmod +x gradlew
 
-      - name: 테스트
-        run: ./gradlew test
+      - name: 테스트 (AWS 연결 제외)
+        run: ./gradlew test -Djunit.platform.exclude.tags=aws
 
       - name: 테스트 결과 리포트 생성
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -12,6 +12,17 @@ on:
       - '**/.env.example'
       - '**/*.example'
       - '.gitignore'
+  push: # 브랜치 테스트 추가
+    branches:
+      - dev
+    paths-ignore:
+      - '**/README.md'
+      - '**/*.md'
+      - '**/*.mdx'
+      - 'docs/**'
+      - '**/.env.example'
+      - '**/*.example'
+      - '.gitignore'
 
 jobs:
   test:
@@ -47,7 +58,9 @@ jobs:
 
       - name: 테스트 커버리지 업로드
         uses: codecov/codecov-action@v4
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: >
+          github.event_name == 'push' ||
+          github.event.pull_request.head.repo.full_name == github.repository
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           files: build/reports/jacoco/test/jacocoTestReport.xml

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 ## 📊Test Coverage
 
-[![codecov](https://codecov.io/github/sb10-part3-team3/sb10-MoNew-team3/branch/dev/graph/badge.svg?token=HH8VH1APA9)](https://codecov.io/github/sb10-part3-team3/sb10-MoNew-team3)
+[![codecov](https://codecov.io/github/sb10-part3-team3/sb10-MoNew-team3/branch/dev/graph/badge.svg)](https://codecov.io/github/sb10-part3-team3/sb10-MoNew-team3/tree/dev)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Team3
+
 ## 📊Test Coverage
 
-[![codecov](https://codecov.io/github/Minbro-Kim/10-sprint-mission/graph/badge.svg?token=B0WE4JVIIN&branch=dev)](https://codecov.io/github/Minbro-Kim/10-sprint-mission/tree/dev)
+[![codecov](https://codecov.io/github/sb10-part3-team3/sb10-MoNew-team3/branch/dev/graph/badge.svg?token=HH8VH1APA9)](https://codecov.io/github/sb10-part3-team3/sb10-MoNew-team3)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+## 📊Test Coverage
+
+[![codecov](https://codecov.io/github/Minbro-Kim/10-sprint-mission/graph/badge.svg?token=B0WE4JVIIN&branch=dev)](https://codecov.io/github/Minbro-Kim/10-sprint-mission/tree/dev)


### PR DESCRIPTION
## 관련 이슈
- closes #126 

## 작업 내용
- README.md 파일 생성 및 배지 추가
- test-dev.yml 파일에서 aws 태그 제외 테스트 수행으로 수정
  - push 조건을 추가하여 dev 브랜치 자체 커버리지 갱신되도록 수정
- codecov.yml 파일에서 절대 커버리지 기준(70%)으로 변경

## 변경 사항
- 커버리지 배지는 개발중인 것을 고려하여 dev 브랜치 기준으로 설정하였습니다.

## 테스트 내용
- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * README에 Team3 헤더와 dev 브랜치용 커버리지 배지("📊Test Coverage") 섹션을 추가했습니다.

* **Chores**
  * 프로젝트 커버리지 목표를 70%로 고정하고 실패 임계값을 조정했습니다.
  * CI 워크플로우가 dev 브랜치의 push를 포함하도록 확장하고, 특정 경로는 무시하도록 설정했습니다.
  * 테스트 실행에서 AWS 태그 테스트를 제외하도록 업데이트하고, 코드커버리지 업로드 조건을 확장했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->