### PR TITLE
feat: 알림 개별 수정 기능

### DIFF
--- a/src/main/java/com/team3/monew/controller/NotificationController.java
+++ b/src/main/java/com/team3/monew/controller/NotificationController.java
@@ -12,6 +12,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -36,5 +39,13 @@ public class NotificationController implements NotificationApi {
         requestUserId,
         cursor, after, limit);
     return ResponseEntity.ok(dto);
+  }
+
+  @PatchMapping("/{notificationId}")
+  public ResponseEntity<?> confirm(
+      @RequestHeader(REQUEST_USER_ID_HEADER) UUID requestUserId,
+      @PathVariable UUID notificationId) {
+    notificationService.confirm(requestUserId, notificationId);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/team3/monew/controller/api/NotificationApi.java
+++ b/src/main/java/com/team3/monew/controller/api/NotificationApi.java
@@ -16,6 +16,8 @@ import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -41,4 +43,19 @@ public interface NotificationApi {
       @RequestParam(defaultValue = "50") @Min(1) @Max(100) Integer limit
   );
 
+  @Operation(summary = "알림 확인", description = "알림을 확인합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "204", description = "알림 확인 성공"),
+      @ApiResponse(responseCode = "404", description = "사용자 정보 없음/알림정보 없음",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 (입력값 검증 실패)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  @PatchMapping("/{notificationId}")
+  ResponseEntity<?> confirm(
+      @RequestHeader(REQUEST_USER_ID_HEADER) UUID requestUserId,
+      @PathVariable UUID notificationId
+  );
 }

--- a/src/main/java/com/team3/monew/controller/api/NotificationApi.java
+++ b/src/main/java/com/team3/monew/controller/api/NotificationApi.java
@@ -46,6 +46,8 @@ public interface NotificationApi {
   @Operation(summary = "알림 확인", description = "알림을 확인합니다.")
   @ApiResponses({
       @ApiResponse(responseCode = "204", description = "알림 확인 성공"),
+      @ApiResponse(responseCode = "403", description = "해당 알림에 대한 확인 권한 없음",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
       @ApiResponse(responseCode = "404", description = "사용자 정보 없음/알림정보 없음",
           content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
       @ApiResponse(responseCode = "400", description = "잘못된 요청 (입력값 검증 실패)",

--- a/src/main/java/com/team3/monew/entity/Notification.java
+++ b/src/main/java/com/team3/monew/entity/Notification.java
@@ -72,4 +72,12 @@ public class Notification extends BaseEntity {
     this.isConfirmed = false;
   }
 
+  public void confirm() {
+    if (this.isConfirmed) {
+      return; // 이미 확인된건 변경X
+    }
+    this.isConfirmed = true;
+    this.confirmedAt = Instant.now();
+  }
+
 }

--- a/src/main/java/com/team3/monew/exception/notification/NotificationConfirmForbiddenException.java
+++ b/src/main/java/com/team3/monew/exception/notification/NotificationConfirmForbiddenException.java
@@ -1,0 +1,13 @@
+package com.team3.monew.exception.notification;
+
+import com.team3.monew.global.enums.ErrorCode;
+import java.util.Map;
+import java.util.UUID;
+
+public class NotificationConfirmForbiddenException extends NotificationException {
+
+  public NotificationConfirmForbiddenException(UUID notificationId, UUID requestUserId) {
+    super(ErrorCode.NOTIFICATION_CONFIRM_FORBIDDEN,
+        Map.of("notificationId", notificationId, "userId", requestUserId));
+  }
+}

--- a/src/main/java/com/team3/monew/exception/notification/NotificationException.java
+++ b/src/main/java/com/team3/monew/exception/notification/NotificationException.java
@@ -1,0 +1,16 @@
+package com.team3.monew.exception.notification;
+
+import com.team3.monew.global.enums.ErrorCode;
+import com.team3.monew.global.exception.BusinessException;
+import java.util.Map;
+
+public class NotificationException extends BusinessException {
+
+  public NotificationException(ErrorCode errorCode) {
+    super(errorCode, Map.of());
+  }
+
+  public NotificationException(ErrorCode errorCode, Map<String, Object> details) {
+    super(errorCode, details);
+  }
+}

--- a/src/main/java/com/team3/monew/exception/notification/NotificationNotFoundException.java
+++ b/src/main/java/com/team3/monew/exception/notification/NotificationNotFoundException.java
@@ -1,0 +1,12 @@
+package com.team3.monew.exception.notification;
+
+import com.team3.monew.global.enums.ErrorCode;
+import java.util.Map;
+import java.util.UUID;
+
+public class NotificationNotFoundException extends NotificationException {
+
+  public NotificationNotFoundException(UUID notificationId) {
+    super(ErrorCode.NOTIFICATION_NOT_FOUND, Map.of("notificationId", notificationId));
+  }
+}

--- a/src/main/java/com/team3/monew/global/enums/ErrorCode.java
+++ b/src/main/java/com/team3/monew/global/enums/ErrorCode.java
@@ -25,10 +25,14 @@ public enum ErrorCode {
   INTEREST_KEYWORD_DUPLICATED(HttpStatus.BAD_REQUEST, "중복된 관심사 키워드가 존재합니다."),
   INTEREST_ALREADY_SUBSCRIBING(HttpStatus.CONFLICT, "이미 구독중인 관심사입니다."),
 
+  // NOTIFICATION
+  NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 알림입니다."),
+  NOTIFICATION_CONFIRM_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 알림에 대한 확인 권한이 없습니다."),
   //COMMON
   INVALID_PARAMETER_TYPE(HttpStatus.BAD_REQUEST, "해당 파라미터가 유효하지 않습니다."),
   INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "입력 형식이 올바르지 않습니다."),
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."),
+
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/team3/monew/service/NotificationService.java
+++ b/src/main/java/com/team3/monew/service/NotificationService.java
@@ -9,6 +9,8 @@ import com.team3.monew.entity.Notification;
 import com.team3.monew.entity.User;
 import com.team3.monew.entity.enums.NotificationResourceType;
 import com.team3.monew.exception.comment.CommentNotFoundException;
+import com.team3.monew.exception.notification.NotificationConfirmForbiddenException;
+import com.team3.monew.exception.notification.NotificationNotFoundException;
 import com.team3.monew.exception.user.UserNotFoundException;
 import com.team3.monew.mapper.NotificationMapper;
 import com.team3.monew.repository.CommentRepository;
@@ -115,6 +117,23 @@ public class NotificationService {
         totalElements,
         hasNext
     );
+  }
+
+  public void confirm(UUID requestUserId, UUID notificationId) {
+    log.debug("개별 알림 확인 시작: userId={}, notificationId={}", requestUserId, notificationId);
+    if (!userRepository.existsById(requestUserId)) {
+      throw new UserNotFoundException(requestUserId);
+    }
+    log.debug("개별 알림 확인에서 사용자 유효성 확인 완료: userId={}, notificationId={}", requestUserId,
+        notificationId);
+    Notification notification = notificationRepository.findById(notificationId)
+        .orElseThrow(() -> new NotificationNotFoundException(notificationId));
+    log.debug("개별 알림 확인에서 알림 조회 성공: notificationId={}", notificationId);
+    if (!notification.getUser().getId().equals(requestUserId)) {
+      throw new NotificationConfirmForbiddenException(notificationId, requestUserId);
+    }
+    notification.confirm();
+    log.info("개별 알림 확인 요청 성공: userId={}, notificationId={}", requestUserId, notificationId);
   }
 
   private String generateCommentLikedContent(String actorUserNickname) {

--- a/src/test/java/com/team3/monew/controller/NotificationControllerTest.java
+++ b/src/test/java/com/team3/monew/controller/NotificationControllerTest.java
@@ -229,7 +229,7 @@ class NotificationControllerTest {
   void shouldFailConfirmNotification_whenUserIdNotGiven() throws Exception {
     // given
     UUID notificationId = UUID.randomUUID();
-    // when & theb
+    // when & then
     mockMvc.perform(patch(NOTIFICATION_URL + "/" + notificationId))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.details.header").value("Monew-Request-User-ID"))

--- a/src/test/java/com/team3/monew/controller/NotificationControllerTest.java
+++ b/src/test/java/com/team3/monew/controller/NotificationControllerTest.java
@@ -4,7 +4,10 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -13,10 +16,12 @@ import com.team3.monew.dto.pagination.CursorPageResponseDto;
 import com.team3.monew.entity.Notification;
 import com.team3.monew.entity.User;
 import com.team3.monew.entity.enums.NotificationResourceType;
+import com.team3.monew.exception.notification.NotificationConfirmForbiddenException;
+import com.team3.monew.exception.notification.NotificationNotFoundException;
+import com.team3.monew.exception.user.UserNotFoundException;
 import com.team3.monew.global.exception.GlobalExceptionHandler;
 import com.team3.monew.service.NotificationService;
 import java.time.Instant;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.UUID;
@@ -205,5 +210,92 @@ class NotificationControllerTest {
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.details.header").value("Monew-Request-User-ID"))
         .andExpect(jsonPath("$.code").value("INVALID_INPUT_VALUE"));
+  }
+
+  @Test
+  @DisplayName("사용자 아이디 헤더와 알림 아이디로 특정 알림 확인에 성공한다.(204)")
+  void shouldConfirmNotification_whenUserIdAndNotificationIdAreGiven() throws Exception {
+    // given
+    UUID notificationId = UUID.randomUUID();
+    // when & then
+    mockMvc.perform(patch(NOTIFICATION_URL + "/" + notificationId)
+            .header("Monew-Request-User-ID", userId1))
+        .andExpect(status().isNoContent());
+    then(notificationService).should().confirm(eq(userId1), eq(notificationId));
+  }
+
+  @Test
+  @DisplayName("사용자 아이디 헤더가 없을 때, 알림 확인 실패 응답을 보낸다.")
+  void shouldFailConfirmNotification_whenUserIdNotGiven() throws Exception {
+    // given
+    UUID notificationId = UUID.randomUUID();
+    // when & theb
+    mockMvc.perform(patch(NOTIFICATION_URL + "/" + notificationId))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.details.header").value("Monew-Request-User-ID"))
+        .andExpect(jsonPath("$.code").value("INVALID_INPUT_VALUE"));
+  }
+
+  @Test
+  @DisplayName("알림 아이디 형식이 잘못되면, 알림 확인 실패 응답을 보낸다.")
+  void shouldResponseErrorResponse_whenNotificationIdIsNotUUID() throws Exception {
+    // given
+    long wrongNotificationId = 1234;
+    // when & theb
+    mockMvc.perform(patch(NOTIFICATION_URL + "/" + wrongNotificationId)
+            .header("Monew-Request-User-ID", userId1))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.details.parameter").value("notificationId"))
+        .andExpect(jsonPath("$.code").value("INVALID_PARAMETER_TYPE"));
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 알림 아이디로 확인을 시도하면, 알림 확인 실패 응답을 보낸다.")
+  void shouldResponseErrorResponse_whenNotificationIdNotFound() throws Exception {
+    // given
+    UUID notificationId = UUID.randomUUID();
+    willThrow(new NotificationNotFoundException(notificationId))
+        .given(notificationService)
+        .confirm(eq(userId1), eq(notificationId));
+
+    // when & then
+    mockMvc.perform(patch(NOTIFICATION_URL + "/" + notificationId)
+            .header("Monew-Request-User-ID", userId1))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.details.notificationId").value(notificationId.toString()))
+        .andExpect(jsonPath("$.code").value("NOTIFICATION_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 사용자 아이디로 확인을 시도하면, 알림 확인 실패 응답을 보낸다.")
+  void shouldResponseErrorResponse_whenUserNotFound() throws Exception {
+    // given
+    UUID notificationId = UUID.randomUUID();
+    willThrow(new UserNotFoundException(userId1))
+        .given(notificationService)
+        .confirm(eq(userId1), eq(notificationId));
+    // when & then
+    mockMvc.perform(patch(NOTIFICATION_URL + "/" + notificationId)
+            .header("Monew-Request-User-ID", userId1))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.details.userId").value(userId1.toString()))
+        .andExpect(jsonPath("$.code").value("USER_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("해당 알림의 소유자가 아닌 사용자가 알림 확인 요청을 보내면, 알림 확인 실패 응답을 보낸다.")
+  void shouldResponseErrorResponse_whenUserNotAuthorized() throws Exception {
+    // given
+    UUID notificationId = UUID.randomUUID();
+    willThrow(new NotificationConfirmForbiddenException(notificationId, userId1))
+        .given(notificationService)
+        .confirm(eq(userId1), eq(notificationId));
+    // when & then
+    mockMvc.perform(patch(NOTIFICATION_URL + "/" + notificationId)
+            .header("Monew-Request-User-ID", userId1))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.details.notificationId").value(notificationId.toString()))
+        .andExpect(jsonPath("$.details.userId").value(userId1.toString()))
+        .andExpect(jsonPath("$.code").value("NOTIFICATION_CONFIRM_FORBIDDEN"));
   }
 }

--- a/src/test/java/com/team3/monew/integration/NotificationIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/NotificationIntegrationTest.java
@@ -393,7 +393,7 @@ public class NotificationIntegrationTest {
     }
 
     @Test
-    @DisplayName("이미 확인되 알림을 확인하면 성공응답이되, 확인 시간이 변경되지 않는다.")
+    @DisplayName("이미 확인되 알림을 확인하면 성공응답이지만, 확인 시간이 변경되지 않는다.")
     void shouldConfirmNotificationAlreadyConfirmed_whenUserIdAndNotificationIdAreGiven()
         throws Exception {
       //given

--- a/src/test/java/com/team3/monew/integration/NotificationIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/NotificationIntegrationTest.java
@@ -3,7 +3,12 @@ package com.team3.monew.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -28,8 +33,8 @@ import com.team3.monew.repository.UserRepository;
 import com.team3.monew.service.NotificationService;
 import jakarta.persistence.EntityManager;
 import java.time.Instant;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -370,6 +375,99 @@ public class NotificationIntegrationTest {
               jsonPath("$.nextCursor").value(notification2.getId().toString()),//마지막 확인한 요소의 값
               jsonPath("$.nextAfter").value(formatter.format(notification2.getCreatedAt()))
           );
+    }
+
+    @Test
+    @DisplayName("사용자 아이디와 알림 아이디로 알림을 확인한다.")
+    void shouldConfirmNotification_whenUserIdAndNotificationIdAreGiven() throws Exception {
+      // when & then
+      mockMvc.perform(patch("/api/notifications/" + notification1.getId())
+              .header("Monew-Request-User-ID", subscriber.getId()))
+          .andExpect(status().isNoContent());
+
+      Notification updatedNotification = notificationRepository.findById(notification1.getId())
+          .orElseThrow();
+
+      assertTrue(updatedNotification.isConfirmed());
+      assertNotNull(updatedNotification.getConfirmedAt());
+    }
+
+    @Test
+    @DisplayName("이미 확인되 알림을 확인하면 성공응답이되, 확인 시간이 변경되지 않는다.")
+    void shouldConfirmNotificationAlreadyConfirmed_whenUserIdAndNotificationIdAreGiven()
+        throws Exception {
+      //given
+      Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+      ReflectionTestUtils.setField(notification1, "isConfirmed", true);
+      ReflectionTestUtils.setField(notification1, "confirmedAt", now);
+      notificationRepository.saveAndFlush(notification1);
+      em.clear();
+
+      // when & then
+      mockMvc.perform(patch("/api/notifications/" + notification1.getId())
+              .header("Monew-Request-User-ID", subscriber.getId()))
+          .andExpect(status().isNoContent());
+
+      Notification updatedNotification = notificationRepository.findById(notification1.getId())
+          .orElseThrow();
+
+      assertTrue(updatedNotification.isConfirmed());
+      assertNotNull(updatedNotification.getConfirmedAt());
+      assertEquals(now, updatedNotification.getConfirmedAt().truncatedTo(ChronoUnit.MILLIS));
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 사용자 아이디로 알림 확인에 실패한다.")
+    void shouldFailToConfirmNotification_whenUserNotFound() throws Exception {
+      // given
+      UUID wrongUserId = UUID.randomUUID();
+
+      //when & then
+      mockMvc.perform(patch("/api/notifications/" + notification1.getId())
+              .header("Monew-Request-User-ID", wrongUserId))
+          .andExpectAll(
+              status().isNotFound(),
+              jsonPath("$.details.userId").value(wrongUserId.toString())
+          );
+      Notification updatedNotification = notificationRepository.findById(notification1.getId())
+          .orElseThrow();
+      assertFalse(updatedNotification.isConfirmed());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 알림 아이디로 알림 확인에 실패한다.")
+    void shouldFailToConfirmNotification_whenNotificationNotFound() throws Exception {
+      // given
+      UUID wrongNotificationId = UUID.randomUUID();
+
+      //when & then
+      mockMvc.perform(patch("/api/notifications/" + wrongNotificationId)
+              .header("Monew-Request-User-ID", subscriber.getId()))
+          .andExpectAll(
+              status().isNotFound(),
+              jsonPath("$.details.notificationId").value(wrongNotificationId.toString())
+          );
+      Notification updatedNotification = notificationRepository.findById(notification1.getId())
+          .orElseThrow();
+      assertFalse(updatedNotification.isConfirmed());
+    }
+
+    @Test
+    @DisplayName("알림에 대한 권한이 없는 사용자 아이디로 알림 확인에 실패한다.")
+    void shouldFailToConfirmNotification_whenUserNotAuthorized() throws Exception {
+      // given
+
+      //when & then
+      mockMvc.perform(patch("/api/notifications/" + notification1.getId())
+              .header("Monew-Request-User-ID", actor.getId()))
+          .andExpectAll(
+              status().isForbidden(),
+              jsonPath("$.details.notificationId").value(notification1.getId().toString()),
+              jsonPath("$.details.userId").value(actor.getId().toString())
+          );
+      Notification updatedNotification = notificationRepository.findById(notification1.getId())
+          .orElseThrow();
+      assertFalse(updatedNotification.isConfirmed());
     }
 
   }

--- a/src/test/java/com/team3/monew/service/NotificationServiceTest.java
+++ b/src/test/java/com/team3/monew/service/NotificationServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 
 import com.team3.monew.dto.notification.CommentLikedNotificationRequest;
 import com.team3.monew.dto.notification.InterestNotificationRequest;
@@ -19,6 +20,8 @@ import com.team3.monew.entity.Notification;
 import com.team3.monew.entity.User;
 import com.team3.monew.entity.enums.NotificationResourceType;
 import com.team3.monew.exception.comment.CommentNotFoundException;
+import com.team3.monew.exception.notification.NotificationConfirmForbiddenException;
+import com.team3.monew.exception.notification.NotificationNotFoundException;
 import com.team3.monew.exception.user.UserNotFoundException;
 import com.team3.monew.mapper.NotificationMapper;
 import com.team3.monew.repository.CommentRepository;
@@ -408,5 +411,80 @@ class NotificationServiceTest {
     assertEquals(dto.confirmed(), notification.isConfirmed());
     assertEquals(dto.createdAt(), notification.getCreatedAt());
     assertEquals(dto.updatedAt(), notification.getUpdatedAt());
+  }
+
+  @Test
+  @DisplayName("사용자 아이디가 존재하지 않을 때 알림 확인 상태 변경에 실패한다.")
+  void shouldFailToConfirmNotification_whenUserNotFound() {
+    // given
+    given(userRepository.existsById(userId1))
+        .willReturn(false);
+
+    // when & then
+    assertThrows(UserNotFoundException.class, () -> {
+      notificationService.confirm(userId1, likeNotification1.getId());
+    });
+  }
+
+  @Test
+  @DisplayName("알림이 존재하지 않을 때 알림 확인 상태 변경에 실패한다.")
+  void shouldFailToConfirmNotification_whenNotificationNotFound() {
+    // given
+    given(userRepository.existsById(userId1)).willReturn(true);
+    given(notificationRepository.findById(likeNotification1.getId()))
+        .willReturn(Optional.empty());
+
+    // when & then
+    assertThrows(NotificationNotFoundException.class, () -> {
+      notificationService.confirm(userId1, likeNotification1.getId());
+    });
+  }
+
+  @Test
+  @DisplayName("알림이 존제하지만 권한이 없는 사용자 일때, 알림 확인 상태 변경에 실패한다.")
+  void shouldFailToConfirmNotification_whenUnAuthorized() {
+    // given
+    given(userRepository.existsById(userId2)).willReturn(true);
+    given(notificationRepository.findById(likeNotification1.getId()))
+        .willReturn(Optional.of(likeNotification1));
+
+    // when & then
+    assertThrows(NotificationConfirmForbiddenException.class, () -> {
+      notificationService.confirm(userId2, likeNotification1.getId());
+    });
+  }
+
+  @Test
+  @DisplayName("사용자 아이디와 알림 아이디로 미확인 알림의 확인 상태 변경에 성공한다.")
+  void shouldConfirmNotification() {
+    // given
+    given(userRepository.existsById(userId1)).willReturn(true);
+    given(notificationRepository.findById(likeNotification1.getId()))
+        .willReturn(Optional.of(likeNotification1));
+
+    // when
+    notificationService.confirm(userId1, likeNotification1.getId());
+
+    assertTrue(likeNotification1.isConfirmed());
+  }
+
+  @Test
+  @DisplayName("이미 확인된 알림은 확인 상태를 변경하지 않고 성공 응답을 보낸다.")
+  void shouldConfirmNotificationWithNoCommit_WhenNotificationAlreadyConfirmed() {
+    // given
+    ReflectionTestUtils.setField(likeNotification1, "isConfirmed", true);
+    ReflectionTestUtils.setField(likeNotification1, "confirmedAt",
+        Instant.parse("2026-03-01T12:00:00Z"));
+
+    given(userRepository.existsById(userId1)).willReturn(true);
+    given(notificationRepository.findById(likeNotification1.getId()))
+        .willReturn(Optional.of(likeNotification1));
+
+    // when
+    notificationService.confirm(userId1, likeNotification1.getId());
+
+    assertTrue(likeNotification1.isConfirmed());
+    assertEquals(likeNotification1.getConfirmedAt(),
+        Instant.parse("2026-03-01T12:00:00Z"));//기존 확인 시간과 동일
   }
 }

--- a/src/test/java/com/team3/monew/service/NotificationServiceTest.java
+++ b/src/test/java/com/team3/monew/service/NotificationServiceTest.java
@@ -441,7 +441,7 @@ class NotificationServiceTest {
   }
 
   @Test
-  @DisplayName("알림이 존제하지만 권한이 없는 사용자 일때, 알림 확인 상태 변경에 실패한다.")
+  @DisplayName("알림이 존재하지만 권한이 없는 사용자 일때, 알림 확인 상태 변경에 실패한다.")
   void shouldFailToConfirmNotification_whenUnAuthorized() {
     // given
     given(userRepository.existsById(userId2)).willReturn(true);


### PR DESCRIPTION
## 관련 이슈
- 주요 이슈
  - closes #14 
- 서브 이슈
  - closes #192   
   - closes #193
    - closes #194     

## 작업 내용
- [feat: 컨트롤러 API 작성](https://github.com/sb10-part3-team3/sb10-MoNew-team3/commit/d98e097ea58a2e49958a16fd1dd90d7fe4012b3b) 
  - 슬라이스 테스트 작성
  - 컨트롤러 API 메서드 작성
  - 스웨거 문서 작성
  - 필요한 예외 정의
 
- [feat: 개별 알림 확인 서비스 작성](https://github.com/sb10-part3-team3/sb10-MoNew-team3/commit/62cb7f677cc8a5babb071323a1b42fe2f388bdf9) 
  - 단위 테스트 작성
  - 서비스 메서드 작성
  - 엔터티 확인 메서드 작성
- [test: 개별 알림 확인 통합 테스트 작성](https://github.com/sb10-part3-team3/sb10-MoNew-team3/commit/eb1e7ac067c712f1200e41292a44743589004e3d)

## 변경 사항
- 

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 알림이 이미 확인된 경우, 성공 응답을 보내지만, 실제 업데이트가 이뤄지지는 않아 DB 연결을 하지 않습니다.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 알림 확인 기능이 추가되었습니다. 사용자는 이제 개별 알림을 확인 상태로 표시할 수 있습니다.
  * 알림 확인 시 확인 시간이 자동으로 기록됩니다.
  * 중복 확인을 방지하는 안전 장치가 포함되었습니다.

* **버그 수정**
  * 존재하지 않는 알림이나 권한 없는 사용자 접근에 대한 적절한 오류 응답을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->