### PR TITLE
feat: 관심사 삭제

### DIFF
--- a/src/main/java/com/team3/monew/controller/InterestController.java
+++ b/src/main/java/com/team3/monew/controller/InterestController.java
@@ -23,7 +23,7 @@ public class InterestController implements InterestApi {
   public ResponseEntity<InterestDto> create(
       @Valid @RequestBody InterestRegisterRequest dto
   ) {
-    InterestDto response = interestService.create(dto);
+    InterestDto response = interestService.createInterest(dto);
 
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(response);
@@ -38,5 +38,12 @@ public class InterestController implements InterestApi {
     InterestDto response = interestService.updateKeyword(userId, interestId, dto);
 
     return ResponseEntity.ok(response);
+  }
+
+  @Override
+  public ResponseEntity<Void> delete(UUID interestId) {
+    interestService.deleteInterest(interestId);
+
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/team3/monew/controller/api/InterestApi.java
+++ b/src/main/java/com/team3/monew/controller/api/InterestApi.java
@@ -87,4 +87,31 @@ public interface InterestApi {
       @PathVariable UUID interestId,
       @RequestBody @Valid InterestUpdateRequest dto
   );
+
+  @Operation(
+      summary = "관심사 삭제",
+      description = "관심사를 삭제합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "204",
+          description = "삭제 성공"
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = "해당 관심사를 찾을 수 없습니다.",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class)
+          )
+      )
+  })
+  @DeleteMapping("/{interestId}")
+  ResponseEntity<Void> delete(
+      @Parameter(
+          description = "삭제할 관심사 ID",
+          required = true
+      )
+      @PathVariable UUID interestId
+  );
 }

--- a/src/main/java/com/team3/monew/controller/api/InterestApi.java
+++ b/src/main/java/com/team3/monew/controller/api/InterestApi.java
@@ -75,6 +75,22 @@ public interface InterestApi {
               mediaType = "application/json",
               schema = @Schema(implementation = InterestDto.class)
           )
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = "해당 관심사를 찾을 수 없습니다.",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class)
+          )
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class)
+          )
       )
   })
   @PatchMapping("/{interestId}")
