### PR TITLE
feat: 관심사 목록 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'       // 비동기
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'    // XML 라이브러리
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     // DB
@@ -56,6 +57,11 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
     testImplementation 'io.projectreactor:reactor-test'                 // Reactor 비동기 테스트 모듈
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'      // MockWebServer 라이브러리
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+	annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 }
 
 tasks.named('test') {
@@ -65,8 +71,6 @@ tasks.named('test') {
             excludeTags cliTags.split(',')
         }
     }
-    systemProperty 'spring.profiles.active', 'test'
-    finalizedBy jacocoTestReport
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -57,11 +57,11 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
     testImplementation 'io.projectreactor:reactor-test'                 // Reactor 비동기 테스트 모듈
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'      // MockWebServer 라이브러리
-	// QueryDSL
-	implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
-	annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
-	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
-	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 }
 
 tasks.named('test') {
@@ -71,8 +71,9 @@ tasks.named('test') {
             excludeTags cliTags.split(',')
         }
     }
+    systemProperty 'spring.profiles.active', 'test'
+    finalizedBy jacocoTestReport
 }
-
 
 jacocoTestReport {
     dependsOn test

--- a/src/main/java/com/team3/monew/config/QueryDslConfig.java
+++ b/src/main/java/com/team3/monew/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.team3.monew.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+  @PersistenceContext
+  private EntityManager em;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(em);
+  }
+}

--- a/src/main/java/com/team3/monew/controller/InterestController.java
+++ b/src/main/java/com/team3/monew/controller/InterestController.java
@@ -1,11 +1,15 @@
 package com.team3.monew.controller;
 
 import com.team3.monew.controller.api.InterestApi;
+import com.team3.monew.dto.interest.CursorPageResponseInterestDto;
 import com.team3.monew.dto.interest.InterestDto;
 import com.team3.monew.dto.interest.InterestRegisterRequest;
 import com.team3.monew.dto.interest.InterestUpdateRequest;
+import com.team3.monew.dto.interest.internal.InterestCursor;
+import com.team3.monew.dto.interest.internal.InterestSearchCondition;
 import com.team3.monew.service.InterestService;
 import jakarta.validation.Valid;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -45,5 +49,34 @@ public class InterestController implements InterestApi {
     interestService.deleteInterest(interestId);
 
     return ResponseEntity.noContent().build();
+  }
+
+  @Override
+  public ResponseEntity<CursorPageResponseInterestDto> findAll(
+      UUID userId,
+      String keyword,
+      String orderBy,
+      String direction,
+      String cursor,
+      Instant after,
+      int limit
+  ) {
+    InterestCursor interestCursor =
+        (cursor == null || after == null)
+            ? new InterestCursor(null, null)
+            : new InterestCursor(cursor, after);
+
+    InterestSearchCondition condition = new InterestSearchCondition(
+        keyword,
+        orderBy,
+        direction,
+        interestCursor,
+        limit
+    );
+
+    CursorPageResponseInterestDto response =
+        interestService.findAll(condition, userId);
+
+    return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/team3/monew/controller/api/InterestApi.java
+++ b/src/main/java/com/team3/monew/controller/api/InterestApi.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import java.time.Instant;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
@@ -154,6 +155,14 @@ public interface InterestApi {
               mediaType = "application/json",
               schema = @Schema(implementation = CursorPageResponseInterestDto.class)
           )
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = "잘못된 요청값입니다. (예: 정렬 조건/페이지 크기 오류)",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class)
+          )
       )
   })
   ResponseEntity<CursorPageResponseInterestDto> findAll(
@@ -176,6 +185,6 @@ public interface InterestApi {
       @RequestParam(value = "after", required = false) Instant after,
 
       @Parameter(description = "페이지 크기", example = "10")
-      @RequestParam(value = "limit", defaultValue = "10") int limit
+      @RequestParam(value = "limit", defaultValue = "10") @Min(1) int limit
   );
 }

--- a/src/main/java/com/team3/monew/controller/api/InterestApi.java
+++ b/src/main/java/com/team3/monew/controller/api/InterestApi.java
@@ -1,5 +1,6 @@
 package com.team3.monew.controller.api;
 
+import com.team3.monew.dto.interest.CursorPageResponseInterestDto;
 import com.team3.monew.dto.interest.InterestDto;
 import com.team3.monew.dto.interest.InterestRegisterRequest;
 import com.team3.monew.dto.interest.InterestUpdateRequest;
@@ -12,6 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.time.Instant;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -137,5 +139,43 @@ public interface InterestApi {
           required = true
       )
       @PathVariable UUID interestId
+  );
+
+  @GetMapping
+  @Operation(
+      summary = "관심사 목록 조회",
+      description = "관심사를 검색하고 정렬 및 커서 기반 페이지네이션으로 조회합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "조회 성공",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = CursorPageResponseInterestDto.class)
+          )
+      )
+  })
+  ResponseEntity<CursorPageResponseInterestDto> findAll(
+      @Parameter(description = "요청 사용자 ID", required = true)
+      @RequestHeader("Monew-Request-User-Id") UUID userId,
+
+      @Parameter(description = "검색어 (관심사 이름 또는 키워드)")
+      @RequestParam(value = "keyword", required = false) String keyword,
+
+      @Parameter(description = "정렬 기준 (name, subscriberCount)")
+      @RequestParam(value = "orderBy", defaultValue = "name") String orderBy,
+
+      @Parameter(description = "정렬 방향 (ASC, DESC)")
+      @RequestParam(value = "direction", defaultValue = "ASC") String direction,
+
+      @Parameter(description = "다음 페이지 커서 값")
+      @RequestParam(value = "cursor", required = false) String cursor,
+
+      @Parameter(description = "다음 페이지 기준 시간")
+      @RequestParam(value = "after", required = false) Instant after,
+
+      @Parameter(description = "페이지 크기", example = "10")
+      @RequestParam(value = "limit", defaultValue = "10") int limit
   );
 }

