### PR TITLE
feat: 뉴스 기사 저장 시 알람 연동 구현

### DIFF
--- a/src/main/java/com/team3/monew/component/news/client/ChosunNewsClient.java
+++ b/src/main/java/com/team3/monew/component/news/client/ChosunNewsClient.java
@@ -3,9 +3,10 @@ package com.team3.monew.component.news.client;
 import com.team3.monew.component.news.collect.NewsCollector;
 import com.team3.monew.component.news.filter.NewsFilter;
 import com.team3.monew.component.news.record.ParsedNewsArticle;
+import com.team3.monew.entity.InterestKeyword;
 import com.team3.monew.entity.enums.NewsSourceType;
+import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -25,10 +26,11 @@ public class ChosunNewsClient implements NewsClient {
   }
 
   @Override
-  public Mono<List<ParsedNewsArticle>> fetchAndProcess(Set<String> keywords) {
+  public Mono<List<ParsedNewsArticle>> fetchAndProcess(
+      Collection<InterestKeyword> interestKeywords) {
     // CHOSUN은 단일 쿼리만 있음
-    return newsCollector.collectRawNews(getSourceType(), keywords)
-        .map(newsFilter::filterKeyword)
+    return newsCollector.collectRawNews(getSourceType(), interestKeywords)
+        .map(parsedData -> newsFilter.filterKeyword(parsedData, interestKeywords))
         .flatMapIterable(list -> list)       // 단일 쿼리지만 구조를 맞추기 위해 사용
         .collectList();
   }

--- a/src/main/java/com/team3/monew/component/news/client/NaverNewsClient.java
+++ b/src/main/java/com/team3/monew/component/news/client/NaverNewsClient.java
@@ -3,9 +3,12 @@ package com.team3.monew.component.news.client;
 import com.team3.monew.component.news.collect.NewsCollector;
 import com.team3.monew.component.news.filter.NewsFilter;
 import com.team3.monew.component.news.record.ParsedNewsArticle;
+import com.team3.monew.entity.InterestKeyword;
 import com.team3.monew.entity.enums.NewsSourceType;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
-import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -25,12 +28,21 @@ public class NaverNewsClient implements NewsClient {
   }
 
   @Override
-  public Mono<List<ParsedNewsArticle>> fetchAndProcess(Set<String> keywords) {
+  public Mono<List<ParsedNewsArticle>> fetchAndProcess(
+      Collection<InterestKeyword> interestKeywords) {
     // Naver는 키워드별로 쿼리를 여러개 보냄
-    return newsCollector.collectRawNews(getSourceType(), keywords)
-        .map(newsFilter::filterKeyword)
+    return newsCollector.collectRawNews(getSourceType(), interestKeywords)
+        .map(parsedData -> newsFilter.filterKeyword(parsedData, interestKeywords))
         .flatMapIterable(list -> list)       // 여러개의 쿼리 결과값을 하나로 합침
-        .distinct(ParsedNewsArticle::link)                       // 키워드별 쿼리에 중복 가능성이 있어 제거
-        .collectList();
+        .collect(Collectors.toMap(
+            ParsedNewsArticle::link,
+            article -> article,                   // 키워드별 쿼리에 중복 가능성이 있어 제거
+            (existing, replacement) -> {
+              // 관심사 몰아주기
+              existing.interestKeywords().addAll(replacement.interestKeywords());
+              return existing;
+            }
+        ))
+        .map(value -> new ArrayList<>(value.values()));
   }
 }

--- a/src/main/java/com/team3/monew/component/news/client/NaverNewsClient.java
+++ b/src/main/java/com/team3/monew/component/news/client/NaverNewsClient.java
@@ -7,8 +7,11 @@ import com.team3.monew.entity.InterestKeyword;
 import com.team3.monew.entity.enums.NewsSourceType;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -39,10 +42,27 @@ public class NaverNewsClient implements NewsClient {
             article -> article,
             (existing, replacement) -> {
               // 키워드별 쿼리에 중복 가능성이 있는데 더 많은 관심사 있는 쪽을 살림
-              if (existing.interestKeywords().size() >= replacement.interestKeywords().size()) {
-                return existing;
-              }
-              return replacement;
+
+              List<InterestKeyword> merged = Stream.concat(
+                      existing.interestKeywords().stream(),
+                      replacement.interestKeywords().stream())
+                  .collect(Collectors.toMap(
+                      ik -> ik.getInterest().getId() + ":" + ik.getKeyword(), // 중복기준 Key
+                      ik -> ik,
+                      (oldValue, newValue) -> oldValue
+                  ))
+                  .values()
+                  .stream()
+                  .toList();
+
+              return new ParsedNewsArticle(
+                  existing.sourceType(),
+                  existing.link(),
+                  existing.title(),
+                  existing.publishedAt(),
+                  existing.summary(),
+                  merged
+              );
             }
         ))
         .map(value -> new ArrayList<>(value.values()));