@@ -100,6 +116,14 @@ public interface InterestApi {
       @ApiResponse(
           responseCode = "404",
           description = "해당 관심사를 찾을 수 없습니다.",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class)
+          )
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
           content = @Content(
               mediaType = "application/json",
               schema = @Schema(implementation = ErrorResponse.class)

--- a/src/main/java/com/team3/monew/repository/ArticleInterestRepository.java
+++ b/src/main/java/com/team3/monew/repository/ArticleInterestRepository.java
@@ -1,0 +1,12 @@
+package com.team3.monew.repository;
+
+import com.team3.monew.entity.ArticleInterest;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleInterestRepository extends JpaRepository<ArticleInterest, UUID> {
+
+  List<ArticleInterest> findAllByInterestId(UUID interestId);
+
+}

--- a/src/main/java/com/team3/monew/repository/InterestKeywordRepository.java
+++ b/src/main/java/com/team3/monew/repository/InterestKeywordRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface InterestKeywordRepository extends JpaRepository<InterestKeyword, UUID> {
 
-  List<InterestKeyword> findInterestKeywordsByInterestId(UUID interestId);
+  List<InterestKeyword> findAllByInterestId(UUID interestId);
 }

--- a/src/main/java/com/team3/monew/repository/SubscriptionRepository.java
+++ b/src/main/java/com/team3/monew/repository/SubscriptionRepository.java
@@ -1,10 +1,13 @@
 package com.team3.monew.repository;
 
 import com.team3.monew.entity.Subscription;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SubscriptionRepository extends JpaRepository<Subscription, UUID> {
 
   boolean existsByUserIdAndInterestId(UUID userId, UUID interestId);
+
+  List<Subscription> findAllByInterestId(UUID interestId);
 }

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -3,6 +3,7 @@ package com.team3.monew.service;
 import com.team3.monew.dto.interest.InterestDto;
 import com.team3.monew.dto.interest.InterestRegisterRequest;
 import com.team3.monew.dto.interest.InterestUpdateRequest;
+import com.team3.monew.entity.ArticleInterest;
 import com.team3.monew.entity.Interest;
 import com.team3.monew.entity.InterestKeyword;
 import com.team3.monew.entity.Subscription;
@@ -36,7 +37,7 @@ public class InterestService {
   private final SubscriptionRepository subscriptionRepository;
   private final InterestMapper interestMapper;
 
-  public InterestDto create(InterestRegisterRequest dto) {
+  public InterestDto createInterest(InterestRegisterRequest dto) {
     log.debug("관심사 등록 요청 - name={}, keywordCount={}",
         dto.name(), dto.keywords().size());
 
@@ -121,6 +122,15 @@ public class InterestService {
         interestId, keywords.size(), subscribedByMe);
 
     return interestMapper.toDto(interest, subscribedByMe);
+  }
+
+  public void deleteInterest(UUID interestId) {
+    log.debug("관심사 삭제 요청 - interestId={}", interestId);
+    Interest interest = findInterestOrElseThrow(interestId);
+
+    interestRepository.delete(interest);
+
+    log.debug("관심사 삭제 성공 - interestId={}", interestId);
   }
 
   private Interest findInterestOrElseThrow(UUID interestId) {

--- a/src/test/java/com/team3/monew/controller/InterestControllerTest.java
+++ b/src/test/java/com/team3/monew/controller/InterestControllerTest.java
@@ -5,6 +5,7 @@ import com.team3.monew.dto.interest.InterestDto;
 import com.team3.monew.dto.interest.InterestRegisterRequest;
 import com.team3.monew.dto.interest.InterestUpdateRequest;
 import com.team3.monew.exception.interest.InterestDuplicateNameException;
+import com.team3.monew.exception.interest.InterestNotFoundException;
 import com.team3.monew.service.InterestService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -21,6 +22,10 @@ import java.util.UUID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -55,7 +60,7 @@ class InterestControllerTest {
         false
     );
 
-    given(interestService.create(any(InterestRegisterRequest.class)))
+    given(interestService.createInterest(any(InterestRegisterRequest.class)))
         .willReturn(response);
 
     // when & then
@@ -79,7 +84,7 @@ class InterestControllerTest {
         List.of("keyword", "test")
     );
 
-    given(interestService.create(any(InterestRegisterRequest.class)))
+    given(interestService.createInterest(any(InterestRegisterRequest.class)))
         .willThrow(new InterestDuplicateNameException());
 
     // when & then
@@ -193,5 +198,34 @@ class InterestControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content(objMapper.writeValueAsString(request)))
         .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("관심사를 삭제할 수 있다")
+  void shouldDeleteInterest_whenDeleteRequest() throws Exception {
+    // given
+    UUID interestId = UUID.randomUUID();
+
+    doNothing().when(interestService).deleteInterest(interestId);
+
+    // when & then
+    mockMvc.perform(delete("/api/interests/{interestId}", interestId))
+        .andExpect(status().isNoContent());
+
+    then(interestService).should().deleteInterest(interestId);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 관심사를 삭제하면 404를 반환한다")
+  void shouldReturn404_whenInterestNotFound() throws Exception {
+    // given
+    UUID interestId = UUID.randomUUID();
+
+    doThrow(new InterestNotFoundException())
+        .when(interestService).deleteInterest(interestId);
+
+    // when & then
+    mockMvc.perform(delete("/api/interests/{interestId}", interestId))
+        .andExpect(status().isNotFound());
   }
 }

--- a/src/test/java/com/team3/monew/integration/InterestServiceIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/InterestServiceIntegrationTest.java
@@ -3,11 +3,17 @@ package com.team3.monew.integration;
 import com.team3.monew.dto.interest.InterestDto;
 import com.team3.monew.dto.interest.InterestRegisterRequest;
 import com.team3.monew.dto.interest.InterestUpdateRequest;
+import com.team3.monew.entity.ArticleInterest;
 import com.team3.monew.entity.Interest;
 import com.team3.monew.entity.InterestKeyword;
+import com.team3.monew.entity.Subscription;
 import com.team3.monew.exception.interest.InterestDuplicateNameException;
 import com.team3.monew.exception.interest.InterestException;
+import com.team3.monew.exception.interest.InterestNotFoundException;
+import com.team3.monew.repository.ArticleInterestRepository;
+import com.team3.monew.repository.InterestKeywordRepository;
 import com.team3.monew.repository.InterestRepository;
+import com.team3.monew.repository.SubscriptionRepository;
 import com.team3.monew.service.InterestService;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -32,6 +38,8 @@ public class InterestServiceIntegrationTest {
   private InterestService interestService;
   @Autowired
   private InterestRepository interestRepository;
+  @Autowired
+  private InterestKeywordRepository interestKeywordRepository;
 
   @Test
   @DisplayName("관심사를 등록하면 키워드와 함께 저장된다")
@@ -43,7 +51,7 @@ public class InterestServiceIntegrationTest {
     );
 
     // when
-    InterestDto savedInterest = interestService.create(request);
+    InterestDto savedInterest = interestService.createInterest(request);
 
     // then
     Optional<Interest> found = interestRepository.findById(savedInterest.id());
@@ -69,10 +77,10 @@ public class InterestServiceIntegrationTest {
         List.of("asdf")
     );
 
-    interestService.create(request1);
+    interestService.createInterest(request1);
 
     // when & then
-    assertThatThrownBy(() -> interestService.create(request2))
+    assertThatThrownBy(() -> interestService.createInterest(request2))
         .isInstanceOf(InterestDuplicateNameException.class);
   }
 
@@ -90,10 +98,10 @@ public class InterestServiceIntegrationTest {
         List.of("keyword")
     );
 
-    interestService.create(request);
+    interestService.createInterest(request);
 
     // when & then
-    assertThatThrownBy(() -> interestService.create(request2))
+    assertThatThrownBy(() -> interestService.createInterest(request2))
         .isInstanceOf(InterestDuplicateNameException.class);
   }
 
@@ -106,7 +114,7 @@ public class InterestServiceIntegrationTest {
         List.of("코스피", "삼성전자")
     );
 
-    InterestDto saved = interestService.create(createRequest);
+    InterestDto saved = interestService.createInterest(createRequest);
 
     // when
     interestService.updateKeyword(
@@ -132,7 +140,7 @@ public class InterestServiceIntegrationTest {
         List.of("금리", "환율")
     );
 
-    InterestDto saved = interestService.create(request);
+    InterestDto saved = interestService.createInterest(request);
 
     // when
     interestService.updateKeyword(
@@ -158,7 +166,7 @@ public class InterestServiceIntegrationTest {
         List.of("아파트")
     );
 
-    InterestDto saved = interestService.create(request);
+    InterestDto saved = interestService.createInterest(request);
 
     // when & then
     assertThatThrownBy(() ->
@@ -179,7 +187,7 @@ public class InterestServiceIntegrationTest {
         List.of("비트코인")
     );
 
-    InterestDto saved = interestService.create(request);
+    InterestDto saved = interestService.createInterest(request);
 
     // when & then
     assertThatThrownBy(() ->
@@ -200,7 +208,7 @@ public class InterestServiceIntegrationTest {
         List.of("개발")
     );
 
-    InterestDto saved = interestService.create(request);
+    InterestDto saved = interestService.createInterest(request);
 
     // when & then
     assertThatThrownBy(() ->
@@ -221,7 +229,7 @@ public class InterestServiceIntegrationTest {
         List.of("정치")
     );
 
-    InterestDto saved = interestService.create(request);
+    InterestDto saved = interestService.createInterest(request);
 
     // when & then
     assertThatThrownBy(() ->
@@ -231,5 +239,53 @@ public class InterestServiceIntegrationTest {
             new InterestUpdateRequest(List.of("경제", "경제"))
         )
     ).isInstanceOf(InterestException.class);
+  }
+
+  @Test
+  @DisplayName("관심사를 삭제할 수 있다")
+  void shouldDeleteInterest_whenDeleteRequest() {
+    // given
+    InterestRegisterRequest request = new InterestRegisterRequest(
+        "삭제용",
+        List.of("키워드", "삭제될 키워드")
+    );
+
+    InterestDto saved = interestService.createInterest(request);
+
+    // when
+    interestService.deleteInterest(saved.id());
+
+    // then
+    assertThat(interestRepository.findById(saved.id())).isEmpty();
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 관심사를 삭제하면 예외가 발생한다")
+  void shouldThrowException_whenInterestNotFound() {
+    // given
+    UUID invalidId = UUID.randomUUID();
+
+    // when & then
+    assertThatThrownBy(() -> interestService.deleteInterest(invalidId))
+        .isInstanceOf(InterestNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("관심사를 삭제하면 연관 키워드도 함께 삭제된다")
+  void shouldDeleteInterestWithKeywords_whenDeleteRequest() {
+    // given
+    InterestRegisterRequest request = new InterestRegisterRequest(
+        "삭제용",
+        List.of("키워드", "삭제될 키워드")
+    );
+
+    InterestDto saved = interestService.createInterest(request);
+
+    // when
+    interestService.deleteInterest(saved.id());
+
+    // then
+    assertThat(interestRepository.findById(saved.id())).isEmpty();
+    assertThat(interestKeywordRepository.findAllByInterestId(saved.id())).isEmpty();
   }
 }

--- a/src/test/java/com/team3/monew/service/InterestServiceTest.java
+++ b/src/test/java/com/team3/monew/service/InterestServiceTest.java
@@ -73,7 +73,7 @@ class InterestServiceTest {
     given(interestMapper.toDto(savedInterest, false)).willReturn(response);
 
     // when
-    InterestDto result = interestService.create(request);
+    InterestDto result = interestService.createInterest(request);
 
     // then
     assertThat(result.name()).isEqualTo("주식");
@@ -92,7 +92,7 @@ class InterestServiceTest {
     given(interestRepository.existsByName("테스트")).willReturn(true);
 
     // when & then
-    assertThatThrownBy(() -> interestService.create(request))
+    assertThatThrownBy(() -> interestService.createInterest(request))
         .isInstanceOf(InterestDuplicateNameException.class);
 
     then(interestRepository).should(never()).saveAndFlush(any());
@@ -113,7 +113,7 @@ class InterestServiceTest {
     given(interestRepository.existsByName("applf")).willReturn(false);
 
     // when & then
-    assertThatThrownBy(() -> interestService.create(request))
+    assertThatThrownBy(() -> interestService.createInterest(request))
         .isInstanceOf(InterestDuplicateNameException.class);
 
     then(interestRepository).should(never()).saveAndFlush(any());
@@ -274,5 +274,35 @@ class InterestServiceTest {
 
     then(subscriptionRepository).should(never()).existsByUserIdAndInterestId(any(), any());
     then(interestMapper).should(never()).toDto(any(), any(Boolean.class));
+  }
+
+  @Test
+  @DisplayName("관심사를 삭제할 수 있다")
+  void shouldDeleteInterest_whenDeleteRequest() {
+    // given
+    UUID interestId = UUID.randomUUID();
+    Interest interest = Interest.create("주식");
+
+    given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+
+    // when
+    interestService.deleteInterest(interestId);
+
+    // then
+    then(interestRepository).should().delete(interest);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 관심사를 삭제하면 예외가 발생한다")
+  void shouldThrowException_whenInterestNotFound() {
+    // given
+    UUID interestId = UUID.randomUUID();
+    given(interestRepository.findById(interestId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> interestService.deleteInterest(interestId))
+        .isInstanceOf(InterestNotFoundException.class);
+
+    then(interestRepository).should(never()).delete(any());
   }
 }


### PR DESCRIPTION
## 관련 이슈
- closes #20 #136 #138 #139 #140 

## 작업 내용
- feat: 관심사 삭제 기능 구현
  - InterestService에 관심사 삭제 메서드(deleteInterest) 구현
  - 관심사 존재 여부 확인 후 삭제하는 로직 구현
  - 존재하지 않는 경우 InterestException을 통해 예외 처리

- test: 관심사 삭제 단위 테스트 작성
  - 관심사 삭제 성공 케이스
  - 존재하지 않는 관심사 삭제 시 예외 발생 케이스

- test: 관심사 삭제 통합 테스트 작성
  - 관심사 삭제 시 DB에서 정상적으로 삭제되는지 검증
  - 관심사 삭제 시 연관된 키워드가 함께 삭제되는지 검증
    - orphanRemoval 및 DB ON DELETE CASCADE 기반 삭제 동작 확인
  - 존재하지 않는 관심사 삭제 시 예외 발생 케이스

- feat: 관심사 컨트롤러 삭제 API 구현
  - DELETE /api/interests/{interestId} 엔드포인트 구현
  - InterestService와 연동하여 삭제 처리
  - 삭제 성공 시 204 No Content 응답 반환

- test: 관심사 컨트롤러 슬라이스 테스트 작성
  - 관심사 삭제 성공 시 204 응답 검증
  - 존재하지 않는 관심사 삭제 시 404 응답 검증

- refactor: 서비스 로깅 추가
  - 관심사 삭제 요청/성공에 대한 로그 추가
  - 요청 흐름에 debug 로그 적용

## 변경 사항
- 기타
  - 연관 엔티티(Subscription, ArticleInterest)는 DB의 ON DELETE CASCADE 설정을 통해 자동 삭제되도록 처리

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 변경사항 - 기타에 작성한 것처럼 연관 엔티티는 DB의 ON DELETE CASCADE 설정을 통해 자동 삭제되도록 처리하였으며, 테스트 코드는 따로 작성하지 않았습니다

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관심사 삭제 기능이 추가되었습니다. DELETE 엔드포인트로 특정 관심사를 제거할 수 있으며, 성공 시 204 No Content를 반환하고 존재하지 않을 경우 404를 반환합니다.

* **개선**
  * 관심사 생성 흐름이 내부적으로 정리되어 안정성이 향상되었습니다.

* **테스트**
  * 삭제 동작 및 생성 흐름에 대한 단위 및 통합 테스트가 추가/확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->