### PR TITLE
feat: 관심사 뉴스 등록 알림 등록 기능

### DIFF
--- a/src/main/java/com/team3/monew/config/AsyncConfig.java
+++ b/src/main/java/com/team3/monew/config/AsyncConfig.java
@@ -31,6 +31,20 @@ public class AsyncConfig implements AsyncConfigurer {
     return executor;
   }
 
+  //배치 이벤트가 발행되는 스레드풀
+  @Bean(name = "batchNotificationTaskExecutor")
+  public TaskExecutor createBatchNotificationTaskExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(5); //기본 스레드 수
+    executor.setMaxPoolSize(10);
+    executor.setQueueCapacity(100);//스레드 별 대기 가능
+    executor.setThreadNamePrefix("batch-noti-task-");//스레드 이름
+    executor.setWaitForTasksToCompleteOnShutdown(true); // 진행 중인 작업 완료 후 종료
+    executor.setAwaitTerminationSeconds(100);           // 최대 대기 시간 설정
+    executor.initialize();
+    return executor;
+  }
+
   @Override
   public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
     return (ex, method, params) -> {

--- a/src/main/java/com/team3/monew/config/AsyncConfig.java
+++ b/src/main/java/com/team3/monew/config/AsyncConfig.java
@@ -1,6 +1,7 @@
 package com.team3.monew.config;
 
 import java.util.Arrays;
+import java.util.concurrent.ThreadPoolExecutor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.context.annotation.Bean;
@@ -41,6 +42,8 @@ public class AsyncConfig implements AsyncConfigurer {
     executor.setThreadNamePrefix("batch-noti-task-");//스레드 이름
     executor.setWaitForTasksToCompleteOnShutdown(true); // 진행 중인 작업 완료 후 종료
     executor.setAwaitTerminationSeconds(100);           // 최대 대기 시간 설정
+    executor.setRejectedExecutionHandler(
+        new ThreadPoolExecutor.CallerRunsPolicy());//큐가 가득찾을 때 메인 스레드 사용
     executor.initialize();
     return executor;
   }

--- a/src/main/java/com/team3/monew/dto/notification/CommentLikedNotificationRequest.java
+++ b/src/main/java/com/team3/monew/dto/notification/CommentLikedNotificationRequest.java
@@ -1,4 +1,4 @@
-package com.team3.monew.dto.user.notification;
+package com.team3.monew.dto.notification;
 
 import java.util.UUID;
 

--- a/src/main/java/com/team3/monew/dto/notification/InterestNotificationRequest.java
+++ b/src/main/java/com/team3/monew/dto/notification/InterestNotificationRequest.java
@@ -1,5 +1,6 @@
 package com.team3.monew.dto.notification;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -10,4 +11,7 @@ public record InterestNotificationRequest(
     List<UUID> subscriberIds
 ) {
 
+  public InterestNotificationRequest {
+    subscriberIds = subscriberIds == null ? new ArrayList<UUID>() : List.copyOf(subscriberIds);
+  }
 }

--- a/src/main/java/com/team3/monew/dto/notification/InterestNotificationRequest.java
+++ b/src/main/java/com/team3/monew/dto/notification/InterestNotificationRequest.java
@@ -1,0 +1,13 @@
+package com.team3.monew.dto.notification;
+
+import java.util.List;
+import java.util.UUID;
+
+public record InterestNotificationRequest(
+    UUID interestId,
+    String interestName,
+    Integer articleCount,
+    List<UUID> subscriberIds
+) {
+
+}

--- a/src/main/java/com/team3/monew/dto/notification/InterestNotificationRequest.java
+++ b/src/main/java/com/team3/monew/dto/notification/InterestNotificationRequest.java
@@ -1,6 +1,5 @@
 package com.team3.monew.dto.notification;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 

--- a/src/main/java/com/team3/monew/dto/notification/InterestNotificationRequest.java
+++ b/src/main/java/com/team3/monew/dto/notification/InterestNotificationRequest.java
@@ -12,6 +12,6 @@ public record InterestNotificationRequest(
 ) {
 
   public InterestNotificationRequest {
-    subscriberIds = subscriberIds == null ? new ArrayList<UUID>() : List.copyOf(subscriberIds);
+    subscriberIds = subscriberIds == null ? List.of() : List.copyOf(subscriberIds);
   }
 }

--- a/src/main/java/com/team3/monew/event/InterestNotificationEvent.java
+++ b/src/main/java/com/team3/monew/event/InterestNotificationEvent.java
@@ -1,0 +1,17 @@
+package com.team3.monew.event;
+
+import java.util.Map;
+import java.util.UUID;
+
+public record InterestNotificationEvent(
+    Map<UUID, InterestArticleSummary> interestArticleSummaryMap
+) {
+
+  public record InterestArticleSummary(
+      String interestName,
+      Integer articleCount
+  ) {
+
+  }
+
+}

--- a/src/main/java/com/team3/monew/listener/NotificationEventListener.java
+++ b/src/main/java/com/team3/monew/listener/NotificationEventListener.java
@@ -10,6 +10,7 @@ import com.team3.monew.global.exception.BusinessException;
 import com.team3.monew.repository.SubscriptionRepository;
 import com.team3.monew.repository.SubscriptionRepository.SubscriptionInfo;
 import com.team3.monew.service.NotificationService;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -70,6 +71,7 @@ public class NotificationEventListener {
       Map<UUID, List<SubscriptionInfo>> subscribers = subscriptionRepository.findAllProjectedByInterestIdIn(
               keySet).stream()
           .collect(Collectors.groupingBy(SubscriptionInfo::getInterestId));
+      List<InterestNotificationRequest> requests = new ArrayList<>();
 
       event.interestArticleSummaryMap().forEach((key, value) -> {
         List<UUID> ids = subscribers.getOrDefault(key, List.of()).stream()
@@ -77,15 +79,12 @@ public class NotificationEventListener {
         if (ids.isEmpty()) {
           return;
         }
-        notificationService.registerInterestNotification(
-            new InterestNotificationRequest(
-                key,
-                value.interestName(),
-                value.articleCount(),
-                ids
-            )
-        );
+        requests.add(
+            new InterestNotificationRequest(key, value.interestName(), value.articleCount(), ids));
       });
+      if (!requests.isEmpty()) {
+        notificationService.registerInterestNotification(requests);
+      }
 
     } catch (BusinessException e) {
       log.warn("알림 등록 취소: 관련 리소스를 찾을 수 없음: Message={}, Details={}"

--- a/src/main/java/com/team3/monew/listener/NotificationEventListener.java
+++ b/src/main/java/com/team3/monew/listener/NotificationEventListener.java
@@ -1,10 +1,20 @@
 package com.team3.monew.listener;
 
-import com.team3.monew.dto.user.notification.CommentLikedNotificationRequest;
+import com.team3.monew.dto.notification.CommentLikedNotificationRequest;
+import com.team3.monew.dto.notification.InterestNotificationRequest;
 import com.team3.monew.event.CommentLikedEvent;
+import com.team3.monew.event.InterestNotificationEvent;
 import com.team3.monew.exception.comment.CommentNotFoundException;
 import com.team3.monew.exception.user.UserNotFoundException;
+import com.team3.monew.global.exception.BusinessException;
+import com.team3.monew.repository.SubscriptionRepository;
+import com.team3.monew.repository.SubscriptionRepository.SubscriptionInfo;
 import com.team3.monew.service.NotificationService;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.retry.annotation.Backoff;
@@ -20,6 +30,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class NotificationEventListener {
 
   private final NotificationService notificationService;
+  private final SubscriptionRepository subscriptionRepository;
 
   @Async("realTimeNotificationTaskExecutor") //알림용 스레드풀 사용
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -39,8 +50,46 @@ public class NotificationEventListener {
           )
       );
     } catch (CommentNotFoundException | UserNotFoundException e) {
-      log.info("알림 전송 취소: 관련 리소스를 찾을 수 없음: CommentId={}, ActorUserId={}, Message={}, Details={}",
+      log.warn("알림 등록 취소: 관련 리소스를 찾을 수 없음: CommentId={}, ActorUserId={}, Message={}, Details={}",
           event.commentId(), event.actorUserId(), e.getMessage(), e.getDetails());
+    } //그 외는 비동기 예외
+  }
+
+  @Async("batchNotificationTaskExecutor") //배치용 스레드풀 사용
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  @Retryable(
+      retryFor = {
+          org.springframework.dao.TransientDataAccessException.class,
+          org.springframework.dao.CannotAcquireLockException.class}, // 일시적 DB 오류만 재시도
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 1000)      // 1초 간격으로
+  )
+  public void handleInterestNotificationEvent(InterestNotificationEvent event) {
+    try {
+      Set<UUID> keySet = event.interestArticleSummaryMap().keySet();
+      Map<UUID, List<SubscriptionInfo>> subscribers = subscriptionRepository.findAllProjectedByInterestIdIn(
+              keySet).stream()
+          .collect(Collectors.groupingBy(SubscriptionInfo::getInterestId));
+
+      event.interestArticleSummaryMap().forEach((key, value) -> {
+        List<UUID> ids = subscribers.getOrDefault(key, List.of()).stream()
+            .map(SubscriptionInfo::getUserId).toList();
+        if (ids.isEmpty()) {
+          return;
+        }
+        notificationService.registerInterestNotification(
+            new InterestNotificationRequest(
+                key,
+                value.interestName(),
+                value.articleCount(),
+                ids
+            )
+        );
+      });
+
+    } catch (BusinessException e) {
+      log.warn("알림 등록 취소: 관련 리소스를 찾을 수 없음: Message={}, Details={}"
+          , e.getMessage(), e.getDetails());
     } //그 외는 비동기 예외
   }
 }

--- a/src/main/java/com/team3/monew/listener/NotificationEventListener.java
+++ b/src/main/java/com/team3/monew/listener/NotificationEventListener.java
@@ -6,7 +6,6 @@ import com.team3.monew.event.CommentLikedEvent;
 import com.team3.monew.event.InterestNotificationEvent;
 import com.team3.monew.exception.comment.CommentNotFoundException;
 import com.team3.monew.exception.user.UserNotFoundException;
-import com.team3.monew.global.exception.BusinessException;
 import com.team3.monew.repository.SubscriptionRepository;
 import com.team3.monew.repository.SubscriptionRepository.SubscriptionInfo;
 import com.team3.monew.service.NotificationService;

--- a/src/main/java/com/team3/monew/listener/NotificationEventListener.java
+++ b/src/main/java/com/team3/monew/listener/NotificationEventListener.java
@@ -10,6 +10,7 @@ import com.team3.monew.global.exception.BusinessException;
 import com.team3.monew.repository.SubscriptionRepository;
 import com.team3.monew.repository.SubscriptionRepository.SubscriptionInfo;
 import com.team3.monew.service.NotificationService;
+import jakarta.persistence.EntityNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -18,6 +19,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Async;
@@ -85,10 +87,9 @@ public class NotificationEventListener {
       if (!requests.isEmpty()) {
         notificationService.registerInterestNotification(requests);
       }
-
-    } catch (BusinessException e) {
-      log.warn("알림 등록 취소: 관련 리소스를 찾을 수 없음: Message={}, Details={}"
-          , e.getMessage(), e.getDetails());
-    } //그 외는 비동기 예외
+    } catch (EntityNotFoundException | DataIntegrityViolationException e) {
+      //존재하지 않는 프록시 객체 저장 시도 또는 외래키 위반
+      log.warn("알림 등록 취소: 관련 리소스를 찾을 수 없음.(탈퇴 유저) message={}", e.getMessage());
+    } //그 외는 비동기 예외(재시도)
   }
 }