--- a/src/main/java/com/team3/monew/component/news/client/NaverNewsClient.java
+++ b/src/main/java/com/team3/monew/component/news/client/NaverNewsClient.java
@@ -36,11 +36,13 @@ public class NaverNewsClient implements NewsClient {
         .flatMapIterable(list -> list)       // 여러개의 쿼리 결과값을 하나로 합침
         .collect(Collectors.toMap(
             ParsedNewsArticle::link,
-            article -> article,                   // 키워드별 쿼리에 중복 가능성이 있어 제거
+            article -> article,
             (existing, replacement) -> {
-              // 관심사 몰아주기
-              existing.interestKeywords().addAll(replacement.interestKeywords());
-              return existing;
+              // 키워드별 쿼리에 중복 가능성이 있는데 더 많은 관심사 있는 쪽을 살림
+              if (existing.interestKeywords().size() >= replacement.interestKeywords().size()) {
+                return existing;
+              }
+              return replacement;
             }
         ))
         .map(value -> new ArrayList<>(value.values()));

--- a/src/main/java/com/team3/monew/component/news/client/NaverNewsClient.java
+++ b/src/main/java/com/team3/monew/component/news/client/NaverNewsClient.java
@@ -41,8 +41,8 @@ public class NaverNewsClient implements NewsClient {
             ParsedNewsArticle::link,
             article -> article,
             (existing, replacement) -> {
-              // 키워드별 쿼리에 중복 가능성이 있는데 더 많은 관심사 있는 쪽을 살림
 
+              // 관심사 합치기
               List<InterestKeyword> merged = Stream.concat(
                       existing.interestKeywords().stream(),
                       replacement.interestKeywords().stream())

--- a/src/main/java/com/team3/monew/component/news/client/NewsClient.java
+++ b/src/main/java/com/team3/monew/component/news/client/NewsClient.java
@@ -1,14 +1,15 @@
 package com.team3.monew.component.news.client;
 
 import com.team3.monew.component.news.record.ParsedNewsArticle;
+import com.team3.monew.entity.InterestKeyword;
 import com.team3.monew.entity.enums.NewsSourceType;
+import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 import reactor.core.publisher.Mono;
 
 public interface NewsClient {
 
   NewsSourceType getSourceType();
 
-  Mono<List<ParsedNewsArticle>> fetchAndProcess(Set<String> keywords);
+  Mono<List<ParsedNewsArticle>> fetchAndProcess(Collection<InterestKeyword> interestKeywords);
 }

--- a/src/main/java/com/team3/monew/component/news/collect/ChosunNewsCollect.java
+++ b/src/main/java/com/team3/monew/component/news/collect/ChosunNewsCollect.java
@@ -3,10 +3,11 @@ package com.team3.monew.component.news.collect;
 import com.team3.monew.component.news.parse.NewsParser;
 import com.team3.monew.component.news.record.ParsedData;
 import com.team3.monew.component.news.record.RawArticleResult;
+import com.team3.monew.entity.InterestKeyword;
 import com.team3.monew.entity.enums.NewsSourceType;
 import com.team3.monew.exception.news.NewsClientException;
 import java.time.Duration;
-import java.util.Set;
+import java.util.Collection;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,7 +32,7 @@ public class ChosunNewsCollect implements NewsCollect {
 
   @Override
   public Flux<ParsedData> collect(WebClient webClient, NewsSourceType sourceType,
-      Set<String> keywords) {
+      Collection<InterestKeyword> interestKeywords) {
     String fullBaseUrl = chosunBaseUrl.contains("://") ? chosunBaseUrl : "http://" + chosunBaseUrl;
     String fullUrl = fullBaseUrl + CHOSUN_QUERY_PATH;
 

--- a/src/main/java/com/team3/monew/component/news/collect/NaverNewsCollect.java
+++ b/src/main/java/com/team3/monew/component/news/collect/NaverNewsCollect.java
@@ -10,9 +10,7 @@ import com.team3.monew.exception.news.NewsClientException;
 import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
@@ -45,7 +43,7 @@ public class NaverNewsCollect implements NewsCollect {
 
   private static final int NAVER_CONCURRENCY_SIZE = 5;
 
-  // keyword별 검색시간
+  // keyword별 검색시간(Key형태: '관심사__키워드')
   private final Map<String, Instant> lastCollectedAt = new ConcurrentHashMap<>();
 
   @Override
@@ -54,9 +52,8 @@ public class NaverNewsCollect implements NewsCollect {
 
     return Flux.fromIterable(interestKeywords)
         .flatMap(interestKeyword -> {
-              String keyword = resolveKeyword(interestKeyword);
 
-              return fetchNewsData(webClient, keyword, 1)
+              return fetchNewsData(webClient, interestKeyword, 1)
                   .flatMap(raw -> {
                     ParsedData parsedData = newsParser.parse(sourceType, raw);
                     return parsedData.isEmpty() ? Mono.empty() : Mono.just(parsedData);
@@ -69,6 +66,7 @@ public class NaverNewsCollect implements NewsCollect {
                     }
 
                     // 키워드의 첫 다운로드면 통과
+                    String keyword = resolveKeyword(interestKeyword);
                     if (!lastCollectedAt.containsKey(keyword)) {
                       lastCollectedAt.put(keyword, data.lastBuildDate());
                       log.info("Naver 뉴스기사 collect 성공 - interest={}, keyword={}",
@@ -83,7 +81,7 @@ public class NaverNewsCollect implements NewsCollect {
                     if (lastCollectedAt.get(keyword).isBefore(lastPublishedAt) ||
                         lastCollectedAt.get(keyword).equals(lastPublishedAt)) {
                       log.debug("{}번째 페이지 요청", data.page() + 1);
-                      return fetchNewsData(webClient, keyword, data.page() + 1)
+                      return fetchNewsData(webClient, interestKeyword, data.page() + 1)
                           .map(raw -> newsParser.parse(sourceType, raw))
                           .filter(nextData -> !nextData.articles().isEmpty());
                     }
@@ -101,13 +99,16 @@ public class NaverNewsCollect implements NewsCollect {
 
 
   private Mono<RawArticleResult> fetchNewsData(
-      WebClient webClient, String keyword, int page) {
+      WebClient webClient, InterestKeyword interestKeyword, int page) {
     String fullBaseUrl = naverBaseUrl.contains("://") ? naverBaseUrl : "http://" + naverBaseUrl;
+
+    String queryKeyword =
+        interestKeyword.getInterest().getName() + " " + interestKeyword.getKeyword();
 
     return webClient.get().uri(builder ->
             URI.create(fullBaseUrl + builder
                 .path(NAVER_QUERY_PATH)
-                .queryParam("query", keyword)
+                .queryParam("query", queryKeyword)
                 .queryParam("display", NAVER_QUERY_DISPLAY)
                 .queryParam("start", NAVER_QUERY_DISPLAY * (page - 1) + 1)
                 .queryParam("sort", NAVER_QUERY_SORT)
@@ -138,25 +139,25 @@ public class NaverNewsCollect implements NewsCollect {
             )
         )
         .onErrorResume(e -> {
-          List<String> interestKeyword = splitKeyword(keyword);
           log.error("Naver 기사 수집 실패: interest={}, keyword={}, error={}",
-              interestKeyword.get(0), interestKeyword.get(1), e.getMessage());
+              interestKeyword.getInterest().getName(),
+              interestKeyword.getKeyword(),
+              e.getMessage());
+
           return Mono.empty();
         })
         .map(rawData -> {
-          List<String> interestKeyword = splitKeyword(keyword);
           log.info("Naver 뉴스기사 rawData 받기 성공 - interest={}, keyword={}, page={}",
-              interestKeyword.get(0), interestKeyword.get(1), page);
-          return new RawArticleResult(rawData, keyword, page);
+              interestKeyword.getInterest().getName(),
+              interestKeyword.getKeyword(),
+              page);
+
+          return new RawArticleResult(rawData, queryKeyword, page);
         });
   }
 
   private String resolveKeyword(InterestKeyword interestKeyword) {
-    return String.format("%s %s",
+    return String.format("%s__%s",
         interestKeyword.getInterest().getName(), interestKeyword.getKeyword());
-  }
-
-  private List<String> splitKeyword(String combinedKeyword) {
-    return Arrays.stream(combinedKeyword.split(" ")).toList();
   }
 }

--- a/src/main/java/com/team3/monew/component/news/collect/NaverNewsCollect.java
+++ b/src/main/java/com/team3/monew/component/news/collect/NaverNewsCollect.java
@@ -4,13 +4,16 @@ import com.team3.monew.component.news.parse.NewsParser;
 import com.team3.monew.component.news.record.ParsedData;
 import com.team3.monew.component.news.record.RawArticleResult;
 import com.team3.monew.config.NaverProperties;
+import com.team3.monew.entity.InterestKeyword;
 import com.team3.monew.entity.enums.NewsSourceType;
 import com.team3.monew.exception.news.NewsClientException;
 import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -47,46 +50,51 @@ public class NaverNewsCollect implements NewsCollect {
 
   @Override
   public Flux<ParsedData> collect(WebClient webClient, NewsSourceType sourceType,
-      Set<String> keywords) {
+      Collection<InterestKeyword> interestKeywords) {
 
-    return Flux.fromIterable(keywords)
-        .flatMap(keyword ->
-                fetchNewsData(webClient, keyword, 1)
-                    .flatMap(raw -> {
-                      ParsedData parsedData = newsParser.parse(sourceType, raw);
-                      return parsedData.isEmpty() ? Mono.empty() : Mono.just(parsedData);
-                    })
-                    // 재귀 확장용
-                    .expand(data -> {
-                      // 파싱 오류로 나온 빈값 검사
-                      if (data.articles().isEmpty()) {
-                        return Mono.empty();
-                      }
+    return Flux.fromIterable(interestKeywords)
+        .flatMap(interestKeyword -> {
+              String keyword = resolveKeyword(interestKeyword);
 
-                      // 키워드의 첫 다운로드면 통과
-                      if (!lastCollectedAt.containsKey(keyword)) {
-                        lastCollectedAt.put(keyword, data.lastBuildDate());
-                        log.info("Naver 뉴스기사 collect 성공 - keyword={}", keyword);
-                        return Mono.empty();
-                      }
-
-                      Instant lastPublishedAt = data.articles().get(data.articles().size() - 1)
-                          .publishedAt();
-                      // API 호출시간이 마지막 기사 발행시간보다 과거거나
-                      // 같다면 재귀호출(네이버는 기사발행시간이 분단위로 절삭되어 비교해야 함)
-                      if (lastCollectedAt.get(keyword).isBefore(lastPublishedAt)
-                          || lastCollectedAt.get(keyword).equals(lastPublishedAt)) {
-                        log.debug("{}번째 페이지 요청", data.page() + 1);
-                        return fetchNewsData(webClient, keyword, data.page() + 1)
-                            .map(raw -> newsParser.parse(sourceType, raw))
-                            .filter(nextData -> !nextData.articles().isEmpty());
-                      }
-
-                      // API 호출시간이 기사 리스트 안쪽에 포함되어있다면, 즉 이미 봤다고 가정하면
-                      lastCollectedAt.put(keyword, data.lastBuildDate());
-                      log.info("Naver 뉴스기사 collect 성공 - keyword={}", keyword);
+              return fetchNewsData(webClient, keyword, 1)
+                  .flatMap(raw -> {
+                    ParsedData parsedData = newsParser.parse(sourceType, raw);
+                    return parsedData.isEmpty() ? Mono.empty() : Mono.just(parsedData);
+                  })
+                  // 재귀 확장용
+                  .expand(data -> {
+                    // 파싱 오류로 나온 빈값 검사
+                    if (data.articles().isEmpty()) {
                       return Mono.empty();
-                    })
+                    }
+
+                    // 키워드의 첫 다운로드면 통과
+                    if (!lastCollectedAt.containsKey(keyword)) {
+                      lastCollectedAt.put(keyword, data.lastBuildDate());
+                      log.info("Naver 뉴스기사 collect 성공 - interest={}, keyword={}",
+                          interestKeyword.getInterest().getName(), interestKeyword.getKeyword());
+                      return Mono.empty();
+                    }
+
+                    Instant lastPublishedAt = data.articles().get(data.articles().size() - 1)
+                        .publishedAt();
+                    // API 호출시간이 마지막 기사 발행시간보다 과거거나
+                    // 같다면 재귀호출(네이버는 기사발행시간이 분단위로 절삭되어 비교해야 함)
+                    if (lastCollectedAt.get(keyword).isBefore(lastPublishedAt) ||
+                        lastCollectedAt.get(keyword).equals(lastPublishedAt)) {
+                      log.debug("{}번째 페이지 요청", data.page() + 1);
+                      return fetchNewsData(webClient, keyword, data.page() + 1)
+                          .map(raw -> newsParser.parse(sourceType, raw))
+                          .filter(nextData -> !nextData.articles().isEmpty());
+                    }
+
+                    // API 호출시간이 기사 리스트 안쪽에 포함되어있다면, 즉 이미 봤다고 가정하면
+                    lastCollectedAt.put(keyword, data.lastBuildDate());
+                    log.info("Naver 뉴스기사 collect 성공 - interest={}, keyword={}",
+                        interestKeyword.getInterest().getName(), interestKeyword.getKeyword());
+                    return Mono.empty();
+                  });
+            }
             , NAVER_CONCURRENCY_SIZE); // 동시성 제한
 
   }
@@ -130,12 +138,25 @@ public class NaverNewsCollect implements NewsCollect {
             )
         )
         .onErrorResume(e -> {
-          log.error("Naver 기사 수집 실패: keyword={}, error={}", keyword, e.getMessage());
+          List<String> interestKeyword = splitKeyword(keyword);
+          log.error("Naver 기사 수집 실패: interest={}, keyword={}, error={}",
+              interestKeyword.get(0), interestKeyword.get(1), e.getMessage());
           return Mono.empty();
         })
         .map(rawData -> {
-          log.info("Naver 뉴스기사 rawData 받기 성공 - keyword={}, page={}", keyword, page);
+          List<String> interestKeyword = splitKeyword(keyword);
+          log.info("Naver 뉴스기사 rawData 받기 성공 - interest={}, keyword={}, page={}",
+              interestKeyword.get(0), interestKeyword.get(1), page);
           return new RawArticleResult(rawData, keyword, page);
         });
+  }
+
+  private String resolveKeyword(InterestKeyword interestKeyword) {
+    return String.format("%s %s",
+        interestKeyword.getInterest().getName(), interestKeyword.getKeyword());
+  }
+
+  private List<String> splitKeyword(String combinedKeyword) {
+    return Arrays.stream(combinedKeyword.split(" ")).toList();
   }
 }

--- a/src/main/java/com/team3/monew/component/news/collect/NewsCollect.java
+++ b/src/main/java/com/team3/monew/component/news/collect/NewsCollect.java
@@ -1,12 +1,14 @@
 package com.team3.monew.component.news.collect;
 
 import com.team3.monew.component.news.record.ParsedData;
+import com.team3.monew.entity.InterestKeyword;
 import com.team3.monew.entity.enums.NewsSourceType;
-import java.util.Set;
+import java.util.Collection;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 
 public interface NewsCollect {
 
-  Flux<ParsedData> collect(WebClient webClient, NewsSourceType sourceType, Set<String> keywords);
+  Flux<ParsedData> collect(WebClient webClient, NewsSourceType sourceType,
+      Collection<InterestKeyword> interestKeywords);
 }

--- a/src/main/java/com/team3/monew/component/news/collect/NewsCollector.java
+++ b/src/main/java/com/team3/monew/component/news/collect/NewsCollector.java
@@ -1,14 +1,15 @@
 package com.team3.monew.component.news.collect;
 
 import com.team3.monew.component.news.record.ParsedData;
+import com.team3.monew.entity.InterestKeyword;
 import com.team3.monew.entity.enums.NewsSourceType;
 import com.team3.monew.exception.news.NewsIllegalBeanException;
 import io.netty.channel.ChannelOption;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.handler.timeout.WriteTimeoutHandler;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Map;
-import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.stereotype.Component;
@@ -41,7 +42,8 @@ public class NewsCollector {
   }
 
 
-  public Flux<ParsedData> collectRawNews(NewsSourceType sourceType, Set<String> keywords) {
+  public Flux<ParsedData> collectRawNews(NewsSourceType sourceType,
+      Collection<InterestKeyword> interestKeywords) {
     String beanName = sourceType.name().toLowerCase() + "NewsCollect";
     NewsCollect collector = newsCollect.get(beanName);
     if (collector == null) {
@@ -49,6 +51,6 @@ public class NewsCollector {
     }
 
     log.debug("NewsCollector: {} 시작", beanName);
-    return collector.collect(webClient, sourceType, keywords);
+    return collector.collect(webClient, sourceType, interestKeywords);
   }
 }

--- a/src/main/java/com/team3/monew/component/news/filter/NewsFilter.java
+++ b/src/main/java/com/team3/monew/component/news/filter/NewsFilter.java
@@ -2,7 +2,10 @@ package com.team3.monew.component.news.filter;
 
 import com.team3.monew.component.news.record.ParsedData;
 import com.team3.monew.component.news.record.ParsedNewsArticle;
+import com.team3.monew.entity.InterestKeyword;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -17,20 +20,37 @@ public class NewsFilter {
 
   private final KeywordMatch keywordMatch;
 
-  public List<ParsedNewsArticle> filterKeyword(ParsedData parsedData) {
+  public List<ParsedNewsArticle> filterKeyword(ParsedData parsedData,
+      Collection<InterestKeyword> interestKeywords) {
+
+    // 관심사별 묶기
+    Map<String, List<InterestKeyword>> interestMap = interestKeywords.stream()
+        .collect(Collectors.groupingBy(ik -> ik.getInterest().getName()));
+
     List<ParsedNewsArticle> parsedNewsArticles = parsedData.articles().stream()
-        .map(article -> {
+        .filter(article -> {
+
           Set<String> matchedKeywords = Stream.of(
                   keywordMatch.findMatches(article.title()),
                   keywordMatch.findMatches(article.summary()))
               .flatMap(List::stream)
               .collect(Collectors.toSet());
 
-          // set에 데이터가 있어서 article에 저장되면 true
-          article.keywords().addAll(matchedKeywords);
-          return article;
+          boolean isMatched = false;
+          // 관심사 비교
+          for (String interestName : interestMap.keySet()) {
+            if (matchedKeywords.contains(interestName)) {
+              // 키워드 비교
+              for (InterestKeyword ik : interestMap.get(interestName)) {
+                if (matchedKeywords.contains(ik.getKeyword())) {
+                  article.interestKeywords().add(ik);
+                  isMatched = true;
+                }
+              }
+            }
+          }
+          return isMatched;
         })
-        .filter(article -> !article.keywords().isEmpty())
         .toList();
 
     log.info("{} 기사 filter 처리 결과 - beforeSize={}, afterSize={}",

--- a/src/main/java/com/team3/monew/component/news/filter/NewsFilter.java
+++ b/src/main/java/com/team3/monew/component/news/filter/NewsFilter.java
@@ -5,6 +5,7 @@ import com.team3.monew.component.news.record.ParsedNewsArticle;
 import com.team3.monew.entity.InterestKeyword;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -34,15 +35,17 @@ public class NewsFilter {
                   keywordMatch.findMatches(article.title()),
                   keywordMatch.findMatches(article.summary()))
               .flatMap(List::stream)
+              // 매칭되도 반환값이 기사 원문이라 놓칠 가능성이 있어서 반환값을 전부 소문자 형태로 변경
+              .map(keyword -> keyword.toLowerCase(Locale.ROOT))
               .collect(Collectors.toSet());
 
           boolean isMatched = false;
-          // 관심사 비교
+          // 관심사 비교. 비교 대상의 키워드도 전부 소문자로 변경
           for (String interestName : interestMap.keySet()) {
-            if (matchedKeywords.contains(interestName)) {
+            if (matchedKeywords.contains(interestName.toLowerCase(Locale.ROOT))) {
               // 키워드 비교
               for (InterestKeyword ik : interestMap.get(interestName)) {
-                if (matchedKeywords.contains(ik.getKeyword())) {
+                if (matchedKeywords.contains(ik.getKeyword().toLowerCase(Locale.ROOT))) {
                   article.interestKeywords().add(ik);
                   isMatched = true;
                 }

--- a/src/main/java/com/team3/monew/component/news/parse/ChosunNewsParse.java
+++ b/src/main/java/com/team3/monew/component/news/parse/ChosunNewsParse.java
@@ -43,7 +43,7 @@ public class ChosunNewsParse implements NewsParse {
               sourceType,
               item.link(),
               item.title(),
-              Optional.of(item.pubDate()).orElse(Instant.now()),
+              Optional.ofNullable(item.pubDate()).orElse(Instant.now()),
               item.description(),
               new ArrayList<>()))
           // 발행시간 역순 정렬

--- a/src/main/java/com/team3/monew/component/news/parse/ChosunNewsParse.java
+++ b/src/main/java/com/team3/monew/component/news/parse/ChosunNewsParse.java
@@ -43,7 +43,7 @@ public class ChosunNewsParse implements NewsParse {
               sourceType,
               item.link(),
               item.title(),
-              item.pubDate(),
+              Optional.of(item.pubDate()).orElse(Instant.now()),
               item.description(),
               new ArrayList<>()))
           // 발행시간 역순 정렬

--- a/src/main/java/com/team3/monew/component/news/parse/NaverNewsParse.java
+++ b/src/main/java/com/team3/monew/component/news/parse/NaverNewsParse.java
@@ -42,7 +42,7 @@ public class NaverNewsParse implements NewsParse {
               sourceType,
               item.link(),
               item.title(),
-              Optional.of(item.pubDate()).orElse(Instant.now()),
+              Optional.ofNullable(item.pubDate()).orElse(Instant.now()),
               item.description(),
               new ArrayList<>()))
           // 발행시간 역순 정렬

--- a/src/main/java/com/team3/monew/component/news/parse/NaverNewsParse.java
+++ b/src/main/java/com/team3/monew/component/news/parse/NaverNewsParse.java
@@ -42,7 +42,7 @@ public class NaverNewsParse implements NewsParse {
               sourceType,
               item.link(),
               item.title(),
-              item.pubDate(),
+              Optional.of(item.pubDate()).orElse(Instant.now()),
               item.description(),
               new ArrayList<>()))
           // 발행시간 역순 정렬

--- a/src/main/java/com/team3/monew/component/news/record/ParsedNewsArticle.java
+++ b/src/main/java/com/team3/monew/component/news/record/ParsedNewsArticle.java
@@ -3,6 +3,7 @@ package com.team3.monew.component.news.record;
 import com.team3.monew.entity.InterestKeyword;
 import com.team3.monew.entity.enums.NewsSourceType;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 
 public record ParsedNewsArticle(NewsSourceType sourceType,
@@ -12,4 +13,9 @@ public record ParsedNewsArticle(NewsSourceType sourceType,
                                 String summary,
                                 List<InterestKeyword> interestKeywords) {
 
+  public ParsedNewsArticle {
+    interestKeywords = interestKeywords == null
+        ? new ArrayList<>()
+        : new ArrayList<>(interestKeywords);
+  }
 }

--- a/src/main/java/com/team3/monew/component/news/record/ParsedNewsArticle.java
+++ b/src/main/java/com/team3/monew/component/news/record/ParsedNewsArticle.java
@@ -1,5 +1,6 @@
 package com.team3.monew.component.news.record;
 
+import com.team3.monew.entity.InterestKeyword;
 import com.team3.monew.entity.enums.NewsSourceType;
 import java.time.Instant;
 import java.util.List;
@@ -9,6 +10,6 @@ public record ParsedNewsArticle(NewsSourceType sourceType,
                                 String title,
                                 Instant publishedAt,
                                 String summary,
-                                List<String> keywords) {
+                                List<InterestKeyword> interestKeywords) {
 
 }

--- a/src/main/java/com/team3/monew/entity/ArticleInterest.java
+++ b/src/main/java/com/team3/monew/entity/ArticleInterest.java
@@ -32,7 +32,7 @@ public class ArticleInterest {
   @JoinColumn(name = "interest_id", nullable = false)
   private Interest interest;
 
-  @Column(length = 100)
+  @Column(length = 100, nullable = false)
   private String matchedKeyword;
 
   @Column(nullable = false)

--- a/src/main/java/com/team3/monew/entity/ArticleInterest.java
+++ b/src/main/java/com/team3/monew/entity/ArticleInterest.java
@@ -9,40 +9,46 @@ import java.time.Instant;
 import java.util.UUID;
 
 @Entity
-@Table(name = "article_interests")
+@Table(
+    name = "article_interests",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_article_interests_article_id_interest_id_matched_keyword",
+            columnNames = {"article_id", "interest_id", "matched_keyword"})
+    }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ArticleInterest {
 
-    @Id
-    @GeneratedValue
-    private UUID id;
+  @Id
+  @GeneratedValue
+  private UUID id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "article_id", nullable = false)
-    private NewsArticle article;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "article_id", nullable = false)
+  private NewsArticle article;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "interest_id", nullable = false)
-    private Interest interest;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "interest_id", nullable = false)
+  private Interest interest;
 
-    @Column(length = 100)
-    private String matchedKeyword;
+  @Column(length = 100)
+  private String matchedKeyword;
 
-    @Column(nullable = false)
-    private Instant createdAt;
+  @Column(nullable = false)
+  private Instant createdAt;
 
-    public static ArticleInterest create(
-            NewsArticle article,
-            Interest interest,
-            String matchedKeyword
-    ) {
-        ArticleInterest articleInterest = new ArticleInterest();
-        articleInterest.article = article;
-        articleInterest.interest = interest;
-        articleInterest.matchedKeyword = matchedKeyword;
-        articleInterest.createdAt = Instant.now();
+  public static ArticleInterest create(
+      NewsArticle article,
+      Interest interest,
+      String matchedKeyword
+  ) {
+    ArticleInterest articleInterest = new ArticleInterest();
+    articleInterest.article = article;
+    articleInterest.interest = interest;
+    articleInterest.matchedKeyword = matchedKeyword;
+    articleInterest.createdAt = Instant.now();
 
-        return articleInterest;
-    }
+    return articleInterest;
+  }
 }

--- a/src/main/java/com/team3/monew/entity/ArticleInterest.java
+++ b/src/main/java/com/team3/monew/entity/ArticleInterest.java
@@ -9,12 +9,7 @@ import java.time.Instant;
 import java.util.UUID;
 
 @Entity
-@Table(
-        name = "article_interests",
-        uniqueConstraints = {
-                @UniqueConstraint(name = "uk_article_interests_article_id_interest_id", columnNames = {"article_id", "interest_id"})
-        }
-)
+@Table(name = "article_interests")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ArticleInterest {

--- a/src/main/java/com/team3/monew/entity/NewsArticle.java
+++ b/src/main/java/com/team3/monew/entity/NewsArticle.java
@@ -1,14 +1,20 @@
 package com.team3.monew.entity;
 
 import com.team3.monew.entity.base.SoftDeleteEntity;
-import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "news_articles")
@@ -16,54 +22,60 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NewsArticle extends SoftDeleteEntity {
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "source_id", nullable = false)
-    private NewsSource source;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "source_id", nullable = false)
+  private NewsSource source;
 
-    @Column(name = "original_link", nullable = false, unique = true, length = 1000)
-    private String originalLink;
+  @Column(name = "original_link", nullable = false, unique = true, length = 1000)
+  private String originalLink;
 
-    @Column(nullable = false, length = 500)
-    private String title;
+  @Column(nullable = false, length = 500)
+  private String title;
 
-    @Column(nullable = false)
-    private Instant publishedAt;
+  @Column(nullable = false)
+  private Instant publishedAt;
 
-    @Column(length = 1000)
-    private String summary;
+  @Column(length = 1000)
+  private String summary;
 
-    @Column(nullable = false)
-    private int commentCount;
+  @Column(nullable = false)
+  private int commentCount;
 
-    @Column(nullable = false)
-    private int viewCount;
+  @Column(nullable = false)
+  private int viewCount;
 
-    @OneToMany(mappedBy = "article")
-    private List<Comment> comments = new ArrayList<>();
+  @OneToMany(mappedBy = "article")
+  private List<Comment> comments = new ArrayList<>();
 
-    @OneToMany(mappedBy = "article")
-    private List<ArticleInterest> articleInterests = new ArrayList<>();
+  @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<ArticleInterest> articleInterests = new ArrayList<>();
 
-    @OneToMany(mappedBy = "article")
-    private List<ArticleView> articleViews = new ArrayList<>();
+  @OneToMany(mappedBy = "article")
+  private List<ArticleView> articleViews = new ArrayList<>();
 
-    public static NewsArticle create(
-            NewsSource source,
-            String originalLink,
-            String title,
-            Instant publishedAt,
-            String summary
-    ) {
-        NewsArticle article = new NewsArticle();
-        article.source = source;
-        article.originalLink = originalLink;
-        article.title = title;
-        article.publishedAt = publishedAt;
-        article.summary = summary;
-        article.commentCount = 0;
-        article.viewCount = 0;
+  public static NewsArticle create(
+      NewsSource source,
+      String originalLink,
+      String title,
+      Instant publishedAt,
+      String summary
+  ) {
+    NewsArticle article = new NewsArticle();
+    article.source = source;
+    article.originalLink = originalLink;
+    article.title = title;
+    article.publishedAt = publishedAt;
+    article.summary = summary;
+    article.commentCount = 0;
+    article.viewCount = 0;
 
-        return article;
-    }
+    return article;
+  }
 
+  // 편의 메소드로 한번에 Article와 Interest에 각각 저장한다
+  public void addArticleInterest(Interest interest, String matchedKeyword) {
+    ArticleInterest articleInterest = ArticleInterest.create(this, interest, matchedKeyword);
+    articleInterests.add(articleInterest);
+    interest.getArticleInterests().add(articleInterest);
+  }
 }

--- a/src/main/java/com/team3/monew/repository/InterestKeywordRepository.java
+++ b/src/main/java/com/team3/monew/repository/InterestKeywordRepository.java
@@ -4,8 +4,12 @@ import com.team3.monew.entity.InterestKeyword;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface InterestKeywordRepository extends JpaRepository<InterestKeyword, UUID> {
 
   List<InterestKeyword> findAllByInterestId(UUID interestId);
+
+  @Query("SELECT ik FROM InterestKeyword ik JOIN FETCH ik.interest")
+  List<InterestKeyword> findAllWithInterest();
 }

--- a/src/main/java/com/team3/monew/repository/NewsArticleRepository.java
+++ b/src/main/java/com/team3/monew/repository/NewsArticleRepository.java
@@ -2,6 +2,7 @@ package com.team3.monew.repository;
 
 import com.team3.monew.entity.NewsArticle;
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -30,4 +31,7 @@ public interface NewsArticleRepository extends JpaRepository<NewsArticle, UUID> 
       AND article.originalLink IN :originalLinks
       """)
   Set<String> findExistingOriginalLinks(@Param("originalLinks") Collection<String> originalLinks);
+
+  @Query("SELECT article FROM NewsArticle article JOIN FETCH article.source")
+  List<NewsArticle> findAllWithNewsSource();
 }

--- a/src/main/java/com/team3/monew/repository/NewsArticleRepository.java
+++ b/src/main/java/com/team3/monew/repository/NewsArticleRepository.java
@@ -1,7 +1,6 @@
 package com.team3.monew.repository;
 
 import com.team3.monew.entity.NewsArticle;
-import java.time.Instant;
 import java.util.Collection;
 import java.util.Set;
 import java.util.UUID;
@@ -28,10 +27,7 @@ public interface NewsArticleRepository extends JpaRepository<NewsArticle, UUID> 
   @Query("""
       SELECT article.originalLink FROM NewsArticle article
       WHERE article.deleteStatus = com.team3.monew.entity.enums.DeleteStatus.ACTIVE
-      AND article.publishedAt >= :since
       AND article.originalLink IN :originalLinks
       """)
-  Set<String> findExistingOriginalLinks(
-      @Param("since") Instant since,
-      @Param("originalLinks") Collection<String> originalLinks);
+  Set<String> findExistingOriginalLinks(@Param("originalLinks") Collection<String> originalLinks);
 }

--- a/src/main/java/com/team3/monew/repository/NewsArticleRepository.java
+++ b/src/main/java/com/team3/monew/repository/NewsArticleRepository.java
@@ -1,6 +1,7 @@
 package com.team3.monew.repository;
 
 import com.team3.monew.entity.NewsArticle;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Set;
 import java.util.UUID;
@@ -24,6 +25,13 @@ public interface NewsArticleRepository extends JpaRepository<NewsArticle, UUID> 
       """)
   void decrementCommentCountById(@Param("articleId") UUID articleId);
 
-  @Query("SELECT article.originalLink FROM NewsArticle article WHERE article.originalLink IN :originalLinks")
-  Set<String> findExistingOriginalLinks(@Param("originalLinks") Collection<String> originalLinks);
+  @Query("""
+      SELECT article.originalLink FROM NewsArticle article
+      WHERE article.deleteStatus = com.team3.monew.entity.enums.DeleteStatus.ACTIVE
+      AND article.publishedAt >= :since
+      AND article.originalLink IN :originalLinks
+      """)
+  Set<String> findExistingOriginalLinks(
+      @Param("since") Instant since,
+      @Param("originalLinks") Collection<String> originalLinks);
 }

--- a/src/main/java/com/team3/monew/service/NewsCollectService.java
+++ b/src/main/java/com/team3/monew/service/NewsCollectService.java
@@ -6,11 +6,12 @@ import com.team3.monew.component.news.record.ParsedNewsArticle;
 import com.team3.monew.entity.InterestKeyword;
 import com.team3.monew.entity.enums.NewsSourceType;
 import com.team3.monew.repository.InterestKeywordRepository;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -37,38 +38,41 @@ public class NewsCollectService {
   }
 
   public Mono<Void> executeNewsCollection() {
-    AtomicLong startTime = new AtomicLong();
-    startTime.set(System.currentTimeMillis());
+    long startTime = System.currentTimeMillis();
     log.debug("뉴스 기사 수집 시작");
 
-    // 키워드를 기준으로 관심사 묶기
-    Map<String, List<InterestKeyword>> keywordInterests = interestKeywordRepository.findAll()
-        .stream()
-        .collect(Collectors.groupingBy(
-            InterestKeyword::getKeyword,    // keyword가 key
-            Collectors.toList()             // keyword를 갖는 관심사 리스트
-        ));
+    return Mono.fromCallable(() -> {
+          // join쓰는 고비용 작업은 boundedElastic 스레드
+          List<InterestKeyword> interestKeywordList = interestKeywordRepository.findAllWithInterest();
 
-    // 키워드 세팅
-    Set<String> keywords = keywordInterests.keySet();
-    keywordMatch.refreshKeywords(keywords);
+          // 관심사와, 키워드를 하나로 묶기
+          Set<String> keywords = interestKeywordList.stream()
+              .flatMap(ik -> Stream.of(ik.getInterest().getName(), ik.getKeyword()))
+              .collect(Collectors.toSet());
+          keywordMatch.refreshKeywords(keywords);
 
-    return Flux.fromIterable(newsClients.values())
-        // 수집, 파싱, 필터까지 수행, NewsSources 개수만큼 동시성 수행
-        .flatMap(client -> client.fetchAndProcess(keywords), newsClients.size())
-        .flatMapIterable(list -> list)
-        .collectList()                            // 여러개의 NewsSource 결과값을 하나로 합침
-        .map(this::deduplicateByLinkWithNaverPriority)
-        .publishOn(Schedulers.boundedElastic())   // 동기저장을 위한 전용 스레드 플로 넘기기
-        .map(newsSaveService::save)
-        .publishOn(Schedulers.parallel())         // 다시 원래 스레드로 복구
-        .doOnSuccess(result ->
-            log.info("뉴스 기사 수집 종료: {}ms", System.currentTimeMillis() - startTime.get()))
-//        .map(k -> 저장된 데이터 알람처리)
-        .then();
+          return interestKeywordList;
+        })
+        .subscribeOn(
+            Schedulers.boundedElastic())   // 위쪽 fromCallable 함수가 boundedElastic 스레드에서 돌아가게 진행
+        // Mono(단일 데이터) -> Flux(n개 데이터)
+        .flatMapMany(interestKeywords ->
+            Flux.fromIterable(newsClients.values())
+                // 수집, 파싱, 필터까지 수행, NewsSources 개수만큼 동시성 수행
+                .flatMap(client -> client.fetchAndProcess(interestKeywords), newsClients.size())
+                .flatMapIterable(list -> list)
+                .collectList()                            // 여러개의 NewsSource 결과값을 하나로 합침
+                .map(this::deduplicateByLinkWithNaverPriorityAndOrderByPublishAtDesc)
+                .publishOn(Schedulers.boundedElastic())   // 동기저장을 위한 전용 스레드 플로 넘기기
+                .map(newsSaveService::saveAndNotify)
+                .publishOn(Schedulers.parallel())         // 다시 원래 스레드로 복구
+                .doOnSuccess(unused ->
+                    log.info("뉴스 기사 수집 종료: {}ms", System.currentTimeMillis() - startTime))
+        ).then();
   }
 
-  private List<ParsedNewsArticle> deduplicateByLinkWithNaverPriority(List<ParsedNewsArticle> list) {
+  private List<ParsedNewsArticle> deduplicateByLinkWithNaverPriorityAndOrderByPublishAtDesc(
+      List<ParsedNewsArticle> list) {
     return list.stream()
         .collect(Collectors.toMap(
             ParsedNewsArticle::link,               //   key: link
@@ -81,6 +85,7 @@ public class NewsCollectService {
         ))
         .values()
         .stream()
+        .sorted(Comparator.comparing(ParsedNewsArticle::publishedAt).reversed())
         .toList();
   }
 }

--- a/src/main/java/com/team3/monew/service/NewsSaveService.java
+++ b/src/main/java/com/team3/monew/service/NewsSaveService.java
@@ -1,6 +1,5 @@
 package com.team3.monew.service;
 
-import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toSet;
 
 import com.team3.monew.component.news.record.ParsedNewsArticle;
@@ -48,8 +47,7 @@ public class NewsSaveService {
     // 새로운 뉴스 Link
     List<String> links = data.stream().map(ParsedNewsArticle::link).toList();
     // repository에 이미 저장된 뉴스 Link
-    Set<String> existingLinks = newsArticleRepository.findExistingOriginalLinks(
-        data.get(data.size() - 1).publishedAt(), links);    // data는 발행일자 역순정렬됨
+    Set<String> existingLinks = newsArticleRepository.findExistingOriginalLinks(links);
 
     // 중복이 걸러진 뉴스기사
     List<ParsedNewsArticle> newNewsArticles = data.stream()
@@ -90,14 +88,6 @@ public class NewsSaveService {
     // Repository에 데이터 저장
     newsArticleRepository.saveAll(savedArticles);
     log.info("뉴스 기사 저장 완료 - articleSize={}", savedArticles.size());
-
-    // 기사별 관심사
-    Map<String, Set<Interest>> InterestsByArticle = savedArticles.stream()
-        .flatMap(article -> article.getArticleInterests().stream())
-        .collect(Collectors.groupingBy(
-            ai -> ai.getArticle().getOriginalLink(),
-            mapping(ArticleInterest::getInterest, toSet())
-        ));
 
     // 관심사별 기사 갯수
     Map<Interest, Integer> articlesByInterest = savedArticles.stream()

--- a/src/main/java/com/team3/monew/service/NewsSaveService.java
+++ b/src/main/java/com/team3/monew/service/NewsSaveService.java
@@ -1,17 +1,28 @@
 package com.team3.monew.service;
 
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toSet;
+
 import com.team3.monew.component.news.record.ParsedNewsArticle;
+import com.team3.monew.entity.ArticleInterest;
+import com.team3.monew.entity.Interest;
 import com.team3.monew.entity.NewsArticle;
 import com.team3.monew.entity.NewsSource;
+import com.team3.monew.entity.base.BaseEntity;
 import com.team3.monew.entity.enums.NewsSourceType;
+import com.team3.monew.event.InterestNotificationEvent;
+import com.team3.monew.event.InterestNotificationEvent.InterestArticleSummary;
+import com.team3.monew.repository.InterestRepository;
 import com.team3.monew.repository.NewsArticleRepository;
 import com.team3.monew.repository.NewsSourceRepository;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,21 +31,25 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class NewsSaveService {
 
+  private final ApplicationEventPublisher eventPublisher;
   private final NewsArticleRepository newsArticleRepository;
   private final NewsSourceRepository newsSourceRepository;
+  private final InterestRepository interestRepository;
 
   @Transactional
-  public List<ParsedNewsArticle> save(List<ParsedNewsArticle> data) {
+  public List<NewsArticle> saveAndNotify(List<ParsedNewsArticle> data) {
 
     log.debug("뉴스 기사 저장 시작");
-    // 새로운 뉴스 Link
-    List<String> newNewsArticleLinks = data.stream()
-        .map(ParsedNewsArticle::link)
-        .toList();
+    if (data.isEmpty()) {
+      log.info("뉴스 기사 저장 스킵 - 저장할 데이터가 없습니다. articleSize=0");
+      return List.of();
+    }
 
+    // 새로운 뉴스 Link
+    List<String> links = data.stream().map(ParsedNewsArticle::link).toList();
     // repository에 이미 저장된 뉴스 Link
     Set<String> existingLinks = newsArticleRepository.findExistingOriginalLinks(
-        newNewsArticleLinks);
+        data.get(data.size() - 1).publishedAt(), links);    // data는 발행일자 역순정렬됨
 
     // 중복이 걸러진 뉴스기사
     List<ParsedNewsArticle> newNewsArticles = data.stream()
@@ -47,24 +62,64 @@ public class NewsSaveService {
     }
 
     // NewsSource 타입
-    Map<NewsSourceType, NewsSource> newsSources = newsSourceRepository.findAll().stream()
-        .collect(Collectors.toMap(
-            NewsSource::getSourceType,
-            source -> source
-        ));
+    Map<NewsSourceType, NewsSource> sourceMap = newsSourceRepository.findAll().stream()
+        .collect(Collectors.toMap(NewsSource::getSourceType, s -> s));
+
+    // 양방향 편의 메소드 저장을 위해 불러오는 Interest
+    Map<String, Interest> interestMap = interestRepository.findAll().stream()
+        .collect(Collectors.toMap(Interest::getName, i -> i));
 
     // Repository에 저장하기 위한 데이터 변환
-    List<NewsArticle> articleToSave = newNewsArticles.stream()
-        .map(raw ->
-            NewsArticle.create(newsSources.get(raw.sourceType()),
-                raw.link(), raw.title(), raw.publishedAt(), raw.summary()))
+    List<NewsArticle> savedArticles = newNewsArticles.stream()
+        .map(parsed -> {
+          // NewsArticle 생성
+          NewsArticle article = NewsArticle.create(sourceMap.get(parsed.sourceType()),
+              parsed.link(), parsed.title(), parsed.publishedAt(), parsed.summary());
+
+          // ArticleInterest 생성
+          parsed.interestKeywords().forEach(ik -> {
+            Interest interest = interestMap.get(ik.getInterest().getName());
+            if (interest != null) {
+              article.addArticleInterest(interest, ik.getKeyword());
+            }
+          });
+
+          return article;
+        })
         .toList();
-
     // Repository에 데이터 저장
-    newsArticleRepository.saveAll(articleToSave);
+    newsArticleRepository.saveAll(savedArticles);
+    log.info("뉴스 기사 저장 완료 - articleSize={}", savedArticles.size());
 
-    log.info("뉴스 기사 저장 완료 - articleSize={}", articleToSave.size());
-    // 저장된 뉴스의 원본 반환
-    return newNewsArticles;
+    // 기사별 관심사
+    Map<String, Set<Interest>> InterestsByArticle = savedArticles.stream()
+        .flatMap(article -> article.getArticleInterests().stream())
+        .collect(Collectors.groupingBy(
+            ai -> ai.getArticle().getOriginalLink(),
+            mapping(ArticleInterest::getInterest, toSet())
+        ));
+
+    // 관심사별 기사 갯수
+    Map<Interest, Integer> articlesByInterest = savedArticles.stream()
+        .flatMap(article -> article.getArticleInterests().stream())
+        .collect(Collectors.groupingBy(
+            ArticleInterest::getInterest,
+            Collectors.collectingAndThen(
+                Collectors.mapping(ArticleInterest::getArticle, toSet()), Set::size
+            )
+        ));
+
+    // 관심사ID, (관심사 이름, 기사 갯수)
+    Map<UUID, InterestArticleSummary> interestArticleSummaryMap = articlesByInterest.keySet()
+        .stream()
+        .collect(Collectors.toMap(
+            BaseEntity::getId,
+            i -> new InterestArticleSummary(i.getName(), articlesByInterest.get(i))
+        ));
+
+    eventPublisher.publishEvent(new InterestNotificationEvent(interestArticleSummaryMap));
+
+    // 비동기 스트리밍 처리때문에 반환값이 필요하여 그냥 아무값이나 보냅니다
+    return savedArticles;
   }
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -146,7 +146,10 @@ CREATE TABLE article_interests (
                                        FOREIGN KEY (article_id) REFERENCES news_articles(id) ON DELETE CASCADE,
 
                                    CONSTRAINT fk_article_interests_interest_id
-                                       FOREIGN KEY (interest_id) REFERENCES interests(id) ON DELETE CASCADE
+                                       FOREIGN KEY (interest_id) REFERENCES interests(id) ON DELETE CASCADE,
+
+                                   CONSTRAINT uk_article_interests_article_id_interest_id_matched_keyword
+                                       UNIQUE (article_id, interest_id, matched_keyword)
 );
 
 CREATE TABLE article_views (

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -146,10 +146,7 @@ CREATE TABLE article_interests (
                                        FOREIGN KEY (article_id) REFERENCES news_articles(id) ON DELETE CASCADE,
 
                                    CONSTRAINT fk_article_interests_interest_id
-                                       FOREIGN KEY (interest_id) REFERENCES interests(id) ON DELETE CASCADE,
-
-                                   CONSTRAINT uk_article_interests_article_id_interest_id
-                                       UNIQUE (article_id, interest_id)
+                                       FOREIGN KEY (interest_id) REFERENCES interests(id) ON DELETE CASCADE
 );
 
 CREATE TABLE article_views (

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -138,7 +138,7 @@ CREATE TABLE article_interests (
                                    id UUID PRIMARY KEY,
                                    article_id UUID NOT NULL,
                                    interest_id UUID NOT NULL,
-                                   matched_keyword VARCHAR(100),
+                                   matched_keyword VARCHAR(100) NOT NULL,
 
                                    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
 

--- a/src/test/java/com/team3/monew/component/news/client/ChosunNewsClientTest.java
+++ b/src/test/java/com/team3/monew/component/news/client/ChosunNewsClientTest.java
@@ -1,14 +1,19 @@
 package com.team3.monew.component.news.client;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 
 import com.team3.monew.component.news.collect.NewsCollector;
 import com.team3.monew.component.news.filter.NewsFilter;
 import com.team3.monew.component.news.record.ParsedData;
 import com.team3.monew.component.news.record.ParsedNewsArticle;
+import com.team3.monew.entity.Interest;
+import com.team3.monew.entity.InterestKeyword;
+import com.team3.monew.entity.enums.NewsSourceType;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -31,6 +36,34 @@ class ChosunNewsClientTest {
   @InjectMocks
   private ChosunNewsClient chosunNewsClient;
 
+  private Interest samsungInterest;
+  private InterestKeyword samsungKeyword;
+  private List<InterestKeyword> samsungKeywordList;
+
+  private Interest appleInterest;
+  private InterestKeyword appleKeyword;
+  private List<InterestKeyword> appleKeywordList;
+
+  private ParsedNewsArticle samsungArticle;
+  private ParsedNewsArticle appleArticle;
+
+
+  @BeforeEach
+  void setUp() {
+    samsungInterest = Interest.create("삼성");
+    samsungKeyword = InterestKeyword.create(samsungInterest, "메모리");
+    samsungKeywordList = new ArrayList<>(List.of(samsungKeyword));
+
+    appleInterest = Interest.create("애플");
+    appleKeyword = InterestKeyword.create(appleInterest, "아이폰");
+    appleKeywordList = new ArrayList<>(List.of(appleKeyword));
+
+    samsungArticle = new ParsedNewsArticle(NewsSourceType.NAVER, "link1", "삼성", null, "메모리",
+        samsungKeywordList);
+    appleArticle = new ParsedNewsArticle(NewsSourceType.NAVER, "link2", "애플", null, "아이폰",
+        appleKeywordList);
+  }
+
   @Test
   @DisplayName("키워드가 없으면 빈 List를 반환한다")
   void shouldReturnEmptyList_whenKeywordsIsEmpty() {
@@ -39,45 +72,26 @@ class ChosunNewsClientTest {
     ParsedData parsedData = new ParsedData(null, null, 0, articles);
 
     given(newsCollector.collectRawNews(any(), any())).willReturn(Flux.just(parsedData));
-    given(newsFilter.filterKeyword(any())).willReturn(articles);
+    given(newsFilter.filterKeyword(any(), anyList())).willReturn(articles);
 
     // when, then
-    StepVerifier.create(chosunNewsClient.fetchAndProcess(Set.of()))
+    StepVerifier.create(chosunNewsClient.fetchAndProcess(List.of()))
         .expectNext(articles)
         .verifyComplete();  // 스트림 정상종료 확인
-  }
-
-  @Test
-  @DisplayName("키워드가 있어도 매칭되지 않으면 빈 List를 반환한다")
-  void shouldReturnEmptyList_whenKeywordsAreUnmatched() {
-    // given
-    List<ParsedNewsArticle> articles = List.of();
-    ParsedData parsedData = new ParsedData(null, null, 0, articles);
-
-    given(newsCollector.collectRawNews(any(), any())).willReturn(Flux.just(parsedData));
-    given(newsFilter.filterKeyword(any())).willReturn(articles);
-
-    // when, then
-    StepVerifier.create(chosunNewsClient.fetchAndProcess(Set.of("삼성")))
-        .expectNext(articles)
-        .verifyComplete();
   }
 
   @Test
   @DisplayName("키워드와 매칭되는 뉴스기사가 있으면 Raw기사 List를 반환한다")
   void shouldReturnRawArticleList_whenKeywordsAreMatched() {
     // given
-    List<ParsedNewsArticle> articles = List.of(
-        new ParsedNewsArticle(null, null, "삼성", null, null, List.of("삼성")),
-        new ParsedNewsArticle(null, null, null, null, "삼성", List.of("삼성"))
-    );
+    List<ParsedNewsArticle> articles = List.of(samsungArticle);
     ParsedData parsedData = new ParsedData(null, null, 0, articles);
 
     given(newsCollector.collectRawNews(any(), any())).willReturn(Flux.just(parsedData));
-    given(newsFilter.filterKeyword(any())).willReturn(articles);
+    given(newsFilter.filterKeyword(any(), anyList())).willReturn(articles);
 
     // when, then
-    StepVerifier.create(chosunNewsClient.fetchAndProcess(Set.of("삼성")))
+    StepVerifier.create(chosunNewsClient.fetchAndProcess(List.of(samsungKeyword)))
         .expectNext(articles)
         .verifyComplete();
   }

--- a/src/test/java/com/team3/monew/component/news/client/NaverNewsClientTest.java
+++ b/src/test/java/com/team3/monew/component/news/client/NaverNewsClientTest.java
@@ -133,8 +133,7 @@ class NaverNewsClientTest {
         .assertNext(list -> {
           assertThat(list).hasSize(1);
           assertThat(list.get(0).link()).isEqualTo("link1");
-          assertThat(list.get(0).interestKeywords()).containsExactlyInAnyOrder(samsungKeyword,
-              appleKeyword);
+          assertThat(list.get(0).interestKeywords()).containsExactly(samsungKeyword, appleKeyword);
         })
         .verifyComplete();
   }

--- a/src/test/java/com/team3/monew/component/news/client/NaverNewsClientTest.java
+++ b/src/test/java/com/team3/monew/component/news/client/NaverNewsClientTest.java
@@ -123,8 +123,7 @@ class NaverNewsClientTest {
     ParsedData parsedData2 = new ParsedData(NewsSourceType.NAVER, null, 0, articles2);
 
     given(newsCollector.collectRawNews(any(), any()))
-        .willReturn(Flux.just(parsedData1))
-        .willReturn(Flux.just(parsedData2));
+        .willReturn(Flux.just(parsedData1, parsedData2));
     given(newsFilter.filterKeyword(any(), anyList()))
         .willReturn(articles1)
         .willReturn(articles2);

--- a/src/test/java/com/team3/monew/component/news/client/NaverNewsClientTest.java
+++ b/src/test/java/com/team3/monew/component/news/client/NaverNewsClientTest.java
@@ -2,15 +2,19 @@ package com.team3.monew.component.news.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 
 import com.team3.monew.component.news.collect.NewsCollector;
 import com.team3.monew.component.news.filter.NewsFilter;
 import com.team3.monew.component.news.record.ParsedData;
 import com.team3.monew.component.news.record.ParsedNewsArticle;
+import com.team3.monew.entity.Interest;
+import com.team3.monew.entity.InterestKeyword;
 import com.team3.monew.entity.enums.NewsSourceType;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -33,22 +37,47 @@ class NaverNewsClientTest {
   @InjectMocks
   private NaverNewsClient naverNewsClient;
 
+  private Interest samsungInterest;
+  private InterestKeyword samsungKeyword;
+  private List<InterestKeyword> samsungKeywordList;
+
+  private Interest appleInterest;
+  private InterestKeyword appleKeyword;
+  private List<InterestKeyword> appleKeywordList;
+
+  private ParsedNewsArticle samsungArticle;
+  private ParsedNewsArticle appleArticle;
+
+
+  @BeforeEach
+  void setUp() {
+    samsungInterest = Interest.create("삼성");
+    samsungKeyword = InterestKeyword.create(samsungInterest, "메모리");
+    samsungKeywordList = new ArrayList<>(List.of(samsungKeyword));
+
+    appleInterest = Interest.create("애플");
+    appleKeyword = InterestKeyword.create(appleInterest, "아이폰");
+    appleKeywordList = new ArrayList<>(List.of(appleKeyword));
+
+    samsungArticle = new ParsedNewsArticle(NewsSourceType.NAVER, "link1", "삼성", null, "메모리",
+        samsungKeywordList);
+    appleArticle = new ParsedNewsArticle(NewsSourceType.NAVER, "link2", "애플", null, "아이폰",
+        appleKeywordList);
+  }
+
   @Test
   @DisplayName("키워드와 매칭되는 뉴스기사가 있으면 뉴스를 반환한다")
   void shouldReturnParsedNewsArticleList_whenKeywordsAreMatched() {
     // given
-    List<ParsedNewsArticle> articles = List.of(
-        new ParsedNewsArticle(null, "1", "삼성", null, null, List.of("삼성")),
-        new ParsedNewsArticle(null, "2", null, null, "삼성", List.of("삼성"))
-    );
-    ParsedData parsedData = new ParsedData(null, null, 0, articles);
+    List<ParsedNewsArticle> parsedNewsArticleList = List.of(samsungArticle);
+    ParsedData parsedData = new ParsedData(NewsSourceType.NAVER, null, 1, parsedNewsArticleList);
 
     given(newsCollector.collectRawNews(any(), any())).willReturn(Flux.just(parsedData));
-    given(newsFilter.filterKeyword(any())).willReturn(articles);
+    given(newsFilter.filterKeyword(any(), anyList())).willReturn(parsedNewsArticleList);
 
-    // when, then
-    StepVerifier.create(naverNewsClient.fetchAndProcess(Set.of("삼성")))
-        .expectNext(articles)
+    // when & then
+    StepVerifier.create(naverNewsClient.fetchAndProcess(samsungKeywordList))
+        .expectNext(parsedNewsArticleList)
         .verifyComplete();
   }
 
@@ -56,30 +85,27 @@ class NaverNewsClientTest {
   @DisplayName("다중 키워드로 여러 기사 List를 받아도 하나의 기사 List로 만들어 반환한다")
   void shouldReturnParsedNewsArticleList_whenMultiKeywordsAreMatched() {
     // given
-    List<ParsedNewsArticle> articles1 = List.of(
-        new ParsedNewsArticle(null, "1", "삼성", null, null, List.of("삼성")),
-        new ParsedNewsArticle(null, "2", null, null, "애플", List.of("애플"))
-    );
+    List<ParsedNewsArticle> articles1 = List.of(samsungArticle, appleArticle);
     ParsedData parsedData1 = new ParsedData(NewsSourceType.NAVER, null, 1, articles1);
 
     List<ParsedNewsArticle> articles2 = List.of(
-        new ParsedNewsArticle(null, "1", "삼성", null, null, List.of("삼성"))
+        new ParsedNewsArticle(null, "link1", "삼성 애플", null, "메모리 아이폰", appleKeywordList)
     );
     ParsedData parsedData2 = new ParsedData(NewsSourceType.NAVER, null, 0, articles2);
 
     given(newsCollector.collectRawNews(any(), any()))
         .willReturn(Flux.just(parsedData1, parsedData2));
-    given(newsFilter.filterKeyword(any()))
+    given(newsFilter.filterKeyword(any(), anyList()))
         .willReturn(articles1)
         .willReturn(articles2);
 
-    // when, then
-    StepVerifier.create(naverNewsClient.fetchAndProcess(Set.of("삼성", "애플")))
+    // when & then
+    StepVerifier.create(naverNewsClient.fetchAndProcess(List.of(samsungKeyword, appleKeyword)))
         .assertNext(list -> {
           assertThat(list)
               .hasSize(2)
               .extracting("link")
-              .containsExactly("1", "2");
+              .containsExactly("link1", "link2");
         })
         .verifyComplete();
   }
@@ -88,30 +114,28 @@ class NaverNewsClientTest {
   @DisplayName("다중 키워드로 동일한 뉴스기사를 가져와도 중복제거를 한 기사 List를 반환한다")
   void shouldReturnDeduplicatedList_whenDuplicateArticlesExist() {
     // given
-    List<ParsedNewsArticle> articles1 = List.of(
-        new ParsedNewsArticle(null, "1", "삼성", null, "애플", List.of("삼성"))
-    );
+    List<ParsedNewsArticle> articles1 = List.of(samsungArticle);
     ParsedData parsedData1 = new ParsedData(NewsSourceType.NAVER, null, 0, articles1);
 
     List<ParsedNewsArticle> articles2 = List.of(
-        new ParsedNewsArticle(null, "1", "삼성", null, "애플", List.of("애플"))
+        new ParsedNewsArticle(null, "link1", "삼성 애플", null, "메모리 아이폰", appleKeywordList)
     );
     ParsedData parsedData2 = new ParsedData(NewsSourceType.NAVER, null, 0, articles2);
 
     given(newsCollector.collectRawNews(any(), any()))
         .willReturn(Flux.just(parsedData1))
         .willReturn(Flux.just(parsedData2));
-    given(newsFilter.filterKeyword(any()))
+    given(newsFilter.filterKeyword(any(), anyList()))
         .willReturn(articles1)
         .willReturn(articles2);
 
     // when, then
-    StepVerifier.create(naverNewsClient.fetchAndProcess(Set.of("삼성", "애플")))
+    StepVerifier.create(naverNewsClient.fetchAndProcess(List.of(samsungKeyword, appleKeyword)))
         .assertNext(list -> {
           assertThat(list)
               .hasSize(1)
               .extracting("link")
-              .containsExactly("1");
+              .containsExactly("link1");
         })
         .verifyComplete();
   }
@@ -124,10 +148,10 @@ class NaverNewsClientTest {
     ParsedData parsedData = new ParsedData(null, null, 0, articles);
 
     given(newsCollector.collectRawNews(any(), any())).willReturn(Flux.just(parsedData));
-    given(newsFilter.filterKeyword(any())).willReturn(articles);
+    given(newsFilter.filterKeyword(any(), anyList())).willReturn(articles);
 
     // when, then
-    StepVerifier.create(naverNewsClient.fetchAndProcess(Set.of()))
+    StepVerifier.create(naverNewsClient.fetchAndProcess(List.of()))
         .expectNext(articles)
         .verifyComplete();
   }

--- a/src/test/java/com/team3/monew/component/news/client/NaverNewsClientTest.java
+++ b/src/test/java/com/team3/monew/component/news/client/NaverNewsClientTest.java
@@ -131,10 +131,10 @@ class NaverNewsClientTest {
     // when, then
     StepVerifier.create(naverNewsClient.fetchAndProcess(List.of(samsungKeyword, appleKeyword)))
         .assertNext(list -> {
-          assertThat(list)
-              .hasSize(1)
-              .extracting("link")
-              .containsExactly("link1");
+          assertThat(list).hasSize(1);
+          assertThat(list.get(0).link()).isEqualTo("link1");
+          assertThat(list.get(0).interestKeywords()).containsExactlyInAnyOrder(samsungKeyword,
+              appleKeyword);
         })
         .verifyComplete();
   }

--- a/src/test/java/com/team3/monew/component/news/collect/ChosunNewsCollectTest.java
+++ b/src/test/java/com/team3/monew/component/news/collect/ChosunNewsCollectTest.java
@@ -67,7 +67,7 @@ class ChosunNewsCollectTest {
         .build();
 
     // when, then
-    StepVerifier.create(newsCollect.collect(webClient, null, null))
+    StepVerifier.create(newsCollect.collect(webClient, null, List.of()))
         .expectNext(parsedData)
         .verifyComplete();
   }
@@ -88,7 +88,7 @@ class ChosunNewsCollectTest {
         .build();
 
     // when, then
-    StepVerifier.create(newsCollect.collect(webClient, null, null))
+    StepVerifier.create(newsCollect.collect(webClient, null, List.of()))
         .expectNextCount(0) // 데이터 0개
         .verifyComplete();
   }
@@ -108,7 +108,7 @@ class ChosunNewsCollectTest {
         .build();
 
     // when, then
-    StepVerifier.create(newsCollect.collect(webClient, null, null))
+    StepVerifier.create(newsCollect.collect(webClient, null, List.of()))
         .expectNextCount(0) // 데이터 0개
         .verifyComplete();
     assertThat(webServer.getRequestCount()).isEqualTo(1); // 횟수 호출 1
@@ -131,7 +131,7 @@ class ChosunNewsCollectTest {
         .build();
 
     // when, then
-    StepVerifier.create(newsCollect.collect(webClient, null, null))
+    StepVerifier.create(newsCollect.collect(webClient, null, List.of()))
         .expectNextCount(0) // 데이터 0개
         .verifyComplete();
     assertThat(webServer.getRequestCount()).isEqualTo(3); // 횟수 호출 3(재시도2)

--- a/src/test/java/com/team3/monew/component/news/collect/NaverNewsCollectTest.java
+++ b/src/test/java/com/team3/monew/component/news/collect/NaverNewsCollectTest.java
@@ -7,13 +7,15 @@ import com.team3.monew.component.news.parse.NewsParser;
 import com.team3.monew.component.news.record.ParsedData;
 import com.team3.monew.component.news.record.ParsedNewsArticle;
 import com.team3.monew.config.NaverProperties;
+import com.team3.monew.entity.Interest;
+import com.team3.monew.entity.InterestKeyword;
 import com.team3.monew.entity.enums.NewsSourceType;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
@@ -43,15 +45,20 @@ class NaverNewsCollectTest {
 
 
   private MockWebServer webServer;
+  private InterestKeyword samsungKeyword;
+  private List<InterestKeyword> samsungKeywordList;
 
   @BeforeEach
-  void serverUp() throws IOException {
+  void setUp() throws IOException {
     webServer = new MockWebServer();
     webServer.start();
+
+    samsungKeyword = InterestKeyword.create(Interest.create("삼성"), "메모리");
+    samsungKeywordList = new ArrayList<>(List.of(samsungKeyword));
   }
 
   @AfterEach
-  void serverDown() throws IOException {
+  void tearDrown() throws IOException {
     webServer.shutdown();
   }
 
@@ -71,7 +78,7 @@ class NaverNewsCollectTest {
         .build();
 
     // when, then
-    StepVerifier.create(newsCollect.collect(webClient, NewsSourceType.NAVER, Set.of("삼성")))
+    StepVerifier.create(newsCollect.collect(webClient, NewsSourceType.NAVER, samsungKeywordList))
         .expectNextCount(0) // 데이터 0개
         .verifyComplete();
   }
@@ -86,7 +93,7 @@ class NaverNewsCollectTest {
     ReflectionTestUtils.setField(newsCollect, "naverBaseUrl", url + ":" + port);
 
     List<ParsedNewsArticle> articles = List.of(
-        new ParsedNewsArticle(null, null, null, null, null, List.of("삼성"))
+        new ParsedNewsArticle(null, null, null, null, null, samsungKeywordList)
     );
     ParsedData parsedData = new ParsedData(null, Instant.now(), 0, articles);
 
@@ -97,7 +104,7 @@ class NaverNewsCollectTest {
         .build();
 
     // when, then
-    StepVerifier.create(newsCollect.collect(webClient, NewsSourceType.NAVER, Set.of("삼성")))
+    StepVerifier.create(newsCollect.collect(webClient, NewsSourceType.NAVER, samsungKeywordList))
         .expectNextCount(1)
         .verifyComplete();
   }
@@ -112,12 +119,12 @@ class NaverNewsCollectTest {
 
     // 키워드별 검색시간 수정
     Map<String, Instant> testAtMap = new HashMap<>();
-    testAtMap.put("삼성", Instant.now().minusSeconds(300));
+    testAtMap.put("삼성 메모리", Instant.now().minusSeconds(300));
     ReflectionTestUtils.setField(newsCollect, "lastCollectedAt", testAtMap);
 
     List<ParsedNewsArticle> articles = List.of(
         new ParsedNewsArticle(null, null, null,
-            Instant.now().minusSeconds(100), null, List.of("삼성"))
+            Instant.now().minusSeconds(100), null, samsungKeywordList)
     );
     ParsedData parsedData1 = new ParsedData(null, Instant.now(), 1, articles);
 
@@ -131,7 +138,7 @@ class NaverNewsCollectTest {
         .build();
 
     // when, then
-    StepVerifier.create(newsCollect.collect(webClient, NewsSourceType.NAVER, Set.of("삼성")))
+    StepVerifier.create(newsCollect.collect(webClient, NewsSourceType.NAVER, samsungKeywordList))
         .expectNextCount(1)
         .verifyComplete();
   }
@@ -146,14 +153,14 @@ class NaverNewsCollectTest {
 
     // 키워드별 검색시간 수정
     Map<String, Instant> testAtMap = new HashMap<>();
-    testAtMap.put("삼성", Instant.now().minusSeconds(300));
+    testAtMap.put("삼성 메모리", Instant.now().minusSeconds(300));
     ReflectionTestUtils.setField(newsCollect, "lastCollectedAt", testAtMap);
 
     List<ParsedNewsArticle> articles = List.of(
         new ParsedNewsArticle(null, null, null,
-            Instant.now().minusSeconds(100), null, List.of("삼성")),
+            Instant.now().minusSeconds(100), null, samsungKeywordList),
         new ParsedNewsArticle(null, null, null,
-            Instant.now().minusSeconds(1000), null, List.of("삼성"))
+            Instant.now().minusSeconds(1000), null, samsungKeywordList)
     );
     ParsedData parsedData1 = new ParsedData(null, Instant.now(), 1, articles);
 
@@ -165,7 +172,7 @@ class NaverNewsCollectTest {
         .build();
 
     // when, then
-    StepVerifier.create(newsCollect.collect(webClient, NewsSourceType.NAVER, Set.of("삼성")))
+    StepVerifier.create(newsCollect.collect(webClient, NewsSourceType.NAVER, samsungKeywordList))
         .expectNextCount(1)
         .verifyComplete();
   }
@@ -183,7 +190,7 @@ class NaverNewsCollectTest {
         .build();
 
     // when, then
-    StepVerifier.create(newsCollect.collect(webClient, NewsSourceType.NAVER, Set.of("삼성")))
+    StepVerifier.create(newsCollect.collect(webClient, NewsSourceType.NAVER, samsungKeywordList))
         .expectNextCount(0)   // data 0개
         .verifyComplete();
   }
@@ -204,7 +211,7 @@ class NaverNewsCollectTest {
         .build();
 
     // when, then
-    StepVerifier.create(newsCollect.collect(webClient, NewsSourceType.NAVER, Set.of("삼성")))
+    StepVerifier.create(newsCollect.collect(webClient, NewsSourceType.NAVER, samsungKeywordList))
         .expectNextCount(0)   // data 0개
         .verifyComplete();
   }

--- a/src/test/java/com/team3/monew/component/news/collect/NaverNewsCollectTest.java
+++ b/src/test/java/com/team3/monew/component/news/collect/NaverNewsCollectTest.java
@@ -119,7 +119,7 @@ class NaverNewsCollectTest {
 
     // 키워드별 검색시간 수정
     Map<String, Instant> testAtMap = new HashMap<>();
-    testAtMap.put("삼성 메모리", Instant.now().minusSeconds(300));
+    testAtMap.put("삼성__메모리", Instant.now().minusSeconds(300));
     ReflectionTestUtils.setField(newsCollect, "lastCollectedAt", testAtMap);
 
     List<ParsedNewsArticle> articles = List.of(
@@ -153,7 +153,7 @@ class NaverNewsCollectTest {
 
     // 키워드별 검색시간 수정
     Map<String, Instant> testAtMap = new HashMap<>();
-    testAtMap.put("삼성 메모리", Instant.now().minusSeconds(300));
+    testAtMap.put("삼성__메모리", Instant.now().minusSeconds(300));
     ReflectionTestUtils.setField(newsCollect, "lastCollectedAt", testAtMap);
 
     List<ParsedNewsArticle> articles = List.of(

--- a/src/test/java/com/team3/monew/component/news/collect/NewsCollectorTest.java
+++ b/src/test/java/com/team3/monew/component/news/collect/NewsCollectorTest.java
@@ -2,6 +2,7 @@ package com.team3.monew.component.news.collect;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -12,7 +13,6 @@ import com.team3.monew.entity.enums.NewsSourceType;
 import com.team3.monew.exception.news.NewsIllegalBeanException;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -43,7 +43,7 @@ class NewsCollectorTest {
 
     // when, then
     assertThatThrownBy(() ->
-        newsCollector.collectRawNews(NewsSourceType.NAVER, Set.of("애플")))
+        newsCollector.collectRawNews(NewsSourceType.NAVER, List.of()))
         .isInstanceOf(NewsIllegalBeanException.class);
   }
 
@@ -54,10 +54,11 @@ class NewsCollectorTest {
     given(newsCollect.get(anyString())).willReturn(naverNewsCollect);
 
     ParsedData parsedData = new ParsedData(null, null, 1, List.of());
-    given(naverNewsCollect.collect(any(), any(), any())).willReturn(Flux.just(parsedData));
+    given(naverNewsCollect.collect(any(), any(), anyList())).willReturn(
+        Flux.just(parsedData));
 
     // when, then
-    StepVerifier.create(newsCollector.collectRawNews(NewsSourceType.NAVER, Set.of("애플")))
+    StepVerifier.create(newsCollector.collectRawNews(NewsSourceType.NAVER, List.of()))
         .expectNext(parsedData)
         .verifyComplete();
     then(naverNewsCollect).should().collect(any(), eq(NewsSourceType.NAVER), any());

--- a/src/test/java/com/team3/monew/component/news/filter/NewsFilterTest.java
+++ b/src/test/java/com/team3/monew/component/news/filter/NewsFilterTest.java
@@ -6,10 +6,11 @@ import static org.mockito.BDDMockito.given;
 
 import com.team3.monew.component.news.record.ParsedData;
 import com.team3.monew.component.news.record.ParsedNewsArticle;
+import com.team3.monew.entity.Interest;
+import com.team3.monew.entity.InterestKeyword;
 import com.team3.monew.entity.enums.NewsSourceType;
 import java.util.ArrayList;
 import java.util.List;
-import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -37,22 +38,21 @@ class NewsFilterTest {
         new ParsedNewsArticle(null, null, "애플", null, "폴더블", new ArrayList<>())
     );
     ParsedData parsedData = new ParsedData(NewsSourceType.NAVER, null, 0, newsArticles);
+    List<InterestKeyword> samsungKeywordList = List.of(
+        InterestKeyword.create(Interest.create("삼성"), "메모리"));
 
     given(keywordMatch.findMatches(any()))
-        .willReturn(List.of("삼성"))
-        .willReturn(List.of("메모리"))
-        .willReturn(List.of())
+        .willReturn(List.of("삼성", "메모리"))
         .willReturn(List.of());
 
     // when
-    List<ParsedNewsArticle> actualData = newsFilter.filterKeyword(parsedData);
+    List<ParsedNewsArticle> actualData = newsFilter.filterKeyword(parsedData, samsungKeywordList);
 
     // then
     assertThat(actualData)
         .hasSize(1)
         .first()
-        .extracting(ParsedNewsArticle::keywords)
-        .asInstanceOf(InstanceOfAssertFactories.LIST)
-        .contains("삼성", "메모리");
+        .extracting("summary")
+        .isEqualTo(" HBM 메모리..");
   }
 }

--- a/src/test/java/com/team3/monew/component/news/filter/NewsFilterTest.java
+++ b/src/test/java/com/team3/monew/component/news/filter/NewsFilterTest.java
@@ -52,7 +52,9 @@ class NewsFilterTest {
     assertThat(actualData)
         .hasSize(1)
         .first()
-        .extracting("summary")
-        .isEqualTo(" HBM 메모리..");
+        .satisfies(article -> {
+          assertThat(article.summary()).isEqualTo(" HBM 메모리..");
+          assertThat(article.interestKeywords()).containsExactly(samsungKeywordList.get(0));
+        });
   }
 }

--- a/src/test/java/com/team3/monew/integration/NewsCollectIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/NewsCollectIntegrationTest.java
@@ -5,12 +5,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.team3.monew.entity.Interest;
 import com.team3.monew.entity.InterestKeyword;
 import com.team3.monew.entity.NewsArticle;
-import com.team3.monew.entity.enums.NewsSourceType;
+import com.team3.monew.repository.ArticleInterestRepository;
 import com.team3.monew.repository.InterestKeywordRepository;
 import com.team3.monew.repository.InterestRepository;
 import com.team3.monew.repository.NewsArticleRepository;
 import com.team3.monew.service.NewsCollectService;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -18,10 +20,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.transaction.annotation.Transactional;
 import reactor.test.StepVerifier;
 
-@Transactional
+//@Transactional
 @SpringBootTest
 @ActiveProfiles("test")
 @Tag("external-api")
@@ -38,18 +39,27 @@ class NewsCollectIntegrationTest {
   private NewsArticleRepository newsArticleRepository;
 
   @Autowired
+  private ArticleInterestRepository articleInterestRepository;
+
+  @Autowired
   private NewsCollectService newsCollectService;
 
-  @Test
-  @DisplayName("뉴스 수집이 실행되면 기사들을 수집하고 저장한다")
-  void shouldCollectAndSaveArticles_whenNewsCollectionIsExecuted() {
-    // given
+  @BeforeEach
+  void setUp() {
     Interest samsung = Interest.create("삼성");
     interestRepository.save(samsung);
     InterestKeyword keyword = InterestKeyword.create(samsung, "메모리");
     interestKeywordRepository.save(keyword);
-    // NewsSource는 SpringBoot 시에 저장하는 것으로 사용
+  }
 
+  @AfterEach
+  void tearDown() {
+    newsArticleRepository.deleteAll();
+  }
+
+  @Test
+  @DisplayName("뉴스 수집이 실행되면 기사들을 수집하고 저장한다")
+  void shouldCollectAndSaveArticles_whenNewsCollectionIsExecuted() {
     // when
     // NewsSource는 현재 Naver, Chosun 2개 존재
     // 네이버 요청시에 100개
@@ -71,13 +81,7 @@ class NewsCollectIntegrationTest {
         });
 
     assertThat(articles)
-        .filteredOn(a -> a.getSource().getSourceType() == NewsSourceType.NAVER)
         // 네이버 쿼리는 키워드 형태로 요청해서 100개 이상인걸 보장
         .hasSizeGreaterThanOrEqualTo(100);
-
-    assertThat(articles)
-        .filteredOn(a -> a.getSource().getSourceType() == NewsSourceType.CHOSUN)
-        // 조선일보는 쿼리 요청후 키워드를 매칭해서 0개 이상임
-        .hasSizeGreaterThanOrEqualTo(0);
   }
 }

--- a/src/test/java/com/team3/monew/integration/NewsCollectIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/NewsCollectIntegrationTest.java
@@ -43,6 +43,9 @@ class NewsCollectIntegrationTest {
   @Autowired
   private NewsCollectService newsCollectService;
 
+  @Autowired
+  private ArticleInterestRepository articleInterestRepository;
+
   private Set<String> keywords;
 
   @BeforeEach
@@ -66,7 +69,10 @@ class NewsCollectIntegrationTest {
 
   @AfterEach
   void tearDown() {
+    articleInterestRepository.deleteAll();
     newsArticleRepository.deleteAll();
+    interestKeywordRepository.deleteAll();
+    interestRepository.deleteAll();
   }
 
   @Test

--- a/src/test/java/com/team3/monew/integration/NewsCollectIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/NewsCollectIntegrationTest.java
@@ -5,12 +5,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.team3.monew.entity.Interest;
 import com.team3.monew.entity.InterestKeyword;
 import com.team3.monew.entity.NewsArticle;
+import com.team3.monew.entity.enums.NewsSourceType;
 import com.team3.monew.repository.ArticleInterestRepository;
 import com.team3.monew.repository.InterestKeywordRepository;
 import com.team3.monew.repository.InterestRepository;
 import com.team3.monew.repository.NewsArticleRepository;
 import com.team3.monew.service.NewsCollectService;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,7 +25,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import reactor.test.StepVerifier;
 
-//@Transactional
 @SpringBootTest
 @ActiveProfiles("test")
 @Tag("external-api")
@@ -39,17 +41,27 @@ class NewsCollectIntegrationTest {
   private NewsArticleRepository newsArticleRepository;
 
   @Autowired
-  private ArticleInterestRepository articleInterestRepository;
-
-  @Autowired
   private NewsCollectService newsCollectService;
+
+  private Set<String> keywords;
 
   @BeforeEach
   void setUp() {
     Interest samsung = Interest.create("삼성");
     interestRepository.save(samsung);
     InterestKeyword keyword = InterestKeyword.create(samsung, "메모리");
-    interestKeywordRepository.save(keyword);
+    InterestKeyword keyword2 = InterestKeyword.create(samsung, "갤럭시");
+
+    Interest apple = Interest.create("애플");
+    interestRepository.save(apple);
+    InterestKeyword keyword3 = InterestKeyword.create(apple, "아이폰");
+
+
+    List<InterestKeyword> interestKeywordList = List.of(keyword, keyword2, keyword3);
+    interestKeywordRepository.saveAll(interestKeywordList);
+
+    keywords = interestKeywordList.stream()
+        .map(InterestKeyword::getKeyword).collect(Collectors.toSet());
   }
 
   @AfterEach
@@ -62,21 +74,22 @@ class NewsCollectIntegrationTest {
   void shouldCollectAndSaveArticles_whenNewsCollectionIsExecuted() {
     // when
     // NewsSource는 현재 Naver, Chosun 2개 존재
-    // 네이버 요청시에 100개
+    // 네이버 요청시 쿼리당 100개
     StepVerifier.create(newsCollectService.executeNewsCollection())
         .verifyComplete();
 
     // then
-    List<NewsArticle> articles = newsArticleRepository.findAll();
+    List<NewsArticle> articles = newsArticleRepository.findAllWithNewsSource();
     assertThat(articles)
         .isNotEmpty()
+        .filteredOn(na -> na.getSource().getSourceType() == NewsSourceType.NAVER)
         .hasSizeGreaterThanOrEqualTo(100)
         .allSatisfy(article -> {
-          boolean inTitle = article.getTitle().contains("메모리");
-          boolean inSummary = article.getSummary().contains("메모리");
+          boolean inTitle = keywords.stream().anyMatch(keyword -> article.getTitle().contains(keyword));
+          boolean inSummary = keywords.stream().anyMatch(keyword -> article.getSummary().contains(keyword));
 
           assertThat(inTitle || inSummary)
-              .as("기사의 제목이나 내용 중에 메모리 키워드가 없습니다")
+              .as("기사의 제목이나 내용 중에 해당하는 키워드가 없습니다")
               .isTrue();
         });
 

--- a/src/test/java/com/team3/monew/service/NewsCollectServiceTest.java
+++ b/src/test/java/com/team3/monew/service/NewsCollectServiceTest.java
@@ -1,7 +1,6 @@
 package com.team3.monew.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.timeout;
@@ -58,15 +57,18 @@ class NewsCollectServiceTest {
   List<InterestKeyword> interestKeywords;
   List<NewsSource> newsSources;
 
+  private Interest samsungInterest;
+  private Interest appleInterest;
+
   @BeforeEach
   void setUp() {
-    Interest interest1 = Interest.create("애플");
-    Interest interest2 = Interest.create("삼성");
+    appleInterest = Interest.create("애플");
+    samsungInterest = Interest.create("삼성");
 
     interestKeywords = List.of(
-        InterestKeyword.create(interest1, "메모리"),
-        InterestKeyword.create(interest2, "메모리"),
-        InterestKeyword.create(interest2, "화성공장")
+        InterestKeyword.create(appleInterest, "메모리"),
+        InterestKeyword.create(samsungInterest, "메모리"),
+        InterestKeyword.create(samsungInterest, "화성공장")
     );
 
     NewsSource naver = NewsSource.create("NAVER", NewsSourceType.NAVER, "baseUrl1");
@@ -78,30 +80,30 @@ class NewsCollectServiceTest {
   @DisplayName("동일한 링크 기사가 여러 Source에서 수집되면, 네이버 기사를 최우선으로 남긴다")
   void shouldKeepNaverArticle_whenMultipleSourcesProvideSameLink() {
     // given
-    given(interestKeywordRepository.findAll()).willReturn(interestKeywords);
+    given(interestKeywordRepository.findAllWithInterest()).willReturn(interestKeywords);
     given(newsClients.values()).willReturn(List.of(naverNewsClient, chosunNewsClient));
     given(newsClients.size()).willReturn(2);
 
     String commonLink = "commonLink";
     List<ParsedNewsArticle> naverList = List.of(
         new ParsedNewsArticle(NewsSourceType.NAVER, commonLink, "제목1", Instant.now(), null,
-            List.of("메모리"))
+            List.of(InterestKeyword.create(samsungInterest, "메모리")))
     );
-    given(naverNewsClient.fetchAndProcess(anySet())).willReturn(Mono.just(naverList));
+    given(naverNewsClient.fetchAndProcess(interestKeywords)).willReturn(Mono.just(naverList));
     List<ParsedNewsArticle> chosunList = List.of(
         new ParsedNewsArticle(NewsSourceType.CHOSUN, commonLink, "제목1", Instant.now(), null,
-            List.of("메모리")),
+            List.of(InterestKeyword.create(samsungInterest, "메모리"))),
         new ParsedNewsArticle(NewsSourceType.CHOSUN, "another Link2", "제목2", Instant.now(), null,
-            List.of("화성공장"))
+            List.of(InterestKeyword.create(appleInterest, "메모리")))
     );
-    given(chosunNewsClient.fetchAndProcess(anySet())).willReturn(Mono.just(chosunList));
+    given(chosunNewsClient.fetchAndProcess(interestKeywords)).willReturn(Mono.just(chosunList));
 
     // when
     newsCollectService.scheduleNewsJob();
 
     // then
     // 비동기 테스트 타이밍 문제로 1초 유예기간 부여
-    then(newsSaveService).should(timeout(1000)).save(listCaptor.capture());
+    then(newsSaveService).should(timeout(1000)).saveAndNotify(listCaptor.capture());
     List<ParsedNewsArticle> deduplicatedLink = listCaptor.getValue();
     assertThat(deduplicatedLink)
         .hasSize(2)

--- a/src/test/java/com/team3/monew/service/NewsSaveServiceTest.java
+++ b/src/test/java/com/team3/monew/service/NewsSaveServiceTest.java
@@ -1,14 +1,20 @@
 package com.team3.monew.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
 
 import com.team3.monew.component.news.record.ParsedNewsArticle;
+import com.team3.monew.entity.Interest;
+import com.team3.monew.entity.InterestKeyword;
 import com.team3.monew.entity.NewsArticle;
 import com.team3.monew.entity.NewsSource;
 import com.team3.monew.entity.enums.NewsSourceType;
+import com.team3.monew.event.InterestNotificationEvent;
+import com.team3.monew.repository.InterestRepository;
 import com.team3.monew.repository.NewsArticleRepository;
 import com.team3.monew.repository.NewsSourceRepository;
 import java.time.Instant;
@@ -23,6 +29,7 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 @Tag("unit")
 @ExtendWith(MockitoExtension.class)
@@ -32,6 +39,10 @@ class NewsSaveServiceTest {
   private NewsArticleRepository newsArticleRepository;
   @Mock
   private NewsSourceRepository newsSourceRepository;
+  @Mock
+  private InterestRepository interestRepository;
+  @Mock
+  private ApplicationEventPublisher eventPublisher;
 
   @InjectMocks
   private NewsSaveService newsSaveService;
@@ -41,26 +52,41 @@ class NewsSaveServiceTest {
 
   @Test
   @DisplayName("중복된 링크를 제거한 새로운 뉴스기사를 저장한다")
-  void shouldSaveOnlyNewArticles_whenDuplicateLinksExist() {
+  void shouldSaveAndNotifyOnlyNewArticles_whenDuplicateLinksExist() {
     // given
+    Interest samsungInterest = Interest.create("삼성");
+    List<InterestKeyword> samsungKeywordList = List.of(
+        InterestKeyword.create(samsungInterest, "메모리"),
+        InterestKeyword.create(samsungInterest, "갤럭시")
+    );
+    Instant articleTime1 = Instant.now();
+    Instant articleTime2 = Instant.now();
+
     List<ParsedNewsArticle> givenData = List.of(
-        new ParsedNewsArticle(NewsSourceType.NAVER, "link1", "기사1", Instant.now(), null,
-            List.of("삼성")),
-        new ParsedNewsArticle(NewsSourceType.CHOSUN, "link2", "기사2", Instant.now(), null,
-            List.of("삼성")),
-        new ParsedNewsArticle(NewsSourceType.NAVER, "link3", "기사3", Instant.now(), null,
-            List.of("삼성"))
+        new ParsedNewsArticle(NewsSourceType.NAVER, "link1", "기사1", articleTime1, null,
+            samsungKeywordList),
+        new ParsedNewsArticle(NewsSourceType.CHOSUN, "link2", "기사2", articleTime2, null,
+            samsungKeywordList),
+        new ParsedNewsArticle(NewsSourceType.NAVER, "link3", "기사3", null, null,
+            samsungKeywordList)
     );
     String existingLink = "link3";
-    given(newsArticleRepository.findExistingOriginalLinks(anyList()))
+    given(newsArticleRepository.findExistingOriginalLinks(any(), anyList()))
         .willReturn(Set.of(existingLink));
 
     NewsSource naver = NewsSource.create("NAVER", NewsSourceType.NAVER, "baseUrl1");
     NewsSource chosun = NewsSource.create("CHOSUN", NewsSourceType.CHOSUN, "baseUrl2");
     given(newsSourceRepository.findAll()).willReturn(List.of(naver, chosun));
 
+    given(interestRepository.findAll()).willReturn(List.of(samsungInterest));
+
+    List<NewsArticle> expectData = List.of(
+        NewsArticle.create(naver, "link1", "기사1", articleTime1, null),
+        NewsArticle.create(chosun, "link2", "기사2", articleTime2, null)
+    );
+
     // when
-    List<ParsedNewsArticle> actualData = newsSaveService.save(givenData);
+    List<NewsArticle> actualData = newsSaveService.saveAndNotify(givenData);
 
     // then
     then(newsArticleRepository).should().saveAll(listCaptor.capture());
@@ -70,7 +96,42 @@ class NewsSaveServiceTest {
         .containsExactly("link1", "link2");
     assertThat(actualData)
         .hasSize(2)
-        .extracting(ParsedNewsArticle::link)
+        .extracting(NewsArticle::getOriginalLink)
         .containsExactly("link1", "link2");
+    then(eventPublisher).should(times(1))
+        .publishEvent(any(InterestNotificationEvent.class));
+  }
+
+  @Test
+  @DisplayName("빈 데이터가 오면 빈 List를 반환한다")
+  void shouldReturnEmptyList_whenInputDataIsEmpty() {
+    // when
+    List<NewsArticle> actualData = newsSaveService.saveAndNotify(List.of());
+
+    // then
+    assertThat(actualData)
+        .isEmpty();
+  }
+
+  @Test
+  @DisplayName("모든 기사가 이미 존재하면 빈 List를 반환한다")
+  void shouldReturnEmptyList_whenAllArticlesAlreadyExist() {
+    // given
+    List<InterestKeyword> samsungKeywordList = List.of(
+        InterestKeyword.create(Interest.create("삼성"), "메모리"));
+    List<ParsedNewsArticle> data = List.of(
+        new ParsedNewsArticle(NewsSourceType.NAVER, "Link1", "삼성", null, "메모리", samsungKeywordList),
+        new ParsedNewsArticle(NewsSourceType.NAVER, "Link2", "삼성 파업", null, "메모리 노동자..",
+            samsungKeywordList)
+    );
+    given(newsArticleRepository.findExistingOriginalLinks(any(), anyList()))
+        .willReturn(Set.of("Link1", "Link2"));
+
+    // when
+    List<NewsArticle> actualData = newsSaveService.saveAndNotify(data);
+
+    // then
+    assertThat(actualData)
+        .isEmpty();
   }
 }

--- a/src/test/java/com/team3/monew/service/NewsSaveServiceTest.java
+++ b/src/test/java/com/team3/monew/service/NewsSaveServiceTest.java
@@ -71,7 +71,7 @@ class NewsSaveServiceTest {
             samsungKeywordList)
     );
     String existingLink = "link3";
-    given(newsArticleRepository.findExistingOriginalLinks(any(), anyList()))
+    given(newsArticleRepository.findExistingOriginalLinks(anyList()))
         .willReturn(Set.of(existingLink));
 
     NewsSource naver = NewsSource.create("NAVER", NewsSourceType.NAVER, "baseUrl1");
@@ -124,7 +124,7 @@ class NewsSaveServiceTest {
         new ParsedNewsArticle(NewsSourceType.NAVER, "Link2", "삼성 파업", null, "메모리 노동자..",
             samsungKeywordList)
     );
-    given(newsArticleRepository.findExistingOriginalLinks(any(), anyList()))
+    given(newsArticleRepository.findExistingOriginalLinks(anyList()))
         .willReturn(Set.of("Link1", "Link2"));
 
     // when


### PR DESCRIPTION
## 관련 이슈
- 주요이슈
  - #179 
- 서브이슈
  - #178 

## 작업 내용
- feat: 뉴스 기사 저장 시 알람 연동 구현
- refactor: 단일 키워드 쿼리 -> '관심사 쿼리' 쿼리로 구조 변경

## 변경 사항
- 뉴스 저장 시 알람이벤트 발행
- 쿼리 구조 변경에 맞춰서 테스트 코드, 로직 코드 수정
- Entity의 ArticleInterest의 (NewsArticle, Interest)의 UK제약 제거
- schema.sql에서 동일한 제약조건 제거

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선사항**
  - 키워드에서 관심사(InterestKeyword) 기반 수집·필터링으로 전환하여 매칭 정밀도 향상
  - 중복 기사 병합 시 관심사 정보 통합 및 링크 기준 병합 후 게시일 역순 정렬 적용
  - 수집→저장 흐름 변경으로 관심사별 요약 집계 및 알림 발송 추가
  - 특정 조회에 대해 연관 데이터 조기 로딩으로 조회 성능 개선

* **테스트**
  - 수집·필터링·저장 관련 테스트 전반 리팩터 및 기대값을 관심사 모델 기준으로 업데이트

* **기타**
  - 기사-관심사 매핑 DB 유니크 제약에 매칭 키(matched_keyword) 포함하도록 변경
<!-- end of auto-generated comment: release notes by coderabbit.ai -->