--- a/src/main/java/com/team3/monew/dto/interest/CursorPageResponseInterestDto.java
+++ b/src/main/java/com/team3/monew/dto/interest/CursorPageResponseInterestDto.java
@@ -7,7 +7,7 @@ public record CursorPageResponseInterestDto(
     String nextCursor,
     String nextAfter,
     int size,
-    int totalElements,
+    long totalElements,
     boolean hasNext
 ) {
 

--- a/src/main/java/com/team3/monew/dto/interest/CursorPageResponseInterestDto.java
+++ b/src/main/java/com/team3/monew/dto/interest/CursorPageResponseInterestDto.java
@@ -1,0 +1,14 @@
+package com.team3.monew.dto.interest;
+
+import java.util.List;
+
+public record CursorPageResponseInterestDto(
+    List<InterestDto> content,
+    String nextCursor,
+    String nextAfter,
+    int size,
+    int totalElements,
+    boolean hasNext
+) {
+
+}

--- a/src/main/java/com/team3/monew/dto/interest/internal/InterestCursor.java
+++ b/src/main/java/com/team3/monew/dto/interest/internal/InterestCursor.java
@@ -1,0 +1,10 @@
+package com.team3.monew.dto.interest.internal;
+
+import java.time.Instant;
+
+public record InterestCursor(
+    String cursor,
+    Instant after
+) {
+
+}

--- a/src/main/java/com/team3/monew/dto/interest/internal/InterestSearchCondition.java
+++ b/src/main/java/com/team3/monew/dto/interest/internal/InterestSearchCondition.java
@@ -1,0 +1,11 @@
+package com.team3.monew.dto.interest.internal;
+
+public record InterestSearchCondition(
+    String keyword,
+    String orderBy,
+    String direction,
+    InterestCursor cursor,
+    int limit
+) {
+
+}

--- a/src/main/java/com/team3/monew/repository/InterestRepository.java
+++ b/src/main/java/com/team3/monew/repository/InterestRepository.java
@@ -6,7 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 import java.util.UUID;
 
-public interface InterestRepository extends JpaRepository<Interest, UUID> {
+public interface InterestRepository extends JpaRepository<Interest, UUID>,
+    InterestRepositoryCustom {
 
   boolean existsByName(String name);
 }

--- a/src/main/java/com/team3/monew/repository/InterestRepositoryCustom.java
+++ b/src/main/java/com/team3/monew/repository/InterestRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.team3.monew.repository;
+
+import com.team3.monew.dto.interest.internal.InterestSearchCondition;
+import com.team3.monew.entity.Interest;
+import java.util.List;
+
+public interface InterestRepositoryCustom {
+
+  List<Interest> searchByCondition(InterestSearchCondition condition);
+
+  int countByCondition(InterestSearchCondition condition);
+
+}

--- a/src/main/java/com/team3/monew/repository/InterestRepositoryCustom.java
+++ b/src/main/java/com/team3/monew/repository/InterestRepositoryCustom.java
@@ -8,6 +8,6 @@ public interface InterestRepositoryCustom {
 
   List<Interest> searchByCondition(InterestSearchCondition condition);
 
-  int countByCondition(InterestSearchCondition condition);
+  long countByCondition(InterestSearchCondition condition);
 
 }

--- a/src/main/java/com/team3/monew/repository/impl/InterestRepositoryImpl.java
+++ b/src/main/java/com/team3/monew/repository/impl/InterestRepositoryImpl.java
@@ -1,0 +1,150 @@
+package com.team3.monew.repository.impl;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.team3.monew.dto.interest.internal.InterestSearchCondition;
+import com.team3.monew.entity.Interest;
+import com.team3.monew.entity.QInterest;
+import com.team3.monew.entity.QInterestKeyword;
+import com.team3.monew.repository.InterestRepositoryCustom;
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.weaver.ast.Or;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class InterestRepositoryImpl implements InterestRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<Interest> searchByCondition(InterestSearchCondition condition) {
+    QInterest interest = QInterest.interest;
+    QInterestKeyword keyword = QInterestKeyword.interestKeyword;
+
+    return queryFactory
+        .selectDistinct(interest)
+        .from(interest)
+        .leftJoin(interest.keywords, keyword)
+        .where(
+            buildSearchCondition(condition, interest, keyword),
+            buildCursorCondition(condition, interest)
+        )
+        .orderBy(getOrderSpecifier(condition, interest))
+        .limit(condition.limit() + 1L)
+        .fetch();
+  }
+
+  @Override
+  public int countByCondition(InterestSearchCondition condition) {
+    QInterest interest = QInterest.interest;
+    QInterestKeyword keyword = QInterestKeyword.interestKeyword;
+
+    BooleanBuilder builder = buildSearchCondition(condition, interest, keyword);
+
+    Long count = queryFactory
+        .select(interest.countDistinct())
+        .from(interest)
+        .leftJoin(interest.keywords, keyword)
+        .where(builder)
+        .fetchOne();
+
+    return count == null ? 0 : count.intValue();
+  }
+
+  private BooleanBuilder buildSearchCondition(
+      InterestSearchCondition condition,
+      QInterest interest,
+      QInterestKeyword keyword
+  ) {
+    BooleanBuilder builder = new BooleanBuilder();
+
+    String searchKeyword = condition.keyword();
+
+    if (searchKeyword == null || searchKeyword.isBlank()) {
+      return builder;
+    }
+
+    builder.and(
+        interest.name.containsIgnoreCase(searchKeyword)
+            .or(keyword.keyword.containsIgnoreCase(searchKeyword))
+    );
+
+    return builder;
+  }
+
+  private OrderSpecifier<?>[] getOrderSpecifier(
+      InterestSearchCondition condition,
+      QInterest interest
+  ) {
+    boolean isDesc = "DESC".equalsIgnoreCase(condition.direction());
+
+    if ("subscriberCount".equals(condition.orderBy())) {
+      return isDesc
+          ? new OrderSpecifier[]{interest.subscriberCount.desc(), interest.createdAt.desc()}
+          : new OrderSpecifier[]{interest.subscriberCount.asc(), interest.createdAt.asc()};
+    }
+
+    return isDesc
+        ? new OrderSpecifier[]{interest.name.desc(), interest.createdAt.desc()}
+        : new OrderSpecifier[]{interest.name.asc(), interest.createdAt.asc()};
+  }
+
+  private BooleanExpression buildCursorCondition(
+      InterestSearchCondition condition,
+      QInterest interest
+  ) {
+    if (condition.cursor() == null) {
+      return null;
+    }
+
+    String cursorValue = condition.cursor().cursor();
+    Instant after = condition.cursor().after();
+
+    if (cursorValue == null || after == null) {
+      return null;
+    }
+
+    String orderBy = condition.orderBy();
+    boolean isDesc = "DESC".equalsIgnoreCase(condition.direction());
+
+    if ("subscriberCount".equals(orderBy)) {
+      int cursorCount = Integer.parseInt(cursorValue);
+
+      if (isDesc) {
+        return interest.subscriberCount.lt(cursorCount)
+            .or(
+                interest.subscriberCount.eq(cursorCount)
+                    .and(interest.createdAt.lt(after))
+            );
+      }
+
+      return interest.subscriberCount.gt(cursorCount)
+          .or(
+              interest.subscriberCount.eq(cursorCount)
+                  .and(interest.createdAt.lt(after))
+          );
+    }
+
+    // 기본: name 정렬
+    if (isDesc) {
+      return interest.name.lt(cursorValue)
+          .or(
+              interest.name.eq(cursorValue)
+                  .and(interest.createdAt.lt(after
+                  ))
+          );
+    }
+
+    return interest.name.gt(cursorValue)
+        .or(
+            interest.name.eq(cursorValue)
+                .and(interest.createdAt.gt(after))
+        );
+  }
+}

--- a/src/main/java/com/team3/monew/repository/impl/InterestRepositoryImpl.java
+++ b/src/main/java/com/team3/monew/repository/impl/InterestRepositoryImpl.java
@@ -39,7 +39,7 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom {
   }
 
   @Override
-  public int countByCondition(InterestSearchCondition condition) {
+  public long countByCondition(InterestSearchCondition condition) {
     QInterest interest = QInterest.interest;
 
     Long count = queryFactory
@@ -48,7 +48,7 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom {
         .where(buildSearchCondition(condition, interest))
         .fetchOne();
 
-    return count == null ? 0 : count.intValue();
+    return count == null ? 0L : count.intValue();
   }
 
   private BooleanBuilder buildSearchCondition(
@@ -119,6 +119,11 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom {
     boolean isDesc = "DESC".equalsIgnoreCase(condition.direction());
 
     if ("subscriberCount".equals(orderBy)) {
+
+      if (!cursorValue.matches("-?\\d+")) {
+        throw new IllegalArgumentException(
+            "Invalid cursor: subscriberCount cursor must be numeric");
+      }
       int cursorCount = Integer.parseInt(cursorValue);
 
       if (isDesc) {
@@ -132,7 +137,7 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom {
       return interest.subscriberCount.gt(cursorCount)
           .or(
               interest.subscriberCount.eq(cursorCount)
-                  .and(interest.createdAt.lt(after))
+                  .and(interest.createdAt.gt(after))
           );
     }
 

--- a/src/main/java/com/team3/monew/repository/impl/InterestRepositoryImpl.java
+++ b/src/main/java/com/team3/monew/repository/impl/InterestRepositoryImpl.java
@@ -1,9 +1,9 @@
 package com.team3.monew.repository.impl;
 
 import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.team3.monew.dto.interest.internal.InterestSearchCondition;
 import com.team3.monew.entity.Interest;
@@ -25,14 +25,12 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom {
   @Override
   public List<Interest> searchByCondition(InterestSearchCondition condition) {
     QInterest interest = QInterest.interest;
-    QInterestKeyword keyword = QInterestKeyword.interestKeyword;
 
     return queryFactory
-        .selectDistinct(interest)
+        .select(interest)
         .from(interest)
-        .leftJoin(interest.keywords, keyword)
         .where(
-            buildSearchCondition(condition, interest, keyword),
+            buildSearchCondition(condition, interest),
             buildCursorCondition(condition, interest)
         )
         .orderBy(getOrderSpecifier(condition, interest))
@@ -43,15 +41,11 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom {
   @Override
   public int countByCondition(InterestSearchCondition condition) {
     QInterest interest = QInterest.interest;
-    QInterestKeyword keyword = QInterestKeyword.interestKeyword;
-
-    BooleanBuilder builder = buildSearchCondition(condition, interest, keyword);
 
     Long count = queryFactory
-        .select(interest.countDistinct())
+        .select(interest.count())
         .from(interest)
-        .leftJoin(interest.keywords, keyword)
-        .where(builder)
+        .where(buildSearchCondition(condition, interest))
         .fetchOne();
 
     return count == null ? 0 : count.intValue();
@@ -59,8 +53,7 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom {
 
   private BooleanBuilder buildSearchCondition(
       InterestSearchCondition condition,
-      QInterest interest,
-      QInterestKeyword keyword
+      QInterest interest
   ) {
     BooleanBuilder builder = new BooleanBuilder();
 
@@ -70,9 +63,21 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom {
       return builder;
     }
 
+    QInterestKeyword keyword = QInterestKeyword.interestKeyword;
+
+    // 테스트 시 페이지네이션 깨짐 현상으로 subquery 사용
     builder.and(
         interest.name.containsIgnoreCase(searchKeyword)
-            .or(keyword.keyword.containsIgnoreCase(searchKeyword))
+            .or(
+                JPAExpressions
+                    .selectOne()
+                    .from(keyword)
+                    .where(
+                        keyword.interest.eq(interest),
+                        keyword.keyword.containsIgnoreCase(searchKeyword)
+                    )
+                    .exists()
+            )
     );
 
     return builder;

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -93,7 +93,7 @@ public class InterestService {
         ? result.subList(0, condition.limit())
         : result;
 
-    int totalElements = interestRepository.countByCondition(condition);
+    long totalElements = interestRepository.countByCondition(condition);
 
     if (content.isEmpty()) {
       log.debug("관심사 목록 조회 결과 없음 - userId={}, keyword={}, totalElements=0",

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -1,8 +1,10 @@
 package com.team3.monew.service;
 
+import com.team3.monew.dto.interest.CursorPageResponseInterestDto;
 import com.team3.monew.dto.interest.InterestDto;
 import com.team3.monew.dto.interest.InterestRegisterRequest;
 import com.team3.monew.dto.interest.InterestUpdateRequest;
+import com.team3.monew.dto.interest.internal.InterestSearchCondition;
 import com.team3.monew.entity.ArticleInterest;
 import com.team3.monew.entity.Interest;
 import com.team3.monew.entity.InterestKeyword;
@@ -17,6 +19,7 @@ import com.team3.monew.repository.InterestKeywordRepository;
 import com.team3.monew.repository.InterestRepository;
 import com.team3.monew.repository.SubscriptionRepository;
 import com.team3.monew.repository.UserRepository;
+import java.time.Instant;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -71,6 +74,59 @@ public class InterestService {
         savedInterest.getId(), savedInterest.getName());
 
     return interestMapper.toDto(savedInterest, false);
+  }
+
+  public CursorPageResponseInterestDto findAll(InterestSearchCondition condition, UUID userId) {
+    List<Interest> result = interestRepository.searchByCondition(condition);
+    boolean hasNext = result.size() > condition.limit();
+    List<Interest> content = hasNext
+        ? result.subList(0, condition.limit())
+        : result;
+
+    if (content.isEmpty()) {
+      return new CursorPageResponseInterestDto(
+          List.of(),
+          null,
+          null,
+          condition.limit(),
+          interestRepository.countByCondition(condition),
+          false
+      );
+    }
+
+    String nextCursor = null;
+    String nextAfter = null;
+
+    if (hasNext) {
+      Interest last = content.get(content.size() - 1);
+
+      if ("subscriberCount".equals(condition.orderBy())) {
+        nextCursor = String.valueOf(last.getSubscriberCount());
+      } else {
+        nextCursor = last.getName();
+      }
+
+      nextAfter = last.getCreatedAt().toString();
+    }
+
+    List<InterestDto> dtoList = content.stream()
+        .map(interest -> {
+          // N+1 문제 발생 가능성 있지만 추후 성능 개선 시 수정 예정
+          boolean subscribedByMe =
+              subscriptionRepository.existsByUserIdAndInterestId(userId, interest.getId());
+          return interestMapper.toDto(interest, subscribedByMe);
+        })
+        .toList();
+    int totalElements = interestRepository.countByCondition(condition);
+
+    return new CursorPageResponseInterestDto(
+        dtoList,
+        nextCursor,
+        nextAfter,
+        condition.limit(),
+        totalElements,
+        hasNext
+    );
   }
 
   public InterestDto updateKeyword(UUID userId, UUID interestId, InterestUpdateRequest dto) {

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -77,19 +77,34 @@ public class InterestService {
   }
 
   public CursorPageResponseInterestDto findAll(InterestSearchCondition condition, UUID userId) {
+    log.debug(
+        "관심사 목록 조회 요청 - userId={}, keyword={}, orderBy={}, direction={}, cursor={}, after={}, limit={}",
+        userId,
+        condition.keyword(),
+        condition.orderBy(),
+        condition.direction(),
+        condition.cursor() == null ? null : condition.cursor().cursor(),
+        condition.cursor() == null ? null : condition.cursor().after(),
+        condition.limit());
+
     List<Interest> result = interestRepository.searchByCondition(condition);
     boolean hasNext = result.size() > condition.limit();
     List<Interest> content = hasNext
         ? result.subList(0, condition.limit())
         : result;
 
+    int totalElements = interestRepository.countByCondition(condition);
+
     if (content.isEmpty()) {
+      log.debug("관심사 목록 조회 결과 없음 - userId={}, keyword={}, totalElements=0",
+          userId, condition.keyword());
+
       return new CursorPageResponseInterestDto(
           List.of(),
           null,
           null,
           condition.limit(),
-          interestRepository.countByCondition(condition),
+          totalElements,
           false
       );
     }
@@ -117,7 +132,10 @@ public class InterestService {
           return interestMapper.toDto(interest, subscribedByMe);
         })
         .toList();
-    int totalElements = interestRepository.countByCondition(condition);
+
+    log.debug(
+        "관심사 목록 조회 성공 - userId={}, contentSize={}, totalElements={}, hasNext={}, nextCursor={}, nextAfter={}",
+        userId, dtoList.size(), totalElements, hasNext, nextCursor, nextAfter);
 
     return new CursorPageResponseInterestDto(
         dtoList,

--- a/src/test/java/com/team3/monew/controller/InterestControllerTest.java
+++ b/src/test/java/com/team3/monew/controller/InterestControllerTest.java
@@ -1,12 +1,16 @@
 package com.team3.monew.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team3.monew.dto.interest.CursorPageResponseInterestDto;
 import com.team3.monew.dto.interest.InterestDto;
 import com.team3.monew.dto.interest.InterestRegisterRequest;
 import com.team3.monew.dto.interest.InterestUpdateRequest;
+import com.team3.monew.dto.interest.internal.InterestCursor;
+import com.team3.monew.dto.interest.internal.InterestSearchCondition;
 import com.team3.monew.exception.interest.InterestDuplicateNameException;
 import com.team3.monew.exception.interest.InterestNotFoundException;
 import com.team3.monew.service.InterestService;
+import java.time.Instant;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -25,9 +29,11 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(InterestController.class)
@@ -227,5 +233,170 @@ class InterestControllerTest {
     // when & then
     mockMvc.perform(delete("/api/interests/{interestId}", interestId))
         .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("관심사 목록을 조회할 수 있다")
+  void shouldFindAllInterests_whenRequestIsValid() throws Exception {
+    // given
+    UUID userId = UUID.randomUUID();
+    Instant after = Instant.parse("2026-04-22T10:00:00Z");
+
+    InterestDto first = new InterestDto(
+        UUID.randomUUID(),
+        "가구",
+        List.of("의자", "책상"),
+        3,
+        true
+    );
+
+    InterestDto second = new InterestDto(
+        UUID.randomUUID(),
+        "나무",
+        List.of("소나무"),
+        1,
+        false
+    );
+
+    CursorPageResponseInterestDto response = new CursorPageResponseInterestDto(
+        List.of(first, second),
+        "나무",
+        after.toString(),
+        2,
+        5,
+        true
+    );
+
+    InterestSearchCondition condition = new InterestSearchCondition(
+        "구",
+        "name",
+        "ASC",
+        new InterestCursor(null, null),
+        2
+    );
+
+    given(interestService.findAll(condition, userId)).willReturn(response);
+
+    // when & then
+    mockMvc.perform(get("/api/interests")
+            .header("Monew-Request-User-Id", userId.toString())
+            .param("keyword", "구")
+            .param("orderBy", "name")
+            .param("direction", "ASC")
+            .param("limit", "2"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content.length()").value(2))
+        .andExpect(jsonPath("$.content[0].name").value("가구"))
+        .andExpect(jsonPath("$.content[0].subscribedByMe").value(true))
+        .andExpect(jsonPath("$.content[1].name").value("나무"))
+        .andExpect(jsonPath("$.content[1].subscribedByMe").value(false))
+        .andExpect(jsonPath("$.nextCursor").value("나무"))
+        .andExpect(jsonPath("$.nextAfter").value(after.toString()))
+        .andExpect(jsonPath("$.size").value(2))
+        .andExpect(jsonPath("$.totalElements").value(5))
+        .andExpect(jsonPath("$.hasNext").value(true));
+
+    then(interestService).should().findAll(condition, userId);
+  }
+
+  @Test
+  @DisplayName("커서 없이 첫 페이지를 조회할 수 있다")
+  void shouldFindFirstPage_whenCursorAndAfterAreMissing() throws Exception {
+    // given
+    UUID userId = UUID.randomUUID();
+
+    CursorPageResponseInterestDto response = new CursorPageResponseInterestDto(
+        List.of(),
+        null,
+        null,
+        10,
+        0,
+        false
+    );
+
+    InterestSearchCondition condition = new InterestSearchCondition(
+        null,
+        "name",
+        "ASC",
+        new InterestCursor(null, null),
+        10
+    );
+
+    given(interestService.findAll(condition, userId)).willReturn(response);
+
+    // when & then
+    mockMvc.perform(get("/api/interests")
+            .header("Monew-Request-User-Id", userId.toString())
+            .param("orderBy", "name")
+            .param("direction", "ASC")
+            .param("limit", "10"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content.length()").value(0))
+        .andExpect(jsonPath("$.nextCursor").doesNotExist())
+        .andExpect(jsonPath("$.nextAfter").doesNotExist())
+        .andExpect(jsonPath("$.size").value(10))
+        .andExpect(jsonPath("$.totalElements").value(0))
+        .andExpect(jsonPath("$.hasNext").value(false));
+
+    then(interestService).should().findAll(condition, userId);
+  }
+
+  @Test
+  @DisplayName("커서와 after 값으로 다음 페이지를 조회할 수 있다")
+  void shouldFindNextPage_whenCursorAndAfterAreGiven() throws Exception {
+    // given
+    UUID userId = UUID.randomUUID();
+    Instant after = Instant.parse("2026-04-22T10:00:00Z");
+
+    CursorPageResponseInterestDto response = new CursorPageResponseInterestDto(
+        List.of(),
+        "다리",
+        "2026-04-22T10:05:00Z",
+        2,
+        5,
+        true
+    );
+
+    InterestSearchCondition condition = new InterestSearchCondition(
+        null,
+        "name",
+        "ASC",
+        new InterestCursor("나무", after),
+        2
+    );
+
+    given(interestService.findAll(condition, userId)).willReturn(response);
+
+    // when & then
+    mockMvc.perform(get("/api/interests")
+            .header("Monew-Request-User-Id", userId.toString())
+            .param("orderBy", "name")
+            .param("direction", "ASC")
+            .param("cursor", "나무")
+            .param("after", after.toString())
+            .param("limit", "2"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.nextCursor").value("다리"))
+        .andExpect(jsonPath("$.hasNext").value(true));
+
+    then(interestService).should().findAll(condition, userId);
+  }
+
+  @Test
+  @DisplayName("관심사 등록 요청이 올바르지 않으면 400을 반환한다")
+  void shouldReturnBadRequest_whenCreateRequestIsInvalid() throws Exception {
+    // given
+    InterestRegisterRequest request = new InterestRegisterRequest(
+        "",
+        List.of()
+    );
+
+    // when & then
+    mockMvc.perform(post("/api/interests")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest());
+
+    then(interestService).should(never()).createInterest(request);
   }
 }

--- a/src/test/java/com/team3/monew/integration/InterestServiceIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/InterestServiceIntegrationTest.java
@@ -20,6 +20,8 @@ import com.team3.monew.repository.InterestRepository;
 import com.team3.monew.repository.SubscriptionRepository;
 import com.team3.monew.repository.UserRepository;
 import com.team3.monew.service.InterestService;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
@@ -52,6 +54,8 @@ public class InterestServiceIntegrationTest {
   private SubscriptionRepository subscriptionRepository;
   @Autowired
   private UserRepository userRepository;
+  @PersistenceContext
+  private EntityManager entityManager;
 
   @Test
   @DisplayName("관심사를 등록하면 키워드와 함께 저장된다")
@@ -312,6 +316,9 @@ public class InterestServiceIntegrationTest {
     Interest i4 = interestRepository.save(Interest.create("책상"));
     Interest i5 = interestRepository.save(Interest.create("카톡"));
 
+    entityManager.flush();
+    entityManager.clear();
+
     User user = userRepository.save(User.create("test@example.com", "tester", "test1234!"));
 
     subscriptionRepository.save(Subscription.create(user, i2));
@@ -363,6 +370,9 @@ public class InterestServiceIntegrationTest {
     interestRepository.save(Interest.create("D"));
     interestRepository.save(Interest.create("E"));
 
+    entityManager.flush();
+    entityManager.clear();
+
     subscriptionRepository.save(Subscription.create(user, beta));
 
     InterestSearchCondition firstCondition = new InterestSearchCondition(
@@ -411,6 +421,9 @@ public class InterestServiceIntegrationTest {
     interestRepository.save(Interest.create("C"));
     interestRepository.save(Interest.create("D"));
     interestRepository.save(Interest.create("E"));
+
+    entityManager.flush();
+    entityManager.clear();
 
     InterestSearchCondition firstCondition = new InterestSearchCondition(
         null,

--- a/src/test/java/com/team3/monew/integration/InterestServiceIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/InterestServiceIntegrationTest.java
@@ -1,12 +1,16 @@
 package com.team3.monew.integration;
 
+import com.team3.monew.dto.interest.CursorPageResponseInterestDto;
 import com.team3.monew.dto.interest.InterestDto;
 import com.team3.monew.dto.interest.InterestRegisterRequest;
 import com.team3.monew.dto.interest.InterestUpdateRequest;
+import com.team3.monew.dto.interest.internal.InterestCursor;
+import com.team3.monew.dto.interest.internal.InterestSearchCondition;
 import com.team3.monew.entity.ArticleInterest;
 import com.team3.monew.entity.Interest;
 import com.team3.monew.entity.InterestKeyword;
 import com.team3.monew.entity.Subscription;
+import com.team3.monew.entity.User;
 import com.team3.monew.exception.interest.InterestDuplicateNameException;
 import com.team3.monew.exception.interest.InterestException;
 import com.team3.monew.exception.interest.InterestNotFoundException;
@@ -14,8 +18,12 @@ import com.team3.monew.repository.ArticleInterestRepository;
 import com.team3.monew.repository.InterestKeywordRepository;
 import com.team3.monew.repository.InterestRepository;
 import com.team3.monew.repository.SubscriptionRepository;
+import com.team3.monew.repository.UserRepository;
 import com.team3.monew.service.InterestService;
+import java.time.Instant;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -40,6 +48,10 @@ public class InterestServiceIntegrationTest {
   private InterestRepository interestRepository;
   @Autowired
   private InterestKeywordRepository interestKeywordRepository;
+  @Autowired
+  private SubscriptionRepository subscriptionRepository;
+  @Autowired
+  private UserRepository userRepository;
 
   @Test
   @DisplayName("관심사를 등록하면 키워드와 함께 저장된다")
@@ -287,5 +299,294 @@ public class InterestServiceIntegrationTest {
     // then
     assertThat(interestRepository.findById(saved.id())).isEmpty();
     assertThat(interestKeywordRepository.findAllByInterestId(saved.id())).isEmpty();
+  }
+
+  @Test
+  @DisplayName("커서가 없을 때 첫번째 페이지를 보여줘야 한다")
+  void shouldReturnFirstPage_whenCursorIsNull() {
+    // given
+    // 관심사 생성 (정렬 확인 위해 이름 순서 의도적으로 섞음)
+    Interest i1 = interestRepository.save(Interest.create("나무"));
+    Interest i2 = interestRepository.save(Interest.create("가구"));
+    Interest i3 = interestRepository.save(Interest.create("다리"));
+    Interest i4 = interestRepository.save(Interest.create("책상"));
+    Interest i5 = interestRepository.save(Interest.create("카톡"));
+
+    User user = userRepository.save(User.create("test@example.com", "tester", "test1234!"));
+
+    subscriptionRepository.save(Subscription.create(user, i2));
+
+    InterestSearchCondition condition = new InterestSearchCondition(
+        null,
+        "name",
+        "ASC",
+        new InterestCursor(null, null),
+        2
+    );
+
+    // when
+    CursorPageResponseInterestDto response =
+        interestService.findAll(condition, user.getId());
+
+    // then
+    assertThat(response.content()).hasSize(2);
+
+    // 정렬 확인 (name ASC → 가구, 나무)
+    assertThat(response.content())
+        .extracting(InterestDto::name)
+        .containsExactly("가구", "나무");
+    assertThat(response.hasNext()).isTrue();
+    assertThat(response.nextCursor()).isEqualTo("나무");
+    assertThat(response.nextAfter()).isNotNull();
+    assertThat(response.totalElements()).isEqualTo(5);
+
+    // subscribedByMe 확인
+    Map<String, Boolean> map = response.content().stream()
+        .collect(Collectors.toMap(InterestDto::name, InterestDto::subscribedByMe));
+
+    assertThat(map.get("가구")).isTrue();
+    assertThat(map.get("나무")).isFalse();
+  }
+
+  @Test
+  @DisplayName("커서와 after 값으로 다음 페이지를 조회할 수 있다")
+  void shouldReturnNextPage_whenCursorAndAfterAreGiven() {
+    // given
+    User user = userRepository.save(
+        User.create("test@example.com", "tester", "test1234!")
+    );
+    UUID userId = user.getId();
+
+    interestRepository.save(Interest.create("나무"));
+    Interest furniture = interestRepository.save(Interest.create("가구"));
+    Interest bridge = interestRepository.save(Interest.create("다리"));
+    interestRepository.save(Interest.create("책상"));
+    interestRepository.save(Interest.create("카톡"));
+
+    subscriptionRepository.save(Subscription.create(user, furniture));
+
+    InterestSearchCondition firstCondition = new InterestSearchCondition(
+        null,
+        "name",
+        "ASC",
+        new InterestCursor(null, null),
+        2
+    );
+
+    CursorPageResponseInterestDto firstPage = interestService.findAll(firstCondition, userId);
+
+    InterestSearchCondition secondCondition = new InterestSearchCondition(
+        null,
+        "name",
+        "ASC",
+        new InterestCursor(firstPage.nextCursor(), Instant.parse(firstPage.nextAfter())),
+        2
+    );
+
+    // when
+    CursorPageResponseInterestDto secondPage = interestService.findAll(secondCondition, userId);
+
+    // then
+    assertThat(secondPage.content()).hasSize(2);
+    assertThat(secondPage.content())
+        .extracting(InterestDto::name)
+        .containsExactly("다리", "책상");
+    assertThat(secondPage.hasNext()).isTrue();
+    assertThat(secondPage.nextCursor()).isEqualTo("책상");
+    assertThat(secondPage.nextAfter()).isNotNull();
+    assertThat(secondPage.totalElements()).isEqualTo(5);
+  }
+
+  @Test
+  @DisplayName("더 이상 데이터가 없으면 마지막 페이지를 반환한다")
+  void shouldReturnLastPage_whenNoMoreDataExists() {
+    // given
+    User user = userRepository.save(
+        User.create("test@example.com", "tester", "test1234!")
+    );
+    UUID userId = user.getId();
+
+    interestRepository.save(Interest.create("나무"));
+    interestRepository.save(Interest.create("가구"));
+    interestRepository.save(Interest.create("다리"));
+    interestRepository.save(Interest.create("책상"));
+    interestRepository.save(Interest.create("카톡"));
+
+    InterestSearchCondition firstCondition = new InterestSearchCondition(
+        null,
+        "name",
+        "ASC",
+        new InterestCursor(null, null),
+        2
+    );
+
+    CursorPageResponseInterestDto firstPage = interestService.findAll(firstCondition, userId);
+
+    InterestSearchCondition secondCondition = new InterestSearchCondition(
+        null,
+        "name",
+        "ASC",
+        new InterestCursor(firstPage.nextCursor(), Instant.parse(firstPage.nextAfter())),
+        2
+    );
+
+    CursorPageResponseInterestDto secondPage = interestService.findAll(secondCondition, userId);
+
+    InterestSearchCondition thirdCondition = new InterestSearchCondition(
+        null,
+        "name",
+        "ASC",
+        new InterestCursor(secondPage.nextCursor(), Instant.parse(secondPage.nextAfter())),
+        2
+    );
+
+    // when
+    CursorPageResponseInterestDto thirdPage = interestService.findAll(thirdCondition, userId);
+
+    // then
+    assertThat(thirdPage.content()).hasSize(1);
+    assertThat(thirdPage.content())
+        .extracting(InterestDto::name)
+        .containsExactly("카톡");
+    assertThat(thirdPage.hasNext()).isFalse();
+    assertThat(thirdPage.nextCursor()).isNull();
+    assertThat(thirdPage.nextAfter()).isNull();
+    assertThat(thirdPage.totalElements()).isEqualTo(5);
+  }
+
+  @Test
+  @DisplayName("검색어가 관심사 이름에 일치하면 필터링된 결과를 반환한다")
+  void shouldReturnFilteredPage_whenSearchKeywordMatchesInterestName() {
+    // given
+    User user = userRepository.save(
+        User.create("test@example.com", "tester", "test1234!")
+    );
+    UUID userId = user.getId();
+
+    interestRepository.save(Interest.create("축구"));
+    interestRepository.save(Interest.create("야구"));
+    interestRepository.save(Interest.create("농구"));
+
+    InterestSearchCondition condition = new InterestSearchCondition(
+        "구",
+        "name",
+        "ASC",
+        new InterestCursor(null, null),
+        10
+    );
+
+    // when
+    CursorPageResponseInterestDto response = interestService.findAll(condition, userId);
+
+    // then
+    assertThat(response.content())
+        .extracting(InterestDto::name)
+        .containsExactly("농구", "야구", "축구");
+    assertThat(response.totalElements()).isEqualTo(3);
+    assertThat(response.hasNext()).isFalse();
+    assertThat(response.nextCursor()).isNull();
+    assertThat(response.nextAfter()).isNull();
+  }
+
+  @Test
+  @DisplayName("검색어가 관심사 키워드에 일치하면 필터링된 결과를 반환한다")
+  void shouldReturnFilteredPage_whenSearchKeywordMatchesInterestKeyword() {
+    // given
+    User user = userRepository.save(
+        User.create("test@example.com", "tester", "test1234!")
+    );
+    UUID userId = user.getId();
+
+    Interest soccer = Interest.create("축구");
+    soccer.addKeyword("손흥민");
+    soccer.addKeyword("프리미어리그");
+    interestRepository.save(soccer);
+
+    Interest baseball = Interest.create("야구");
+    baseball.addKeyword("류현진");
+    interestRepository.save(baseball);
+
+    InterestSearchCondition condition = new InterestSearchCondition(
+        "손",
+        "name",
+        "ASC",
+        new InterestCursor(null, null),
+        10
+    );
+
+    // when
+    CursorPageResponseInterestDto response = interestService.findAll(condition, userId);
+
+    // then
+    assertThat(response.content()).hasSize(1);
+    assertThat(response.content().get(0).name()).isEqualTo("축구");
+    assertThat(response.totalElements()).isEqualTo(1);
+    assertThat(response.hasNext()).isFalse();
+  }
+
+  @Test
+  @DisplayName("사용자가 구독한 관심사는 subscribedByMe가 true로 설정된다")
+  void shouldSetSubscribedByMeTrue_whenUserSubscribedInterestExists() {
+    // given
+    User user = userRepository.save(
+        User.create("test@example.com", "tester", "test1234!")
+    );
+    UUID userId = user.getId();
+
+    Interest furniture = interestRepository.save(Interest.create("가구"));
+    Interest tree = interestRepository.save(Interest.create("나무"));
+
+    subscriptionRepository.save(Subscription.create(user, furniture));
+
+    InterestSearchCondition condition = new InterestSearchCondition(
+        null,
+        "name",
+        "ASC",
+        new InterestCursor(null, null),
+        10
+    );
+
+    // when
+    CursorPageResponseInterestDto response = interestService.findAll(condition, userId);
+
+    // then
+    assertThat(response.content()).hasSize(2);
+
+    Map<String, Boolean> subscribedMap = response.content().stream()
+        .collect(Collectors.toMap(InterestDto::name, InterestDto::subscribedByMe));
+
+    assertThat(subscribedMap.get("가구")).isTrue();
+    assertThat(subscribedMap.get("나무")).isFalse();
+  }
+
+  @Test
+  @DisplayName("검색 결과가 없으면 빈 페이지를 반환한다")
+  void shouldReturnEmptyPage_whenNoInterestMatchesKeyword() {
+    // given
+    User user = userRepository.save(
+        User.create("test@example.com", "tester", "test1234!")
+    );
+    UUID userId = user.getId();
+
+    interestRepository.save(Interest.create("축구"));
+    interestRepository.save(Interest.create("야구"));
+
+    InterestSearchCondition condition = new InterestSearchCondition(
+        "경제",
+        "name",
+        "ASC",
+        new InterestCursor(null, null),
+        10
+    );
+
+    // when
+    CursorPageResponseInterestDto response = interestService.findAll(condition, userId);
+
+    // then
+    assertThat(response.content()).isEmpty();
+    assertThat(response.totalElements()).isEqualTo(0);
+    assertThat(response.hasNext()).isFalse();
+    assertThat(response.nextCursor()).isNull();
+    assertThat(response.nextAfter()).isNull();
   }
 }

--- a/src/test/java/com/team3/monew/integration/InterestServiceIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/InterestServiceIntegrationTest.java
@@ -357,13 +357,13 @@ public class InterestServiceIntegrationTest {
     );
     UUID userId = user.getId();
 
-    interestRepository.save(Interest.create("나무"));
-    Interest furniture = interestRepository.save(Interest.create("가구"));
-    Interest bridge = interestRepository.save(Interest.create("다리"));
-    interestRepository.save(Interest.create("책상"));
-    interestRepository.save(Interest.create("카톡"));
+    interestRepository.save(Interest.create("A"));
+    Interest beta = interestRepository.save(Interest.create("B"));
+    interestRepository.save(Interest.create("C"));
+    interestRepository.save(Interest.create("D"));
+    interestRepository.save(Interest.create("E"));
 
-    subscriptionRepository.save(Subscription.create(user, furniture));
+    subscriptionRepository.save(Subscription.create(user, beta));
 
     InterestSearchCondition firstCondition = new InterestSearchCondition(
         null,
@@ -390,9 +390,9 @@ public class InterestServiceIntegrationTest {
     assertThat(secondPage.content()).hasSize(2);
     assertThat(secondPage.content())
         .extracting(InterestDto::name)
-        .containsExactly("다리", "책상");
+        .containsExactly("C", "D");
     assertThat(secondPage.hasNext()).isTrue();
-    assertThat(secondPage.nextCursor()).isEqualTo("책상");
+    assertThat(secondPage.nextCursor()).isEqualTo("D");
     assertThat(secondPage.nextAfter()).isNotNull();
     assertThat(secondPage.totalElements()).isEqualTo(5);
   }
@@ -406,11 +406,11 @@ public class InterestServiceIntegrationTest {
     );
     UUID userId = user.getId();
 
-    interestRepository.save(Interest.create("나무"));
-    interestRepository.save(Interest.create("가구"));
-    interestRepository.save(Interest.create("다리"));
-    interestRepository.save(Interest.create("책상"));
-    interestRepository.save(Interest.create("카톡"));
+    interestRepository.save(Interest.create("A"));
+    interestRepository.save(Interest.create("B"));
+    interestRepository.save(Interest.create("C"));
+    interestRepository.save(Interest.create("D"));
+    interestRepository.save(Interest.create("E"));
 
     InterestSearchCondition firstCondition = new InterestSearchCondition(
         null,
@@ -447,7 +447,7 @@ public class InterestServiceIntegrationTest {
     assertThat(thirdPage.content()).hasSize(1);
     assertThat(thirdPage.content())
         .extracting(InterestDto::name)
-        .containsExactly("카톡");
+        .containsExactly("E");
     assertThat(thirdPage.hasNext()).isFalse();
     assertThat(thirdPage.nextCursor()).isNull();
     assertThat(thirdPage.nextAfter()).isNull();

--- a/src/test/java/com/team3/monew/repository/impl/InterestRepositoryTest.java
+++ b/src/test/java/com/team3/monew/repository/impl/InterestRepositoryTest.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @DataJpaTest
 @Import({InterestRepositoryImpl.class, JpaAuditingConfig.class, QueryDslConfig.class})
@@ -154,5 +155,220 @@ class InterestRepositoryTest {
     assertThat(result)
         .extracting(Interest::getName)
         .containsExactly("야구", "경제", "게임");
+  }
+
+  @Test
+  @DisplayName("검색어가 없으면 전체 관심사가 조회된다")
+  void shouldReturnAllInterests_whenKeywordIsNull() {
+    // given
+    Interest a = Interest.create("A");
+    Interest b = Interest.create("B");
+    Interest c = Interest.create("C");
+
+    em.persist(a);
+    em.persist(b);
+    em.persist(c);
+    em.flush();
+    em.clear();
+
+    InterestSearchCondition condition = new InterestSearchCondition(
+        null,
+        "name",
+        "ASC",
+        new InterestCursor(null, null),
+        10
+    );
+
+    // when
+    List<Interest> result = interestRepository.searchByCondition(condition);
+
+    // then
+    assertThat(result)
+        .extracting(Interest::getName)
+        .containsExactly("A", "B", "C");
+  }
+
+  @Test
+  @DisplayName("구독자 수 오름차순으로 정렬된다")
+  void shouldSearchByCondition_orderBySubscriberCountAsc() {
+    // given
+    Interest a = Interest.create("A");
+    Interest b = Interest.create("B");
+    Interest c = Interest.create("C");
+
+    ReflectionTestUtils.setField(a, "subscriberCount", 30);
+    ReflectionTestUtils.setField(b, "subscriberCount", 10);
+    ReflectionTestUtils.setField(c, "subscriberCount", 20);
+
+    em.persist(a);
+    em.persist(b);
+    em.persist(c);
+    em.flush();
+    em.clear();
+
+    InterestSearchCondition condition = new InterestSearchCondition(
+        null,
+        "subscriberCount",
+        "ASC",
+        new InterestCursor(null, null),
+        10
+    );
+
+    // when
+    List<Interest> result = interestRepository.searchByCondition(condition);
+
+    // then
+    assertThat(result)
+        .extracting(Interest::getName)
+        .containsExactly("B", "C", "A");
+  }
+
+  @Test
+  @DisplayName("구독자 수 내림차순으로 정렬된다")
+  void shouldSearchByCondition_orderBySubscriberCountDesc() {
+    // given
+    Interest a = Interest.create("A");
+    Interest b = Interest.create("B");
+    Interest c = Interest.create("C");
+
+    ReflectionTestUtils.setField(a, "subscriberCount", 30);
+    ReflectionTestUtils.setField(b, "subscriberCount", 10);
+    ReflectionTestUtils.setField(c, "subscriberCount", 20);
+
+    em.persist(a);
+    em.persist(b);
+    em.persist(c);
+    em.flush();
+    em.clear();
+
+    InterestSearchCondition condition = new InterestSearchCondition(
+        null,
+        "subscriberCount",
+        "DESC",
+        new InterestCursor(null, null),
+        10
+    );
+
+    // when
+    List<Interest> result = interestRepository.searchByCondition(condition);
+
+    // then
+    assertThat(result)
+        .extracting(Interest::getName)
+        .containsExactly("A", "C", "B");
+  }
+
+  @Test
+  @DisplayName("이름 오름차순 정렬에서 커서 이후 데이터만 조회된다")
+  void shouldReturnNextPage_whenCursorIsGivenWithNameAsc() {
+    // given
+    Interest a = Interest.create("A");
+    Interest b = Interest.create("B");
+    Interest c = Interest.create("C");
+    Interest d = Interest.create("D");
+
+    em.persist(a);
+    em.persist(b);
+    em.persist(c);
+    em.persist(d);
+    em.flush();
+    em.clear();
+
+    Interest savedB = interestRepository.findAll().stream()
+        .filter(interest -> interest.getName().equals("B"))
+        .findFirst()
+        .orElseThrow();
+
+    InterestSearchCondition condition = new InterestSearchCondition(
+        null,
+        "name",
+        "ASC",
+        new InterestCursor(savedB.getName(), savedB.getCreatedAt()),
+        10
+    );
+
+    // when
+    List<Interest> result = interestRepository.searchByCondition(condition);
+
+    // then
+    assertThat(result)
+        .extracting(Interest::getName)
+        .containsExactly("C", "D");
+  }
+
+  @Test
+  @DisplayName("구독자 수 오름차순 정렬에서 커서 이후 데이터만 조회된다")
+  void shouldReturnNextPage_whenCursorIsGivenWithSubscriberCountAsc() {
+    // given
+    Interest a = Interest.create("A");
+    Interest b = Interest.create("B");
+    Interest c = Interest.create("C");
+    Interest d = Interest.create("D");
+
+    ReflectionTestUtils.setField(a, "subscriberCount", 10);
+    ReflectionTestUtils.setField(b, "subscriberCount", 20);
+    ReflectionTestUtils.setField(c, "subscriberCount", 30);
+    ReflectionTestUtils.setField(d, "subscriberCount", 40);
+
+    em.persist(a);
+    em.persist(b);
+    em.persist(c);
+    em.persist(d);
+    em.flush();
+    em.clear();
+
+    Interest savedB = interestRepository.findAll().stream()
+        .filter(interest -> interest.getName().equals("B"))
+        .findFirst()
+        .orElseThrow();
+
+    InterestSearchCondition condition = new InterestSearchCondition(
+        null,
+        "subscriberCount",
+        "ASC",
+        new InterestCursor(String.valueOf(savedB.getSubscriberCount()), savedB.getCreatedAt()),
+        10
+    );
+
+    // when
+    List<Interest> result = interestRepository.searchByCondition(condition);
+
+    // then
+    assertThat(result)
+        .extracting(Interest::getName)
+        .containsExactly("C", "D");
+  }
+
+  @Test
+  @DisplayName("검색 조건에 맞는 전체 관심사 개수를 반환한다")
+  void shouldCountByCondition() {
+    // given
+    Interest soccer = Interest.create("축구");
+    soccer.addKeyword("손흥민");
+
+    Interest baseball = Interest.create("야구");
+    baseball.addKeyword("류현진");
+
+    Interest basketball = Interest.create("농구");
+
+    em.persist(soccer);
+    em.persist(baseball);
+    em.persist(basketball);
+    em.flush();
+    em.clear();
+
+    InterestSearchCondition condition = new InterestSearchCondition(
+        "구",
+        "name",
+        "ASC",
+        new InterestCursor(null, null),
+        10
+    );
+
+    // when
+    long count = interestRepository.countByCondition(condition);
+
+    // then
+    assertThat(count).isEqualTo(3);
   }
 }

--- a/src/test/java/com/team3/monew/repository/impl/InterestRepositoryTest.java
+++ b/src/test/java/com/team3/monew/repository/impl/InterestRepositoryTest.java
@@ -1,0 +1,158 @@
+package com.team3.monew.repository.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.team3.monew.config.JpaAuditingConfig;
+import com.team3.monew.config.QueryDslConfig;
+import com.team3.monew.dto.interest.internal.InterestCursor;
+import com.team3.monew.dto.interest.internal.InterestSearchCondition;
+import com.team3.monew.entity.Interest;
+import com.team3.monew.repository.InterestRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import({InterestRepositoryImpl.class, JpaAuditingConfig.class, QueryDslConfig.class})
+@Tag("integration")
+class InterestRepositoryTest {
+
+  @Autowired
+  private InterestRepository interestRepository;
+
+  @Autowired
+  private TestEntityManager em;
+
+  @Test
+  @DisplayName("검색어가 관심사 이름에 부분 일치하면 조회된다")
+  void shouldSearchedByCondition_whenSearchByInterestName() {
+    // given
+    Interest economy = Interest.create("경제");
+    Interest baseball = Interest.create("야구");
+    Interest game = Interest.create("게임");
+
+    em.persist(economy);
+    em.persist(baseball);
+    em.persist(game);
+    em.flush();
+    em.clear();
+
+    InterestSearchCondition condition = new InterestSearchCondition(
+        "게",
+        "name",
+        "ASC",
+        new InterestCursor(null, null),
+        10
+    );
+
+    // when
+    List<Interest> result = interestRepository.searchByCondition(condition);
+
+    // then
+    assertThat(result).hasSize(1);
+    assertThat(result)
+        .extracting(Interest::getName)
+        .containsExactly("게임");
+  }
+
+  @Test
+  @DisplayName("검색어가 관심사 키워드에 부분 일치하면 조회된다")
+  void shouldSearchByCondition_whenSearchByKeyword() {
+    // given
+    Interest soccer = Interest.create("축구");
+    soccer.addKeyword("손흥민");
+    soccer.addKeyword("프리미어리그");
+
+    Interest baseball = Interest.create("야구");
+    baseball.addKeyword("류현진");
+
+    em.persist(soccer);
+    em.persist(baseball);
+    em.flush();
+    em.clear();
+
+    InterestSearchCondition condition = new InterestSearchCondition(
+        "손",
+        "name",
+        "ASC",
+        new InterestCursor(null, null),
+        10
+    );
+
+    // when
+    List<Interest> result = interestRepository.searchByCondition(condition);
+
+    // then
+    assertThat(result).hasSize(1);
+    assertThat(result)
+        .extracting(Interest::getName)
+        .containsExactly("축구");
+  }
+
+  @Test
+  @DisplayName("관심사 이름 오름차순으로 정렬된다")
+  void shouldSearchByCondition_orderByNameAsc() {
+    // given
+    Interest economy = Interest.create("경제");
+    Interest baseball = Interest.create("야구");
+    Interest game = Interest.create("게임");
+
+    em.persist(economy);
+    em.persist(baseball);
+    em.persist(game);
+    em.flush();
+    em.clear();
+
+    InterestSearchCondition condition = new InterestSearchCondition(
+        null,
+        "name",
+        "ASC",
+        new InterestCursor(null, null),
+        10
+    );
+
+    // when
+    List<Interest> result = interestRepository.searchByCondition(condition);
+
+    // then
+    assertThat(result)
+        .extracting(Interest::getName)
+        .containsExactly("게임", "경제", "야구");
+  }
+
+  @Test
+  @DisplayName("관심사 이름 내림차순으로 정렬된다")
+  void shouldSearchByCondition_orderByNameDesc() {
+    // given
+    Interest economy = Interest.create("경제");
+    Interest baseball = Interest.create("야구");
+    Interest game = Interest.create("게임");
+
+    em.persist(economy);
+    em.persist(baseball);
+    em.persist(game);
+    em.flush();
+    em.clear();
+
+    InterestSearchCondition condition = new InterestSearchCondition(
+        null,
+        "name",
+        "DESC",
+        new InterestCursor(null, null),
+        10
+    );
+
+    // when
+    List<Interest> result = interestRepository.searchByCondition(condition);
+
+    // then
+    assertThat(result)
+        .extracting(Interest::getName)
+        .containsExactly("야구", "경제", "게임");
+  }
+}

--- a/src/test/java/com/team3/monew/service/InterestServiceTest.java
+++ b/src/test/java/com/team3/monew/service/InterestServiceTest.java
@@ -1,8 +1,11 @@
 package com.team3.monew.service;
 
+import com.team3.monew.dto.interest.CursorPageResponseInterestDto;
 import com.team3.monew.dto.interest.InterestDto;
 import com.team3.monew.dto.interest.InterestRegisterRequest;
 import com.team3.monew.dto.interest.InterestUpdateRequest;
+import com.team3.monew.dto.interest.internal.InterestCursor;
+import com.team3.monew.dto.interest.internal.InterestSearchCondition;
 import com.team3.monew.entity.Interest;
 import com.team3.monew.entity.InterestKeyword;
 import com.team3.monew.exception.interest.InterestDuplicateNameException;
@@ -11,6 +14,8 @@ import com.team3.monew.exception.interest.InterestNotFoundException;
 import com.team3.monew.mapper.InterestMapper;
 import com.team3.monew.repository.InterestRepository;
 import com.team3.monew.repository.SubscriptionRepository;
+import jakarta.persistence.criteria.CriteriaBuilder.In;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -22,9 +27,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.then;
@@ -304,5 +312,139 @@ class InterestServiceTest {
         .isInstanceOf(InterestNotFoundException.class);
 
     then(interestRepository).should(never()).delete(any());
+  }
+
+  @Test
+  @DisplayName("limit + 1개 조회 시 hasNext는 true이고 content는 limit만 반환된다")
+  void shouldFindAllInterest_whenFindRequest() {
+    // given
+    UUID userId = UUID.randomUUID();
+
+    Interest i1 = createInterest("가구");
+    Interest i2 = createInterest("나무");
+    Interest i3 = createInterest("다리");
+
+    List<Interest> result = List.of(i1, i2, i3);
+
+    InterestSearchCondition condition = new InterestSearchCondition(
+        null, "name", "ASC", new InterestCursor(null, null), 2
+    );
+
+    given(interestRepository.searchByCondition(condition)).willReturn(result);
+    given(interestRepository.countByCondition(condition)).willReturn(3);
+
+    given(subscriptionRepository.existsByUserIdAndInterestId(any(), any()))
+        .willReturn(false);
+
+    given(interestMapper.toDto(any(), anyBoolean()))
+        .willAnswer(invocation ->
+            new InterestDto(
+                ((Interest) invocation.getArgument(0)).getId(),
+                ((Interest) invocation.getArgument(0)).getName(),
+                List.of(),
+                0,
+                false
+            ));
+
+    // when
+    CursorPageResponseInterestDto response
+        = interestService.findAll(condition, userId);
+
+    // then
+    assertThat(response.content()).hasSize(2);
+    assertThat(response.hasNext()).isTrue();
+    assertThat(response.nextCursor()).isEqualTo("나무");
+    assertThat(response.nextAfter()).isNotNull();
+  }
+
+  private Interest createInterest(String name) {
+    Interest interest = Interest.create(name);
+    ReflectionTestUtils.setField(interest, "createdAt", Instant.now());
+    return interest;
+  }
+
+  @Test
+  @DisplayName("limit 이하 조회 시 hasNext는 false이고 nextCursor는 null이다")
+  void shouldFindInterestHasNextIsFalseAndNextCursorIsNull_whenLimit() {
+    // given
+    UUID userId = UUID.randomUUID();
+
+    Interest i1 = createInterest("가구");
+    Interest i2 = createInterest("나무");
+
+    List<Interest> result = List.of(i1, i2);
+
+    InterestSearchCondition condition = new InterestSearchCondition(
+        null, "name", "ASC", new InterestCursor(null, null), 3
+    );
+
+    given(interestRepository.searchByCondition(condition)).willReturn(result);
+    given(interestRepository.countByCondition(condition)).willReturn(2);
+
+    given(subscriptionRepository.existsByUserIdAndInterestId(any(), any()))
+        .willReturn(false);
+
+    given(interestMapper.toDto(any(), anyBoolean()))
+        .willReturn(new InterestDto(UUID.randomUUID(), "dummy", List.of(), 0, false));
+
+    // when
+    CursorPageResponseInterestDto response =
+        interestService.findAll(condition, userId);
+
+    // then
+    assertThat(response.hasNext()).isFalse();
+    assertThat(response.nextCursor()).isNull();
+    assertThat(response.nextAfter()).isNull();
+  }
+
+  @Test
+  @DisplayName("조회 결과가 없으면 빈 리스트를 반환한다")
+  void shouldReturnEmptyList_whenResultIsNone() {
+    // given
+    UUID userId = UUID.randomUUID();
+
+    InterestSearchCondition condition = new InterestSearchCondition(
+        null, "name", "ASC", new InterestCursor(null, null), 10
+    );
+
+    given(interestRepository.searchByCondition(condition)).willReturn(List.of());
+    given(interestRepository.countByCondition(condition)).willReturn(0);
+
+    // when
+    CursorPageResponseInterestDto response
+        = interestService.findAll(condition, userId);
+
+    // then
+    assertThat(response.content()).isEmpty();
+    assertThat(response.hasNext()).isFalse();
+  }
+
+  @Test
+  @DisplayName("subscribedByMe가 true로 반영된다")
+  void shouldSubscribedByMeIsTrue_whenSubscribing() {
+    // given
+    UUID userId = UUID.randomUUID();
+
+    Interest interest = createInterest("economy");
+
+    InterestSearchCondition condition = new InterestSearchCondition(
+        null, "name", "DESC", new InterestCursor(null, null), 10
+    );
+
+    given(interestRepository.searchByCondition(condition)).willReturn(List.of(interest));
+    given(interestRepository.countByCondition(condition)).willReturn(1);
+
+    given(subscriptionRepository.existsByUserIdAndInterestId(userId, interest.getId()))
+        .willReturn(true);
+
+    given(interestMapper.toDto(any(), eq(true)))
+        .willReturn(new InterestDto(interest.getId(), "economy", List.of(), 0, true));
+
+    // when
+    CursorPageResponseInterestDto response
+        = interestService.findAll(condition, userId);
+
+    // then
+    assertThat(response.content().get(0).subscribedByMe()).isTrue();
   }
 }

--- a/src/test/java/com/team3/monew/service/InterestServiceTest.java
+++ b/src/test/java/com/team3/monew/service/InterestServiceTest.java
@@ -331,7 +331,7 @@ class InterestServiceTest {
     );
 
     given(interestRepository.searchByCondition(condition)).willReturn(result);
-    given(interestRepository.countByCondition(condition)).willReturn(3);
+    given(interestRepository.countByCondition(condition)).willReturn(3L);
 
     given(subscriptionRepository.existsByUserIdAndInterestId(any(), any()))
         .willReturn(false);
@@ -379,7 +379,7 @@ class InterestServiceTest {
     );
 
     given(interestRepository.searchByCondition(condition)).willReturn(result);
-    given(interestRepository.countByCondition(condition)).willReturn(2);
+    given(interestRepository.countByCondition(condition)).willReturn(2L);
 
     given(subscriptionRepository.existsByUserIdAndInterestId(any(), any()))
         .willReturn(false);
@@ -408,7 +408,7 @@ class InterestServiceTest {
     );
 
     given(interestRepository.searchByCondition(condition)).willReturn(List.of());
-    given(interestRepository.countByCondition(condition)).willReturn(0);
+    given(interestRepository.countByCondition(condition)).willReturn(0L);
 
     // when
     CursorPageResponseInterestDto response
@@ -432,7 +432,7 @@ class InterestServiceTest {
     );
 
     given(interestRepository.searchByCondition(condition)).willReturn(List.of(interest));
-    given(interestRepository.countByCondition(condition)).willReturn(1);
+    given(interestRepository.countByCondition(condition)).willReturn(1L);
 
     given(subscriptionRepository.existsByUserIdAndInterestId(userId, interest.getId()))
         .willReturn(true);


### PR DESCRIPTION
## 관련 이슈
- closes #23 #151 #154 #155 #156 

## 작업 내용
- feat: 관심사 목록 조회 기능 구현
  - InterestService에 관심사 목록 조회 메서드(findAll) 구현
  - 검색어(keyword) 기반 관심사 이름 및 키워드 부분 일치 검색 기능 구현
    - interest.name + exists(subquery) 기반 keyword 검색 적용
  - 정렬 조건(orderBy, direction)에 따른 동적 정렬 처리 구현
    - name, subscriberCount 기준 정렬 지원
  - 커서 기반 페이지네이션 로직 구현
    - limit + 1 조회를 통한 hasNext 계산
    - nextCursor, nextAfter 생성 로직 구현
    - content slicing 처리
  - 사용자 구독 여부(subscribedByMe) 계산 로직 구현

- refactor: 관심사 조회 쿼리 개선
  - 기존 left join + distinct 방식 제거
  - exists(subquery) 기반으로 변경하여 pagination 안정성 확보
  - 불필요한 row 증가 및 distinct 제거로 성능 및 정확도 개선

- refactor: count 쿼리 로직 개선
  - countByCondition에서 left join 제거
  - search 조건과 동일한 필터 기준 유지하도록 수정
  - interest.count() 기반으로 단순화

- test: 관심사 조회 Repository 테스트 작성
  - 관심사 이름 부분 일치 검색 테스트
  - 관심사 키워드 부분 일치 검색 테스트
  - 정렬(name ASC/DESC) 테스트
  - QueryDSL 기반 검색 조건 정상 동작 검증

- test: 관심사 조회 서비스 단위 테스트 작성
  - limit + 1 기반 hasNext 계산 검증
  - nextCursor, nextAfter 생성 검증
  - content slicing 검증
  - subscribedByMe 계산 검증

- test: 관심사 조회 서비스 통합 테스트 작성
  - 첫 페이지 조회 검증
  - 다음 페이지 조회 검증 (cursor, after 기반)
  - 마지막 페이지 조회 검증
  - 검색 조건 적용 상태에서 페이지네이션 검증
  - subscribedByMe 실제 DB 기반 검증
  - 빈 결과 조회 검증

- feat: 관심사 컨트롤러 조회 API 구현
  - GET /api/interests 엔드포인트 구현
  - 요청 파라미터 기반 InterestSearchCondition 생성
  - 커서(cursor, after) optional 처리 적용
  - 기본값(orderBy=name, direction=ASC, limit=10) 설정
  - InterestService와 연동하여 조회 결과 반환

- test: 관심사 컨트롤러 슬라이스 테스트 작성
  - 목록 조회 성공 시 응답 구조 검증
  - 커서 없는 첫 페이지 조회 검증
  - cursor/after 기반 다음 페이지 조회 검증
  - 검색 조건 적용 응답 검증
  - 잘못된 요청 시 400 응답 검증

- refactor: 서비스 로깅 추가
  - 관심사 조회 요청 로그 추가
  - 조회 결과(contentSize, totalElements, hasNext 등) 로그 추가
  - 빈 결과 조회 시 로그 추가

## 변경 사항
- 없음

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- QueryDSL로 다시 작성하는데 시간이 조금 걸렸습니다.. 처음이라 잘못 작성한 부분이 있을 수 있으니 InterestRepositoryImpl 부분을 한 번 더 확인해주시면 감사하겠습니다!

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관심사 목록 조회 API 추가: 커서 기반 페이지네이션, 키워드 검색, 이름/구독자수 기준 정렬, 페이지 크기 제어 및 요청자 기준 구독 여부 포함 응답 제공.

* **테스트**
  * 단위·통합 테스트 추가로 페이지네이션, 정렬, 필터링 및 구독 상태 동작 검증 강화.

* **잡무(Chores)**
  * 테스트 실행 관련 빌드 동작 일부 조정(테스트 프로파일/리포트 연동 변경).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->