--- a/src/main/java/com/team3/monew/repository/SubscriptionRepository.java
+++ b/src/main/java/com/team3/monew/repository/SubscriptionRepository.java
@@ -1,13 +1,23 @@
 package com.team3.monew.repository;
 
 import com.team3.monew.entity.Subscription;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface SubscriptionRepository extends JpaRepository<Subscription, UUID> {
 
   boolean existsByUserIdAndInterestId(UUID userId, UUID interestId);
+  public interface SubscriptionInfo {
+
+    UUID getUserId();
 
   List<Subscription> findAllByInterestId(UUID interestId);
+    UUID getInterestId();
+  }
+
+  @Query("select s.user.id as userId, s.interest.id as interestId from Subscription s where s.interest.id in :interestIds")
+  List<SubscriptionInfo> findAllProjectedByInterestIdIn(Collection<UUID> interestIds);
 }

--- a/src/main/java/com/team3/monew/repository/SubscriptionRepository.java
+++ b/src/main/java/com/team3/monew/repository/SubscriptionRepository.java
@@ -10,11 +10,13 @@ import org.springframework.data.jpa.repository.Query;
 public interface SubscriptionRepository extends JpaRepository<Subscription, UUID> {
 
   boolean existsByUserIdAndInterestId(UUID userId, UUID interestId);
+
+  List<Subscription> findAllByInterestId(UUID interestId);
+
   public interface SubscriptionInfo {
 
     UUID getUserId();
 
-  List<Subscription> findAllByInterestId(UUID interestId);
     UUID getInterestId();
   }
 

--- a/src/main/java/com/team3/monew/service/NotificationService.java
+++ b/src/main/java/com/team3/monew/service/NotificationService.java
@@ -12,6 +12,7 @@ import com.team3.monew.repository.CommentRepository;
 import com.team3.monew.repository.NotificationRepository;
 import com.team3.monew.repository.UserRepository;
 
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -50,10 +51,28 @@ public class NotificationService {
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void registerInterestNotification(List<InterestNotificationRequest> requests) {
-
+    log.debug("관심사 뉴스 알림 벌크 등록 시작: 요청 관심사 개수={}", requests.size());
+    List<Notification> notifications = new ArrayList<>();
+    requests.forEach(request -> {
+      log.debug("관심사 뉴스 알림 생성 시작: interestId={}", request.interestId());
+      request.subscriberIds().forEach(subscriberId -> {
+        User user = userRepository.getReferenceById(subscriberId);
+        String content = generateInterestNotificationContent(request.interestName(),
+            request.articleCount());
+        notifications.add(Notification.create(user, content, NotificationResourceType.INTEREST,
+            request.interestId(), null));
+      });
+      log.debug("관심사 뉴스 알림 생성 완료: interestId={}", request.interestId());
+    });
+    notificationRepository.saveAll(notifications);
+    log.info("관심사 뉴스 알림 벌크 등록 성공: 등록 개수={}", notifications.size());
   }
 
   private String generateCommentLikedContent(String actorUserNickname) {
     return actorUserNickname + "님이 나의 댓글을 좋아합니다.";
+  }
+
+  private String generateInterestNotificationContent(String interestName, Integer articleCount) {
+    return interestName + "와 관련된 기사가 " + articleCount + "건 등록되었습니다.";
   }
 }

--- a/src/main/java/com/team3/monew/service/NotificationService.java
+++ b/src/main/java/com/team3/monew/service/NotificationService.java
@@ -12,6 +12,7 @@ import com.team3.monew.repository.CommentRepository;
 import com.team3.monew.repository.NotificationRepository;
 import com.team3.monew.repository.UserRepository;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -48,7 +49,7 @@ public class NotificationService {
   }
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)
-  public void registerInterestNotification(InterestNotificationRequest request) {
+  public void registerInterestNotification(List<InterestNotificationRequest> requests) {
 
   }
 

--- a/src/main/java/com/team3/monew/service/NotificationService.java
+++ b/src/main/java/com/team3/monew/service/NotificationService.java
@@ -1,6 +1,7 @@
 package com.team3.monew.service;
 
-import com.team3.monew.dto.user.notification.CommentLikedNotificationRequest;
+import com.team3.monew.dto.notification.CommentLikedNotificationRequest;
+import com.team3.monew.dto.notification.InterestNotificationRequest;
 import com.team3.monew.entity.Comment;
 import com.team3.monew.entity.Notification;
 import com.team3.monew.entity.User;
@@ -44,6 +45,11 @@ public class NotificationService {
     log.debug("좋아요 알림 엔터티 생성 성공");
     notificationRepository.save(notification);
     log.info("댓글 좋아요 알림 등록 완료: notificationId={}", notification.getId());
+  }
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void registerInterestNotification(InterestNotificationRequest request) {
+
   }
 
   private String generateCommentLikedContent(String actorUserNickname) {

--- a/src/test/java/com/team3/monew/integration/NotificationIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/NotificationIntegrationTest.java
@@ -2,9 +2,12 @@ package com.team3.monew.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.team3.monew.dto.notification.CommentLikedNotificationRequest;
+import com.team3.monew.dto.notification.InterestNotificationRequest;
 import com.team3.monew.entity.Comment;
+import com.team3.monew.entity.Interest;
 import com.team3.monew.entity.NewsArticle;
 import com.team3.monew.entity.NewsSource;
 import com.team3.monew.entity.Notification;
@@ -14,6 +17,7 @@ import com.team3.monew.entity.enums.NotificationResourceType;
 import com.team3.monew.exception.comment.CommentNotFoundException;
 import com.team3.monew.exception.user.UserNotFoundException;
 import com.team3.monew.repository.CommentRepository;
+import com.team3.monew.repository.InterestRepository;
 import com.team3.monew.repository.NewsArticleRepository;
 import com.team3.monew.repository.NewsSourceRepository;
 import com.team3.monew.repository.NotificationRepository;
@@ -24,6 +28,7 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,79 +60,174 @@ public class NotificationIntegrationTest {
   @Autowired
   private NewsSourceRepository newsSourceRepository;
 
-  private User writer;
-  private User actor;
-  private Comment comment;
-  private NewsArticle article;
+  @Autowired
+  private InterestRepository interestRepository;
 
-  @BeforeEach
-  void setUp() {
-    //비동기이기 때문에 트랜잭셔널 별도임으로 개별 삭제
-    notificationRepository.deleteAll();
-    commentRepository.deleteAll();
-    newsArticleRepository.deleteAll();
-    newsSourceRepository.deleteAll();
-    userRepository.deleteAll();
+  @Nested
+  @DisplayName("좋아요 알림 등록 테스트")
+  class CommentLikeTest {
 
-    writer = userRepository.save(User.create("writer@test.com", "writer", "pwd"));
-    actor = userRepository.save(User.create("actor@test.com", "actor", "pwd"));
-    NewsSource newsSource = NewsSource.create("test", NewsSourceType.NAVER, "url");
-    newsSourceRepository.save(newsSource);
-    article = newsArticleRepository.save(
-        NewsArticle.create(newsSource, "link", "title", Instant.now(), "summary"));
-    comment = commentRepository.save(Comment.create(article, writer, "댓글 내용"));
+    private User writer;
+    private User actor;
+    private Comment comment;
+    private NewsArticle article;
+
+    @BeforeEach
+    void setUp() {
+      //비동기이기 때문에 트랜잭셔널 별도임으로 개별 삭제
+      notificationRepository.deleteAll();
+      commentRepository.deleteAll();
+      newsArticleRepository.deleteAll();
+      newsSourceRepository.deleteAll();
+      userRepository.deleteAll();
+
+      writer = userRepository.save(User.create("writer@test.com", "writer", "pwd"));
+      actor = userRepository.save(User.create("actor@test.com", "actor", "pwd"));
+      NewsSource newsSource = NewsSource.create("test", NewsSourceType.NAVER, "url");
+      newsSourceRepository.save(newsSource);
+      article = newsArticleRepository.save(
+          NewsArticle.create(newsSource, "link", "title", Instant.now(), "summary"));
+      comment = commentRepository.save(Comment.create(article, writer, "댓글 내용"));
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 알림 등록 요청 시, 알림이 저장된다.")
+    void shouldRegisterNotification_whenRequestCommentLikedNotification() {
+      // given
+      CommentLikedNotificationRequest request = new CommentLikedNotificationRequest(
+          actor.getId(), comment.getId());
+
+      // when
+      notificationService.registerLikeNotification(request);
+
+      // then
+      List<Notification> results = notificationRepository.findAll();
+      assertThat(results).hasSize(1);
+      Notification saved = results.get(0);
+      assertThat(saved.getResourceType()).isEqualTo(NotificationResourceType.COMMENT);
+      assertThat(saved.getContent()).contains(actor.getNickname());
+      assertThat(saved.getUser().getId()).isEqualTo(writer.getId());
+      assertThat(saved.getResourceId()).isEqualTo(comment.getId());
+      assertThat(saved.getActorUser().getId()).isEqualTo(actor.getId());
+      assertThat(saved.isConfirmed()).isFalse();
+      assertThat(saved.getConfirmedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 댓글 ID로 알림 등록을 요청하면 예외가 발생한다.")
+    void shouldThrowException_whenCommentNotFound() {
+      // given
+      UUID nonExistCommentId = UUID.randomUUID();
+      CommentLikedNotificationRequest request = new CommentLikedNotificationRequest(
+          actor.getId(), nonExistCommentId);
+
+      // When & Then
+      assertThatThrownBy(() -> notificationService.registerLikeNotification(request))
+          .isInstanceOf(CommentNotFoundException.class);
+      List<Notification> results = notificationRepository.findAll();
+      assertThat(results).hasSize(0);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 좋아요 사용자 ID로 알림 등록을 요청하면 예외가 발생한다.")
+    void shouldThrowException_whenActorUserNotFound() {
+      // given
+      UUID nonExistActorId = UUID.randomUUID();
+      CommentLikedNotificationRequest request = new CommentLikedNotificationRequest(
+          nonExistActorId, comment.getId());
+
+      // When & Then
+      assertThatThrownBy(() -> notificationService.registerLikeNotification(request))
+          .isInstanceOf(UserNotFoundException.class);
+      List<Notification> results = notificationRepository.findAll();
+      assertThat(results).hasSize(0);
+    }
   }
 
-  @Test
-  @DisplayName("댓글 좋아요 알림 등록 요청 시, 알림이 저장된다.")
-  void shouldRegisterNotification_whenRequestCommentLikedNotification() {
-    // given
-    CommentLikedNotificationRequest request = new CommentLikedNotificationRequest(
-        actor.getId(), comment.getId());
+  @Nested
+  @DisplayName("관심사 알림 등록 테스트")
+  class InterestNotificationTest {
 
-    // when
-    notificationService.registerLikeNotification(request);
+    private User subscriber1;
+    private User subscriber2;
+    private User subscriber3;
+    private Interest interest1;
+    private Interest interest2;
 
-    // then
-    List<Notification> results = notificationRepository.findAll();
-    assertThat(results).hasSize(1);
-    Notification saved = results.get(0);
-    assertThat(saved.getResourceType()).isEqualTo(NotificationResourceType.COMMENT);
-    assertThat(saved.getContent()).contains(actor.getNickname());
-    assertThat(saved.getUser().getId()).isEqualTo(writer.getId());
-    assertThat(saved.getResourceId()).isEqualTo(comment.getId());
-    assertThat(saved.getActorUser().getId()).isEqualTo(actor.getId());
-    assertThat(saved.isConfirmed()).isFalse();
-    assertThat(saved.getConfirmedAt()).isNull();
-  }
+    @BeforeEach
+    void setUp() {
+      notificationRepository.deleteAll();
+      interestRepository.deleteAll();
+      userRepository.deleteAll();
 
-  @Test
-  @DisplayName("존재하지 않는 댓글 ID로 알림 등록을 요청하면 예외가 발생한다.")
-  void shouldThrowException_whenCommentNotFound() {
-    // given
-    UUID nonExistCommentId = UUID.randomUUID();
-    CommentLikedNotificationRequest request = new CommentLikedNotificationRequest(
-        actor.getId(), nonExistCommentId);
+      subscriber1 = User.create("sub1@ntest.com", "sub1", "pwd");
+      subscriber2 = User.create("sub2@test.com", "sub2", "pwd");
+      subscriber3 = User.create("sub3@test.com", "sub3", "pwd");
+      interest1 = Interest.create("interest1");
+      interest2 = Interest.create("interest2");
 
-    // When & Then
-    assertThatThrownBy(() -> notificationService.registerLikeNotification(request))
-        .isInstanceOf(CommentNotFoundException.class);
-    List<Notification> results = notificationRepository.findAll();
-    assertThat(results).hasSize(0);
-  }
+      userRepository.saveAll(List.of(subscriber1, subscriber2, subscriber3));
+      interestRepository.saveAll(List.of(interest1, interest2));
+    }
 
-  @Test
-  @DisplayName("존재하지 않는 좋아요 사용자 ID로 알림 등록을 요청하면 예외가 발생한다.")
-  void shouldThrowException_whenActorUserNotFound() {
-    // given
-    UUID nonExistActorId = UUID.randomUUID();
-    CommentLikedNotificationRequest request = new CommentLikedNotificationRequest(
-        nonExistActorId, comment.getId());
+    @Test
+    @DisplayName("관심사 알림 등록 요청 시, 알림이 저장된다.")
+    void shouldRegisterNotification_whenRequestInterestNotification() {
+      // given
+      InterestNotificationRequest request1 = new InterestNotificationRequest(interest1.getId(),
+          interest1.getName(), 10,
+          List.of(subscriber1.getId(), subscriber2.getId(), subscriber3.getId()));
 
-    // When & Then
-    assertThatThrownBy(() -> notificationService.registerLikeNotification(request))
-        .isInstanceOf(UserNotFoundException.class);
-    List<Notification> results = notificationRepository.findAll();
-    assertThat(results).hasSize(0);
+      InterestNotificationRequest request2 = new InterestNotificationRequest(interest2.getId(),
+          interest2.getName(), 3, List.of(subscriber1.getId(), subscriber2.getId()));
+
+      // when
+      notificationService.registerInterestNotification(List.of(request1, request2));
+
+      // then
+      List<Notification> results = notificationRepository.findAll();
+      assertAll(
+          // 1. 총 생성 개수 확인 1번 관심사 3명, 2번 관심사 2명
+          () -> assertThat(results).hasSize(5),
+
+          // 2. 리소스 타입 확인
+          () -> assertThat(results).extracting(Notification::getResourceType)
+              .containsOnly(NotificationResourceType.INTEREST),
+
+          // 3-1. 관심사1의 알림 개수 및 내용 확인
+          () -> {
+            List<Notification> int1Notifications = results.stream()
+                .filter(n -> n.getResourceId().equals(interest1.getId()))
+                .toList();
+            assertThat(int1Notifications).hasSize(3);
+            assertThat(int1Notifications).extracting(Notification::getContent)
+                .containsOnly(interest1.getName() + "와 관련된 기사가 10건 등록되었습니다.");
+          },
+
+          // 3-2. 관심사2의 알림 개수 및 내용 확인
+          () -> {
+            List<Notification> int2Notifications = results.stream()
+                .filter(n -> n.getResourceId().equals(interest2.getId()))
+                .toList();
+            assertThat(int2Notifications).hasSize(2);
+            assertThat(int2Notifications).extracting(Notification::getContent)
+                .containsOnly(interest2.getName() + "와 관련된 기사가 3건 등록되었습니다.");
+          },
+
+          // 4. 1번 유저 2개 알림 등록
+          () -> {
+            List<Notification> sub1Notifications = results.stream()
+                .filter(n -> n.getUser().getId().equals(subscriber1.getId()))
+                .toList();
+            assertThat(sub1Notifications).hasSize(2);
+          },
+
+          // 5. 확인안함 상태
+          () -> assertThat(results).allSatisfy(n -> {
+            assertThat(n.isConfirmed()).isFalse();
+            assertThat(n.getConfirmedAt()).isNull();
+          })
+      );
+    }
   }
 }

--- a/src/test/java/com/team3/monew/integration/NotificationIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/NotificationIntegrationTest.java
@@ -3,7 +3,7 @@ package com.team3.monew.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.team3.monew.dto.user.notification.CommentLikedNotificationRequest;
+import com.team3.monew.dto.notification.CommentLikedNotificationRequest;
 import com.team3.monew.entity.Comment;
 import com.team3.monew.entity.NewsArticle;
 import com.team3.monew.entity.NewsSource;
@@ -30,7 +30,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
 @Tag("integration")
 @SpringBootTest

--- a/src/test/java/com/team3/monew/integration/NotificationIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/NotificationIntegrationTest.java
@@ -160,7 +160,7 @@ public class NotificationIntegrationTest {
       interestRepository.deleteAll();
       userRepository.deleteAll();
 
-      subscriber1 = User.create("sub1@ntest.com", "sub1", "pwd");
+      subscriber1 = User.create("sub1@test.com", "sub1", "pwd");
       subscriber2 = User.create("sub2@test.com", "sub2", "pwd");
       subscriber3 = User.create("sub3@test.com", "sub3", "pwd");
       interest1 = Interest.create("interest1");

--- a/src/test/java/com/team3/monew/listener/NotificationEventListenerIntegrationTest.java
+++ b/src/test/java/com/team3/monew/listener/NotificationEventListenerIntegrationTest.java
@@ -208,7 +208,7 @@ public class NotificationEventListenerIntegrationTest {
       listenerThreadName.set(Thread.currentThread().getName());
       return null;
     }).given(subscriptionRepository)
-        .findAllProjectedByInterestIdIn(interestArticleSummaryMap.keySet());
+        .findAllProjectedByInterestIdIn(eq(interestArticleSummaryMap.keySet()));
 
     // when
     transactionTemplate.execute(status -> {

--- a/src/test/java/com/team3/monew/listener/NotificationEventListenerIntegrationTest.java
+++ b/src/test/java/com/team3/monew/listener/NotificationEventListenerIntegrationTest.java
@@ -9,7 +9,7 @@ import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 
-import com.team3.monew.dto.user.notification.CommentLikedNotificationRequest;
+import com.team3.monew.dto.notification.CommentLikedNotificationRequest;
 import com.team3.monew.event.CommentLikedEvent;
 import com.team3.monew.service.NotificationService;
 import java.util.UUID;

--- a/src/test/java/com/team3/monew/listener/NotificationEventListenerIntegrationTest.java
+++ b/src/test/java/com/team3/monew/listener/NotificationEventListenerIntegrationTest.java
@@ -3,6 +3,7 @@ package com.team3.monew.listener;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.after;
@@ -10,8 +11,14 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 
 import com.team3.monew.dto.notification.CommentLikedNotificationRequest;
+import com.team3.monew.dto.notification.InterestNotificationRequest;
 import com.team3.monew.event.CommentLikedEvent;
+import com.team3.monew.event.InterestNotificationEvent;
+import com.team3.monew.event.InterestNotificationEvent.InterestArticleSummary;
+import com.team3.monew.repository.SubscriptionRepository;
 import com.team3.monew.service.NotificationService;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.DisplayName;
@@ -35,6 +42,9 @@ public class NotificationEventListenerIntegrationTest {
 
   @MockitoBean
   private NotificationService notificationService;
+
+  @MockitoBean
+  private SubscriptionRepository subscriptionRepository;
 
   @MockitoSpyBean
   private NotificationEventListener notificationEventListener;
@@ -130,6 +140,92 @@ public class NotificationEventListenerIntegrationTest {
           assertThat(listenerThreadName.get()).isNotNull();
           assertThat(listenerThreadName.get()).isNotEqualTo(mainThreadName);
           assertThat(listenerThreadName.get()).startsWith("real-time-noti-task-");//스레드풀 확인
+        });
+  }
+
+  @Test
+  @DisplayName("관심사 이벤트를 발행해도 호출부에서 커밋이 이뤄지지 않으면 알림 리스너가 이를 수신하지 않는다.")
+  void shouldNotCatchInterestEvent_whenItIsNotCommitted() {
+    // given
+    Map<UUID, InterestArticleSummary> interestArticleSummaryMap = new HashMap<>();
+    interestArticleSummaryMap.put(UUID.randomUUID(), new InterestArticleSummary("test1", 10));
+    interestArticleSummaryMap.put(UUID.randomUUID(), new InterestArticleSummary("test2", 3));
+    interestArticleSummaryMap.put(UUID.randomUUID(), new InterestArticleSummary("test3", 2));
+    InterestNotificationEvent event = new InterestNotificationEvent(interestArticleSummaryMap);
+
+    // when
+    // 커밋 안됨
+    eventPublisher.publishEvent(event);
+
+    // then
+    // 비동기 실행 시간을 고려
+    then(notificationEventListener).should(after(1000).never())
+        .handleInterestNotificationEvent(event);
+    then(notificationService).should(never())
+        .registerInterestNotification(any(InterestNotificationRequest.class));
+  }
+
+  @Test
+  @DisplayName("관심사 이벤트를 발행하고 호출부에서 커밋이 이뤄지면 알림 리스너가 이를 수신하여 내부코드를 실행한다.")
+  void shouldCatchInterestEventAndDoInnerJob_whenItIsPublishedAndCommitted() {
+    // given
+    Map<UUID, InterestArticleSummary> interestArticleSummaryMap = new HashMap<>();
+    interestArticleSummaryMap.put(UUID.randomUUID(), new InterestArticleSummary("test1", 10));
+    interestArticleSummaryMap.put(UUID.randomUUID(), new InterestArticleSummary("test2", 3));
+    interestArticleSummaryMap.put(UUID.randomUUID(), new InterestArticleSummary("test3", 2));
+    InterestNotificationEvent event = new InterestNotificationEvent(interestArticleSummaryMap);
+
+    // when
+    // 트랜잭션 종료 및 커밋
+    transactionTemplate.execute(status -> {
+      eventPublisher.publishEvent(event);
+      return null;
+    });
+
+    // then
+    //비동기 고려하여 타임 아웃 설정
+    then(notificationEventListener).should(timeout(1000)).handleInterestNotificationEvent(event);
+    then(subscriptionRepository).should()
+        .findAllProjectedByInterestIdIn(eq(interestArticleSummaryMap.keySet()));
+  }
+
+  @Test
+  @DisplayName("관심사 이벤트를 발행하면 알림 리스너는 메인 스레드와 다른 스레드에서 비동기로 실행된다.")
+  void shouldHandleInterestEventAsynchronously_whenItIsPublished() {
+    // given
+    String mainThreadName = Thread.currentThread().getName();
+    // 리스너가 실행된 스레드 이름 저장
+    AtomicReference<String> listenerThreadName = new AtomicReference<>();
+
+    Map<UUID, InterestArticleSummary> interestArticleSummaryMap = new HashMap<>();
+    interestArticleSummaryMap.put(UUID.randomUUID(), new InterestArticleSummary("test1", 10));
+    interestArticleSummaryMap.put(UUID.randomUUID(), new InterestArticleSummary("test2", 3));
+    interestArticleSummaryMap.put(UUID.randomUUID(), new InterestArticleSummary("test3", 2));
+    InterestNotificationEvent event = new InterestNotificationEvent(interestArticleSummaryMap);
+
+    // 서비스가 호출될 때, 실행 중인 스레드 이름 가로채서 저장
+    willAnswer(invocation -> {
+      listenerThreadName.set(Thread.currentThread().getName());
+      return null;
+    }).given(subscriptionRepository)
+        .findAllProjectedByInterestIdIn(interestArticleSummaryMap.keySet());
+
+    // when
+    transactionTemplate.execute(status -> {
+      eventPublisher.publishEvent(event);
+      return null;
+    });
+
+    // then
+    // 스레드 값이 안 담기는 것 방지
+    await()
+        .atMost(1, java.util.concurrent.TimeUnit.SECONDS) // 최대 1초 대기
+        .untilAsserted(() -> {
+          then(subscriptionRepository).should()
+              .findAllProjectedByInterestIdIn(eq(interestArticleSummaryMap.keySet()));
+          assertThat(listenerThreadName.get()).isNotNull();
+          assertThat(listenerThreadName.get()).isNotEqualTo(mainThreadName);
+          assertThat(listenerThreadName.get()).startsWith("batch-noti-task-");//스레드풀 확인
         });
   }
 }

--- a/src/test/java/com/team3/monew/listener/NotificationEventListenerIntegrationTest.java
+++ b/src/test/java/com/team3/monew/listener/NotificationEventListenerIntegrationTest.java
@@ -3,6 +3,7 @@ package com.team3.monew.listener;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willAnswer;
@@ -11,7 +12,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 
 import com.team3.monew.dto.notification.CommentLikedNotificationRequest;
-import com.team3.monew.dto.notification.InterestNotificationRequest;
 import com.team3.monew.event.CommentLikedEvent;
 import com.team3.monew.event.InterestNotificationEvent;
 import com.team3.monew.event.InterestNotificationEvent.InterestArticleSummary;
@@ -162,7 +162,7 @@ public class NotificationEventListenerIntegrationTest {
     then(notificationEventListener).should(after(1000).never())
         .handleInterestNotificationEvent(event);
     then(notificationService).should(never())
-        .registerInterestNotification(any(InterestNotificationRequest.class));
+        .registerInterestNotification(anyList());
   }
 
   @Test

--- a/src/test/java/com/team3/monew/listener/NotificationEventListenerTest.java
+++ b/src/test/java/com/team3/monew/listener/NotificationEventListenerTest.java
@@ -3,15 +3,28 @@ package com.team3.monew.listener;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 import com.team3.monew.dto.notification.CommentLikedNotificationRequest;
+import com.team3.monew.dto.notification.InterestNotificationRequest;
 import com.team3.monew.event.CommentLikedEvent;
+import com.team3.monew.event.InterestNotificationEvent;
+import com.team3.monew.event.InterestNotificationEvent.InterestArticleSummary;
 import com.team3.monew.exception.comment.CommentNotFoundException;
 import com.team3.monew.exception.user.UserNotFoundException;
+import com.team3.monew.repository.SubscriptionRepository;
+import com.team3.monew.repository.SubscriptionRepository.SubscriptionInfo;
 import com.team3.monew.service.NotificationService;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -28,8 +41,33 @@ class NotificationEventListenerTest {
   @Mock
   private NotificationService notificationService;
 
+  @Mock
+  private SubscriptionRepository subscriptionRepository;
+
   @InjectMocks
   private NotificationEventListener notificationEventListener;
+
+  // 레포지토리 인터페이스 객체 생성을 위한 구현체
+  static class TestSubscriptionInfo implements SubscriptionInfo {
+
+    private final UUID userId;
+    private final UUID interestId;
+
+    public TestSubscriptionInfo(UUID userId, UUID interestId) {
+      this.userId = userId;
+      this.interestId = interestId;
+    }
+
+    @Override
+    public UUID getUserId() {
+      return userId;
+    }
+
+    @Override
+    public UUID getInterestId() {
+      return interestId;
+    }
+  }
 
   @Test
   @DisplayName("리스너가 댓글 좋아요 이벤트를 받으면 서비스의 댓글 좋아요 알림 등록 메서드를 호출한다.")
@@ -92,5 +130,55 @@ class NotificationEventListenerTest {
     // when & then
     assertThrows(RuntimeException.class,
         () -> notificationEventListener.handleCommentLikedEvent(event));
+  }
+
+  @Test
+  @DisplayName("리스너가 관심사 뉴스 이벤트를 받으면 서비스의 관심사 뉴스 알림 등록 메서드를 호출한다.")
+  void shouldCallRegisterInterestNotificationMethod_whenListenIt() {
+    // given
+    UUID interestId1 = UUID.randomUUID();
+    UUID interestId2 = UUID.randomUUID();
+    UUID interestId3 = UUID.randomUUID();
+    UUID userId1 = UUID.randomUUID();
+    UUID userId2 = UUID.randomUUID();
+    UUID userId3 = UUID.randomUUID();
+    UUID userId4 = UUID.randomUUID();
+    UUID userId5 = UUID.randomUUID();
+    InterestArticleSummary summary1 = new InterestArticleSummary("interest1", 10);
+    InterestArticleSummary summary2 = new InterestArticleSummary("interest2", 2);
+    InterestArticleSummary summary3 = new InterestArticleSummary("interest3", 3);
+
+    Map<UUID, InterestArticleSummary> map = new HashMap<>();
+    map.put(interestId1, summary1);
+    map.put(interestId2, summary2);
+    map.put(interestId3, summary3);
+    InterestNotificationEvent event = new InterestNotificationEvent(map);
+
+    TestSubscriptionInfo subscriptionInfo1 = new TestSubscriptionInfo(userId1, interestId1);
+    TestSubscriptionInfo subscriptionInfo2 = new TestSubscriptionInfo(userId2, interestId1);
+    TestSubscriptionInfo subscriptionInfo3 = new TestSubscriptionInfo(userId3, interestId1);
+    TestSubscriptionInfo subscriptionInfo4 = new TestSubscriptionInfo(userId4, interestId2);
+    TestSubscriptionInfo subscriptionInfo5 = new TestSubscriptionInfo(userId5, interestId2);
+    TestSubscriptionInfo subscriptionInfo6 = new TestSubscriptionInfo(userId1, interestId2);
+    TestSubscriptionInfo subscriptionInfo7 = new TestSubscriptionInfo(userId2, interestId2);
+
+    given(subscriptionRepository.findAllProjectedByInterestIdIn(
+        Set.of(interestId1, interestId2, interestId3)))
+        .willReturn(
+            List.of(subscriptionInfo1, subscriptionInfo2, subscriptionInfo3, subscriptionInfo4,
+                subscriptionInfo5, subscriptionInfo6, subscriptionInfo7));
+
+    // when
+    notificationEventListener.handleInterestNotificationEvent(event);
+
+    // then
+    then(notificationService).should(times(2)) //구독자가 있는 2개의 관심사에 대해 알림 생성
+        .registerInterestNotification(any(InterestNotificationRequest.class));
+    then(notificationService).should()
+        .registerInterestNotification(argThat(req -> req.interestName().equals("interest1")));
+    then(notificationService).should()
+        .registerInterestNotification(argThat(req -> req.interestName().equals("interest2")));
+    then(notificationService).should(never())
+        .registerInterestNotification(argThat(req -> req.interestName().equals("interest3")));
   }
 }

--- a/src/test/java/com/team3/monew/listener/NotificationEventListenerTest.java
+++ b/src/test/java/com/team3/monew/listener/NotificationEventListenerTest.java
@@ -7,7 +7,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
 
-import com.team3.monew.dto.user.notification.CommentLikedNotificationRequest;
+import com.team3.monew.dto.notification.CommentLikedNotificationRequest;
 import com.team3.monew.event.CommentLikedEvent;
 import com.team3.monew.exception.comment.CommentNotFoundException;
 import com.team3.monew.exception.user.UserNotFoundException;

--- a/src/test/java/com/team3/monew/listener/NotificationEventListenerTest.java
+++ b/src/test/java/com/team3/monew/listener/NotificationEventListenerTest.java
@@ -22,6 +22,7 @@ import com.team3.monew.exception.user.UserNotFoundException;
 import com.team3.monew.repository.SubscriptionRepository;
 import com.team3.monew.repository.SubscriptionRepository.SubscriptionInfo;
 import com.team3.monew.service.NotificationService;
+import jakarta.persistence.EntityNotFoundException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -179,5 +180,30 @@ class NotificationEventListenerTest {
                 list.stream().anyMatch(req -> req.interestName().equals("interest1")) &&
                 list.stream().anyMatch(req -> req.interestName().equals("interest2"))
         ));
+  }
+
+  @Test
+  @DisplayName("관심사 알림 등록 중 Entity 예외가 발생하면 리스너가 처리하고 예외를 외부로 전파하지 않는다.")
+  void shouldCatchAndHandleEntityNotFoundException_whenServiceThrowsIt() {
+    // given
+    UUID interestId = UUID.randomUUID();
+    InterestArticleSummary summary1 = new InterestArticleSummary("interest1", 10);
+    Map<UUID, InterestArticleSummary> map = new HashMap<>();
+    map.put(interestId, summary1);
+    InterestNotificationEvent event = new InterestNotificationEvent(map);
+    TestSubscriptionInfo subscriptionInfo1 = new TestSubscriptionInfo(UUID.randomUUID(),
+        interestId);
+    given(
+        subscriptionRepository.findAllProjectedByInterestIdIn(eq(map.keySet()))).willReturn(
+        List.of(subscriptionInfo1));
+
+    // 서비스에서 댓글을 찾지 못함
+    willThrow(new EntityNotFoundException())
+        .given(notificationService)
+        .registerInterestNotification(anyList());
+
+    // when & then
+    assertDoesNotThrow(() -> notificationEventListener.handleInterestNotificationEvent(event));
+    then(notificationService).should().registerInterestNotification(any());
   }
 }

--- a/src/test/java/com/team3/monew/listener/NotificationEventListenerTest.java
+++ b/src/test/java/com/team3/monew/listener/NotificationEventListenerTest.java
@@ -9,11 +9,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
 import com.team3.monew.dto.notification.CommentLikedNotificationRequest;
-import com.team3.monew.dto.notification.InterestNotificationRequest;
 import com.team3.monew.event.CommentLikedEvent;
 import com.team3.monew.event.InterestNotificationEvent;
 import com.team3.monew.event.InterestNotificationEvent.InterestArticleSummary;

--- a/src/test/java/com/team3/monew/listener/NotificationEventListenerTest.java
+++ b/src/test/java/com/team3/monew/listener/NotificationEventListenerTest.java
@@ -3,6 +3,7 @@ package com.team3.monew.listener;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -172,13 +173,11 @@ class NotificationEventListenerTest {
     notificationEventListener.handleInterestNotificationEvent(event);
 
     // then
-    then(notificationService).should(times(2)) //구독자가 있는 2개의 관심사에 대해 알림 생성
-        .registerInterestNotification(any(InterestNotificationRequest.class));
-    then(notificationService).should()
-        .registerInterestNotification(argThat(req -> req.interestName().equals("interest1")));
-    then(notificationService).should()
-        .registerInterestNotification(argThat(req -> req.interestName().equals("interest2")));
-    then(notificationService).should(never())
-        .registerInterestNotification(argThat(req -> req.interestName().equals("interest3")));
+    then(notificationService).should(times(1))
+        .registerInterestNotification(argThat(list ->
+            list.size() == 2 && // 구독자가 있는 2개만
+                list.stream().anyMatch(req -> req.interestName().equals("interest1")) &&
+                list.stream().anyMatch(req -> req.interestName().equals("interest2"))
+        ));
   }
 }

--- a/src/test/java/com/team3/monew/service/NotificationServiceTest.java
+++ b/src/test/java/com/team3/monew/service/NotificationServiceTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
-import com.team3.monew.dto.user.notification.CommentLikedNotificationRequest;
+import com.team3.monew.dto.notification.CommentLikedNotificationRequest;
 import com.team3.monew.entity.Comment;
 import com.team3.monew.entity.NewsArticle;
 import com.team3.monew.entity.Notification;

--- a/src/test/java/com/team3/monew/service/NotificationServiceTest.java
+++ b/src/test/java/com/team3/monew/service/NotificationServiceTest.java
@@ -1,10 +1,14 @@
 package com.team3.monew.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
 
 import com.team3.monew.dto.notification.CommentLikedNotificationRequest;
+import com.team3.monew.dto.notification.InterestNotificationRequest;
 import com.team3.monew.entity.Comment;
 import com.team3.monew.entity.NewsArticle;
 import com.team3.monew.entity.Notification;
@@ -15,6 +19,7 @@ import com.team3.monew.exception.user.UserNotFoundException;
 import com.team3.monew.repository.CommentRepository;
 import com.team3.monew.repository.NotificationRepository;
 import com.team3.monew.repository.UserRepository;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -129,4 +134,48 @@ class NotificationServiceTest {
         () -> notificationService.registerLikeNotification(request));
     then(notificationRepository).shouldHaveNoInteractions();
   }
+
+  @Test
+  @DisplayName("알림 요청(구독자 아이디, 관심사 아이디, 관심사 이름, 새로 등록된 뉴스 개수)목록으로 뉴스 알림 목록 등록에 성공합니다.")
+  void shouldRegisterInterestNotifications() {
+    // given
+    UUID resourceId2 = UUID.randomUUID();
+    InterestNotificationRequest request1 = new InterestNotificationRequest(resourceId, "test1", 5,
+        List.of(userId, actorUserId));
+    InterestNotificationRequest request2 = new InterestNotificationRequest(resourceId2, "test2", 2,
+        List.of(userId));
+
+    given(userRepository.getReferenceById(any(UUID.class))).willReturn(mock(User.class));
+    // when
+    notificationService.registerInterestNotification(List.of(request1, request2));
+    // then
+    ArgumentCaptor<List<Notification>> notificationCaptor = ArgumentCaptor.forClass(List.class);
+    then(notificationRepository).should().saveAll(notificationCaptor.capture());
+    List<Notification> notifications = notificationCaptor.getValue();
+
+    assertNotNull(notifications);
+    assertAll(
+        () -> assertThat(notifications).hasSize(3),
+        // 1. 리소스 타입 검증
+        () -> assertThat(notifications).extracting(Notification::getResourceType)
+            .containsOnly(NotificationResourceType.INTEREST),
+
+        // 2. 메시지 내용 검증
+        () -> assertThat(notifications).extracting(Notification::getContent)
+            .anyMatch(content -> content.contains("test1") && content.contains("5"))
+            .anyMatch(content -> content.contains("test2") && content.contains("2")),
+
+        // 3. 리소스 아이디 매핑
+        () -> assertThat(notifications).extracting(Notification::getResourceId)
+            .contains(resourceId, resourceId2),
+
+        // 4. 리소스 아이디별 알림 개수
+        () -> assertThat(notifications).filteredOn(n -> n.getResourceId().equals(resourceId))
+            .hasSize(2), // 구독자 2명
+        () -> assertThat(notifications).filteredOn(n -> n.getResourceId().equals(resourceId2))
+            .hasSize(1)  // 1명
+    );
+
+  }
+
 }


### PR DESCRIPTION
## 관련 이슈
- **주요 이슈**
  - closes #134
- **서브 이슈**
  - closes #135 
    - closes #150 
  - closes #148 
  - closes #152 
  - closes #153 

## 작업 내용
- feat: AsyncConfig에 뉴스 알림 이벤트 등록을 위한 스레드 풀 정의
- refactor: CommentLikedNotificationRequest 패키지 위치 조정
- feat: InterestNotificationEvent 및 리스너 정의
  - 프록시 객체 저장 예외 처리(재시도 방지)
  - InterestNotificationEvent 클래스 정의
  - 리스너 함수 정의
  - InterestNotifiacationRequest 클래스 정의
  - 이벤트 단위 테스트 작성
  - 이벤트 리스너 통합 테스트 작성
  - refactor: NotificationService의 관심사 알림 등록을 리스트로 받도록 수정
- feat: 관심사 알림 저장 로직 구현
  - NotificationService에서 관심사 알림 저장 메서드 작성
  - 관련 단위테스트 작성
- test: 관심사 알림 등록 통합테스트
  - 기존 댓글 알림 통합테스트를 Nested로 분리
- fix: SubscriptionRepository rebase 충돌 해결

## 변경 사항
- 기존 Notification dto 패키지 위치가 잘못되어 수정하였습니다.

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 관심사 기반 알림 기능 추가: 사용자가 구독한 관심사의 새로운 콘텐츠에 대해 자동으로 알림을 받습니다.
  * 배치 알림 처리 기능 추가: 대량의 알림을 효율적으로 처리하기 위한 비동기 실행기 구현.
  * 자동 재시도 메커니즘 추가: 일시적인 오류 발생 시 알림 등록이 자동으로 재시도됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->