### PR TITLE
feat: 관심사 구독 취소 구현

### DIFF
--- a/src/main/java/com/team3/monew/controller/InterestController.java
+++ b/src/main/java/com/team3/monew/controller/InterestController.java
@@ -87,4 +87,11 @@ public class InterestController implements InterestApi {
 
     return ResponseEntity.ok(response);
   }
+
+  @Override
+  public ResponseEntity<Void> cancelSubscribe(UUID userId, UUID interestId) {
+    interestService.cancelSubscribe(userId, interestId);
+
+    return ResponseEntity.noContent().build();
+  }
 }

--- a/src/main/java/com/team3/monew/controller/InterestController.java
+++ b/src/main/java/com/team3/monew/controller/InterestController.java
@@ -92,6 +92,6 @@ public class InterestController implements InterestApi {
   public ResponseEntity<Void> cancelSubscribe(UUID userId, UUID interestId) {
     interestService.cancelSubscribe(userId, interestId);
 
-    return ResponseEntity.noContent().build();
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/team3/monew/controller/api/InterestApi.java
+++ b/src/main/java/com/team3/monew/controller/api/InterestApi.java
@@ -277,7 +277,7 @@ public interface InterestApi {
       @RequestHeader("Monew-Request-User-Id") UUID userId,
 
       @Parameter(
-          description = "구독할 관심사 ID",
+          description = "구독을 취소할 관심사 ID",
           required = true
       )
       @PathVariable UUID interestId

--- a/src/main/java/com/team3/monew/controller/api/InterestApi.java
+++ b/src/main/java/com/team3/monew/controller/api/InterestApi.java
@@ -241,4 +241,45 @@ public interface InterestApi {
       )
       @PathVariable UUID interestId
   );
+
+  @Operation(
+      summary = "관심사 구독 취소",
+      description = "관심사 구독을 취소합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "구독 취소 성공"
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = "해당 사용자 또는 관심사를 찾을 수 없습니다.",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class)
+          )
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 내부 오류",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class)
+          )
+      )
+  })
+  @DeleteMapping("/{interestId}/subscriptions")
+  ResponseEntity<Void> cancelSubscribe(
+      @Parameter(
+          description = "요청 사용자 ID",
+          required = true
+      )
+      @RequestHeader("Monew-Request-User-Id") UUID userId,
+
+      @Parameter(
+          description = "구독할 관심사 ID",
+          required = true
+      )
+      @PathVariable UUID interestId
+  );
 }

--- a/src/main/java/com/team3/monew/global/enums/ErrorCode.java
+++ b/src/main/java/com/team3/monew/global/enums/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
   INTEREST_KEYWORD_LIST_IS_BLANK(HttpStatus.BAD_REQUEST, "관심사 키워드가 비어있습니다."),
   INTEREST_KEYWORD_DUPLICATED(HttpStatus.BAD_REQUEST, "중복된 관심사 키워드가 존재합니다."),
   INTEREST_ALREADY_SUBSCRIBING(HttpStatus.CONFLICT, "이미 구독중인 관심사입니다."),
+  INTEREST_NOT_SUBSCRIBING(HttpStatus.BAD_REQUEST, "구독하지 않은 관심사입니다."),
 
   // NOTIFICATION
   NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 알림입니다."),

--- a/src/main/java/com/team3/monew/repository/InterestRepository.java
+++ b/src/main/java/com/team3/monew/repository/InterestRepository.java
@@ -23,6 +23,7 @@ public interface InterestRepository extends JpaRepository<Interest, UUID>,
       update Interest i
       set i.subscriberCount = i.subscriberCount - 1
       where i.id = :interestId
+        and i.subscriberCount > 0
       """)
   int decreaseSubscriberCount(@Param("interestId") UUID interestId);
 }

--- a/src/main/java/com/team3/monew/repository/SubscriptionRepository.java
+++ b/src/main/java/com/team3/monew/repository/SubscriptionRepository.java
@@ -3,6 +3,7 @@ package com.team3.monew.repository;
 import com.team3.monew.entity.Subscription;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,6 +11,8 @@ import org.springframework.data.jpa.repository.Query;
 public interface SubscriptionRepository extends JpaRepository<Subscription, UUID> {
 
   boolean existsByUserIdAndInterestId(UUID userId, UUID interestId);
+
+  Optional<Subscription> findByUserIdAndInterestId(UUID userId, UUID interestId);
 
   List<Subscription> findAllByInterestId(UUID interestId);
 

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -77,6 +77,7 @@ public class InterestService {
     return interestMapper.toDto(savedInterest, false);
   }
 
+  @Transactional(readOnly = true)
   public CursorPageResponseDto<InterestDto> findAll(InterestSearchCondition condition,
       UUID userId) {
     log.debug(

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -71,7 +71,7 @@ public class InterestService {
       throw new InterestDuplicateNameException();
     }
 
-    log.debug("관심사 등록 성공 - interestId={}, name={}",
+    log.info("관심사 등록 성공 - interestId={}, name={}",
         savedInterest.getId(), savedInterest.getName());
 
     return interestMapper.toDto(savedInterest, false);
@@ -194,7 +194,7 @@ public class InterestService {
 
     interest.updateKeywords(keywords);
 
-    log.debug("관심사 키워드 수정 성공 - interestId={}, updatedKeywordsCount={}, subscribedByMe={}",
+    log.info("관심사 키워드 수정 성공 - interestId={}, updatedKeywordsCount={}, subscribedByMe={}",
         interestId, keywords.size(), subscribedByMe);
 
     return interestMapper.toDto(interest, subscribedByMe);
@@ -206,7 +206,7 @@ public class InterestService {
 
     interestRepository.delete(interest);
 
-    log.debug("관심사 삭제 성공 - interestId={}", interestId);
+    log.info("관심사 삭제 성공 - interestId={}", interestId);
   }
 
   public SubscriptionDto subscribe(UUID userId, UUID interestId) {
@@ -228,7 +228,7 @@ public class InterestService {
       interestRepository.increaseSubscriberCount(interestId);
       Interest updatedInterest = findInterestOrElseThrow(interestId);
 
-      log.debug("관심사 구독 성공 - userId={}, interestId={}", userId, interestId);
+      log.info("관심사 구독 성공 - userId={}, interestId={}", userId, interestId);
       return interestMapper.toSubscriptionDto(savedSubscription, updatedInterest);
     } catch (DataIntegrityViolationException e) {
       if (isDuplicateSubscriptionViolation(e)) {
@@ -250,7 +250,7 @@ public class InterestService {
     subscriptionRepository.delete(subscription);
     interestRepository.decreaseSubscriberCount(interestId);
 
-    log.debug("관심사 구독 취소 성공 - interestId={}", interestId);
+    log.info("관심사 구독 취소 성공 - interestId={}", interestId);
   }
 
   private Interest findInterestOrElseThrow(UUID interestId) {

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -239,6 +239,20 @@ public class InterestService {
     }
   }
 
+  public void cancelSubscribe(UUID userId, UUID interestId) {
+    log.debug("관심사 구독 취소 요청 - interestId={}", interestId);
+    findUserOrElseThrow(userId);
+    findInterestOrElseThrow(interestId);
+    Subscription subscription
+        = subscriptionRepository.findByUserIdAndInterestId(userId, interestId)
+        .orElseThrow(() -> new InterestException(ErrorCode.INTEREST_NOT_SUBSCRIBING));
+
+    subscriptionRepository.delete(subscription);
+    interestRepository.decreaseSubscriberCount(interestId);
+
+    log.debug("관심사 구독 취소 성공 - interestId={}", interestId);
+  }
+
   private Interest findInterestOrElseThrow(UUID interestId) {
     return interestRepository.findById(interestId)
         .orElseThrow(InterestNotFoundException::new);

--- a/src/test/java/com/team3/monew/controller/InterestControllerTest.java
+++ b/src/test/java/com/team3/monew/controller/InterestControllerTest.java
@@ -31,6 +31,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -505,5 +507,85 @@ class InterestControllerTest {
     mockMvc.perform(post("/api/interests/{interestId}/subscriptions", interestId)
             .header("Monew-Request-User-Id", "invalid-uuid"))
         .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("관심사 구독을 취소할 수 있다")
+  void shouldCancelSubscribe() throws Exception {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+
+    willDoNothing()
+        .given(interestService)
+        .cancelSubscribe(userId, interestId);
+
+    // when & then
+    mockMvc.perform(delete("/api/interests/{interestId}/subscriptions", interestId)
+            .header("MoNew-Request-User-Id", userId))
+        .andExpect(status().isNoContent());
+
+    then(interestService).should()
+        .cancelSubscribe(userId, interestId);
+  }
+
+  @Test
+  @DisplayName("구독하지 않은 관심사는 구독 취소할 수 없다")
+  void shouldFailToCancelSubscribe_whenNotSubscribing() throws Exception {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+
+    willThrow(new InterestException(ErrorCode.INTEREST_NOT_SUBSCRIBING))
+        .given(interestService)
+        .cancelSubscribe(userId, interestId);
+
+    // when & then
+    mockMvc.perform(delete("/api/interests/{interestId}/subscriptions", interestId)
+            .header("MoNew-Request-User-Id", userId))
+        .andExpect(status().isBadRequest());
+
+    then(interestService).should()
+        .cancelSubscribe(userId, interestId);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 사용자는 관심사 구독을 취소할 수 없다")
+  void shouldFailToCancelSubscribe_whenUserNotFound() throws Exception {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+
+    willThrow(new UserNotFoundException(userId))
+        .given(interestService)
+        .cancelSubscribe(userId, interestId);
+
+    // when & then
+    mockMvc.perform(delete("/api/interests/{interestId}/subscriptions", interestId)
+            .header("MoNew-Request-User-Id", userId))
+        .andExpect(status().isNotFound());
+
+    then(interestService).should()
+        .cancelSubscribe(userId, interestId);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 관심사는 구독을 취소할 수 없다")
+  void shouldFailToCancelSubscribe_whenInterestNotFound() throws Exception {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+
+    willThrow(new InterestNotFoundException())
+        .given(interestService)
+        .cancelSubscribe(userId, interestId);
+
+    // when & then
+    mockMvc.perform(delete("/api/interests/{interestId}/subscriptions", interestId)
+            .header("MoNew-Request-User-Id", userId))
+        .andExpect(status().isNotFound());
+
+    then(interestService).should()
+        .cancelSubscribe(userId, interestId);
   }
 }

--- a/src/test/java/com/team3/monew/controller/InterestControllerTest.java
+++ b/src/test/java/com/team3/monew/controller/InterestControllerTest.java
@@ -525,7 +525,7 @@ class InterestControllerTest {
     // when & then
     mockMvc.perform(delete("/api/interests/{interestId}/subscriptions", interestId)
             .header(REQUEST_USER_HEADER, userId))
-        .andExpect(status().isNoContent());
+        .andExpect(status().isOk());
 
     then(interestService).should()
         .cancelSubscribe(userId, interestId);

--- a/src/test/java/com/team3/monew/controller/InterestControllerTest.java
+++ b/src/test/java/com/team3/monew/controller/InterestControllerTest.java
@@ -55,6 +55,8 @@ class InterestControllerTest {
   @MockitoBean
   private InterestService interestService;
 
+  private static final String REQUEST_USER_HEADER = "Monew-Request-User-Id";
+
   @Test
   @DisplayName("내가 구독하지 않은 상태인 관심사를 등록할 수 있다")
   void shouldRegisterInterest_whenInterestNameDoesntDuplicate() throws Exception {
@@ -146,7 +148,7 @@ class InterestControllerTest {
 
     // when & then
     mockMvc.perform(patch("/api/interests/{interestId}", interestId)
-            .header("Monew-Request-User-Id", userId.toString())
+            .header(REQUEST_USER_HEADER, userId.toString())
             .contentType(MediaType.APPLICATION_JSON)
             .content(objMapper.writeValueAsString(request)))
         .andExpect(status().isOk())
@@ -174,7 +176,7 @@ class InterestControllerTest {
     UUID interestId = UUID.randomUUID();
 
     mockMvc.perform(patch("/api/interests/{interestId}", interestId)
-            .header("Monew-Request-User-Id", userId.toString())
+            .header(REQUEST_USER_HEADER, userId.toString())
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isBadRequest());
   }
@@ -206,7 +208,7 @@ class InterestControllerTest {
 
     // when & then
     mockMvc.perform(patch("/api/interests/{interestId}", interestId)
-            .header("Monew-Request-User-Id", "not-uuid")
+            .header(REQUEST_USER_HEADER, "not-uuid")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objMapper.writeValueAsString(request)))
         .andExpect(status().isBadRequest());
@@ -285,7 +287,7 @@ class InterestControllerTest {
 
     // when & then
     mockMvc.perform(get("/api/interests")
-            .header("Monew-Request-User-Id", userId.toString())
+            .header(REQUEST_USER_HEADER, userId.toString())
             .param("keyword", "구")
             .param("orderBy", "name")
             .param("direction", "ASC")
@@ -332,7 +334,7 @@ class InterestControllerTest {
 
     // when & then
     mockMvc.perform(get("/api/interests")
-            .header("Monew-Request-User-Id", userId.toString())
+            .header(REQUEST_USER_HEADER, userId.toString())
             .param("orderBy", "name")
             .param("direction", "ASC")
             .param("limit", "10"))
@@ -375,7 +377,7 @@ class InterestControllerTest {
 
     // when & then
     mockMvc.perform(get("/api/interests")
-            .header("Monew-Request-User-Id", userId.toString())
+            .header(REQUEST_USER_HEADER, userId.toString())
             .param("orderBy", "name")
             .param("direction", "ASC")
             .param("cursor", "나무")
@@ -427,7 +429,7 @@ class InterestControllerTest {
 
     // when & then
     mockMvc.perform(post("/api/interests/{interestId}/subscriptions", interestId)
-            .header("Monew-Request-User-Id", userId))
+            .header(REQUEST_USER_HEADER, userId))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.id").value(subscriptionId.toString()))
         .andExpect(jsonPath("$.interestId").value(interestId.toString()))
@@ -450,7 +452,7 @@ class InterestControllerTest {
 
     // when & then
     mockMvc.perform(post("/api/interests/{interestId}/subscriptions", interestId)
-            .header("Monew-Request-User-Id", userId))
+            .header(REQUEST_USER_HEADER, userId))
         .andExpect(status().isNotFound());
   }
 
@@ -466,7 +468,7 @@ class InterestControllerTest {
 
     // when & then
     mockMvc.perform(post("/api/interests/{interestId}/subscriptions", interestId)
-            .header("Monew-Request-User-Id", userId))
+            .header(REQUEST_USER_HEADER, userId))
         .andExpect(status().isNotFound());
   }
 
@@ -482,7 +484,7 @@ class InterestControllerTest {
 
     // when & then
     mockMvc.perform(post("/api/interests/{interestId}/subscriptions", interestId)
-            .header("Monew-Request-User-Id", userId))
+            .header(REQUEST_USER_HEADER, userId))
         .andExpect(status().isConflict());
   }
 
@@ -505,7 +507,7 @@ class InterestControllerTest {
 
     // when & then
     mockMvc.perform(post("/api/interests/{interestId}/subscriptions", interestId)
-            .header("Monew-Request-User-Id", "invalid-uuid"))
+            .header(REQUEST_USER_HEADER, "invalid-uuid"))
         .andExpect(status().isBadRequest());
   }
 
@@ -522,7 +524,7 @@ class InterestControllerTest {
 
     // when & then
     mockMvc.perform(delete("/api/interests/{interestId}/subscriptions", interestId)
-            .header("MoNew-Request-User-Id", userId))
+            .header(REQUEST_USER_HEADER, userId))
         .andExpect(status().isNoContent());
 
     then(interestService).should()
@@ -542,7 +544,7 @@ class InterestControllerTest {
 
     // when & then
     mockMvc.perform(delete("/api/interests/{interestId}/subscriptions", interestId)
-            .header("MoNew-Request-User-Id", userId))
+            .header(REQUEST_USER_HEADER, userId))
         .andExpect(status().isBadRequest());
 
     then(interestService).should()
@@ -562,7 +564,7 @@ class InterestControllerTest {
 
     // when & then
     mockMvc.perform(delete("/api/interests/{interestId}/subscriptions", interestId)
-            .header("MoNew-Request-User-Id", userId))
+            .header(REQUEST_USER_HEADER, userId))
         .andExpect(status().isNotFound());
 
     then(interestService).should()
@@ -582,7 +584,7 @@ class InterestControllerTest {
 
     // when & then
     mockMvc.perform(delete("/api/interests/{interestId}/subscriptions", interestId)
-            .header("MoNew-Request-User-Id", userId))
+            .header(REQUEST_USER_HEADER, userId))
         .andExpect(status().isNotFound());
 
     then(interestService).should()

--- a/src/test/java/com/team3/monew/integration/InterestServiceIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/InterestServiceIntegrationTest.java
@@ -15,6 +15,7 @@ import com.team3.monew.exception.interest.InterestDuplicateNameException;
 import com.team3.monew.exception.interest.InterestException;
 import com.team3.monew.exception.interest.InterestNotFoundException;
 import com.team3.monew.exception.user.UserNotFoundException;
+import com.team3.monew.global.enums.ErrorCode;
 import com.team3.monew.repository.InterestKeywordRepository;
 import com.team3.monew.repository.InterestRepository;
 import com.team3.monew.repository.SubscriptionRepository;
@@ -686,5 +687,70 @@ public class InterestServiceIntegrationTest {
     Interest foundInterest = interestRepository.findById(interest.getId()).orElseThrow();
     assertThat(foundInterest.getSubscriberCount()).isEqualTo(1);
     assertThat(subscriptionRepository.findAll()).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("관심사 구독을 취소하면 구독 정보가 삭제되고 구독자 수가 감소한다")
+  void shouldCancelSubscriber() {
+    // given
+    User user = userRepository.save(
+        User.create("test@example.com", "tester", "test1234!")
+    );
+
+    Interest interest = interestRepository.save(Interest.create("주식"));
+
+    Subscription subscription = subscriptionRepository.save(
+        Subscription.create(user, interest)
+    );
+
+    interestRepository.increaseSubscriberCount(interest.getId());
+
+    entityManager.flush();
+    entityManager.clear();
+
+    // when
+    interestService.cancelSubscribe(user.getId(), interest.getId());
+
+    entityManager.flush();
+    entityManager.clear();
+
+    // then
+    assertThat(subscriptionRepository.findById(subscription.getId())).isEmpty();
+    assertThat(subscriptionRepository.findByUserIdAndInterestId(
+        user.getId(), interest.getId()
+    )).isEmpty();
+
+    Interest foundInterest = interestRepository.findById(interest.getId())
+        .orElseThrow();
+    assertThat(foundInterest.getSubscriberCount()).isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("구독하지 않은 관심사는 구독 취소할 수 없다")
+  void shouldFailToCancelSubscribe_whenNotSubscribing() {
+    // given
+    User user = userRepository.save(
+        User.create("test@example.com", "tester", "test1234!")
+    );
+
+    Interest interest = interestRepository.save(
+        Interest.create("주식")
+    );
+
+    entityManager.flush();
+    entityManager.clear();
+
+    // when & then
+    assertThatThrownBy(() -> interestService.cancelSubscribe(user.getId(), interest.getId()))
+        .isInstanceOf(InterestException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.INTEREST_NOT_SUBSCRIBING);
+
+    assertThat(subscriptionRepository.findByUserIdAndInterestId(user.getId(), interest.getId()))
+        .isEmpty();
+
+    Interest foundInterest = interestRepository.findById(interest.getId())
+        .orElseThrow();
+    assertThat(foundInterest.getSubscriberCount()).isEqualTo(0);
   }
 }

--- a/src/test/java/com/team3/monew/repository/impl/InterestRepositoryTest.java
+++ b/src/test/java/com/team3/monew/repository/impl/InterestRepositoryTest.java
@@ -371,4 +371,25 @@ class InterestRepositoryTest {
     // then
     assertThat(count).isEqualTo(3);
   }
+
+  @Test
+  @DisplayName("구독 취소 시 구독자 수는 음수가 되지 않는다")
+  void shouldNotDecreaseSubscriberCountBelowZero() {
+    // given
+    Interest interest = interestRepository.save(Interest.create("주식"));
+
+    em.flush();
+    em.clear();
+
+    // when
+    int updatedCount = interestRepository.decreaseSubscriberCount(interest.getId());
+
+    em.flush();
+    em.clear();
+
+    // then
+    assertThat(updatedCount).isEqualTo(0);
+    Interest foundInterest = interestRepository.findById(interest.getId()).orElseThrow();
+    assertThat(foundInterest.getSubscriberCount()).isEqualTo(0);
+  }
 }

--- a/src/test/java/com/team3/monew/service/InterestServiceTest.java
+++ b/src/test/java/com/team3/monew/service/InterestServiceTest.java
@@ -43,6 +43,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
@@ -603,5 +604,92 @@ class InterestServiceTest {
     then(subscriptionRepository).should().save(any(Subscription.class));
     then(interestRepository).should(never()).increaseSubscriberCount(any(UUID.class));
     then(interestMapper).should(never()).toSubscriptionDto(any(), any());
+  }
+
+  @Test
+  @DisplayName("관심사 구독을 취소할 수 있다")
+  void shouldCancelSubscribe() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+
+    User user = mock(User.class);
+    Interest interest = mock(Interest.class);
+    Subscription subscription = mock(Subscription.class);
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+    given(subscriptionRepository.findByUserIdAndInterestId(userId, interestId))
+        .willReturn(Optional.of(subscription));
+
+    // when
+    interestService.cancelSubscribe(userId, interestId);
+
+    // then
+    then(subscriptionRepository).should().delete(subscription);
+    then(interestRepository).should().decreaseSubscriberCount(interestId);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 사용자면 구독 취소에 실패한다")
+  void shouldFailToCancelSubscribe_whenUserNotFound() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+
+    given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> interestService.cancelSubscribe(userId, interestId))
+        .isInstanceOf(UserNotFoundException.class);
+
+    then(interestRepository).should(never()).findById(any());
+    then(subscriptionRepository).should(never()).findByUserIdAndInterestId(any(), any());
+    then(subscriptionRepository).should(never()).delete(any());
+    then(interestRepository).should(never()).decreaseSubscriberCount(any());
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 관심사면 구독 취소에 실패한다")
+  void shouldFailToCancelSubscribe_whenInterestNotFound() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+
+    User user = mock(User.class);
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(interestRepository.findById(interestId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> interestService.cancelSubscribe(userId, interestId))
+        .isInstanceOf(InterestNotFoundException.class);
+
+    then(subscriptionRepository).should(never()).findByUserIdAndInterestId(any(), any());
+    then(subscriptionRepository).should(never()).delete(any());
+    then(interestRepository).should(never()).decreaseSubscriberCount(any());
+  }
+
+  @Test
+  @DisplayName("구독하지 않은 관심사는 구독 취소할 수 없다")
+  void shouldFailToCancelSubscribe_whenNotSubscribing() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+
+    User user = mock(User.class);
+    Interest interest = mock(Interest.class);
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+    given(subscriptionRepository.findByUserIdAndInterestId(userId, interestId))
+        .willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> interestService.cancelSubscribe(userId, interestId))
+        .isInstanceOf(InterestException.class);
+
+    then(subscriptionRepository).should(never()).delete(any());
+    then(interestRepository).should(never()).decreaseSubscriberCount(any());
   }
 }


### PR DESCRIPTION
<<제목은 커밋과 동일하게>>>

## 관련 이슈
- closes #29 
  - 서브이슈
    - closes #188  
    - closes #189  
    - closes #190 

## 작업 내용

- feat: 관심사 구독 취소 기능 구현
  - InterestService에 관심사 구독 취소 메서드(cancelSubscribe) 구현
  - 사용자 ID와 관심사 ID 기반 구독 삭제 로직 구현
  - 구독 여부 검증 로직 추가
    - findByUserIdAndInterestId 기반 조회 후 없을 경우 예외 처리
  - 구독 취소 성공 시 관심사 subscriberCount 감소 처리
    - decreaseSubscriberCount 쿼리 메서드 활용
  - 구독 취소 성공 시 별도 반환값 없이 처리

- feat: 관심사 구독 취소 Repository 메서드 추가
  - subscriberCount 감소를 위한 JPQL update 쿼리 메서드(decreaseSubscriberCount) 구현
  - 데이터 정합성 유지를 위해 subscriberCount > 0 조건 추가

- feat: 관심사 구독 취소 Controller 구현
  - DELETE /api/interests/{interestId}/subscriptions 엔드포인트 구현
  - RequestHeader 기반 사용자 ID 처리 (MoNew-Request-User-Id)
  - PathVariable 기반 관심사 ID 처리
  - InterestService와 연동하여 구독 취소 수행

- test: 관심사 구독 취소 Test 코드 작성
  - 서비스 단위 테스트 작성
    - 정상 구독 취소 성공 케이스 검증
    - 존재하지 않는 사용자 예외 처리 검증
    - 존재하지 않는 관심사 예외 처리 검증
    - 구독하지 않은 경우 예외 처리 검증
    - 구독 취소 시 subscriberCount 감소 호출 검증
  - 서비스 통합 테스트 작성
    - 실제 DB 기반 구독 삭제 및 subscriberCount 감소 검증
    - 구독 데이터 삭제 여부 검증
    - 구독하지 않은 경우 예외 발생 검증
  - 컨트롤러 슬라이스 테스트 작성
    - 구독 취소 성공 시 200 응답 검증
    - 존재하지 않는 사용자/관심사 요청 시 404 응답 검증
    - 구독하지 않은 경우 400 또는 404 응답 검증 (에러 코드 정책에 따름)
    - 잘못된 요청(헤더 누락, UUID 형식 오류) 시 400 응답 검증

- refactor: 로그 레벨 수정
  - 서비스 주요 흐름에 맞게 debug / info 로그 레벨 정리

- refactor: @Transactional(readOnly = true) 누락 수정
  - 조회 메서드에 readOnly 옵션 적용하여 성능 및 의도 명확화

## 변경 사항
- 주요 변경 사항을 작성해주세요.

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 동시성 환경에서 subscriberCount 정합성을 보장하고 불필요한 엔티티 조회를 줄이기 위해 DB update 쿼리로 직접 처리했습니다!

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
- **관심사 구독 취소**: 사용자가 구독한 관심사를 취소할 수 있는 DELETE API가 추가되었습니다. 취소 성공 시 200 OK로 응답하며, 실패 시 명확한 오류 메시지로 안내됩니다.

## 버그 수정
- **구독자 수 음수 방지**: 취소 처리 시 관심사의 구독자 수가 음수로 내려가지 않도록 안전하게 변경했습니다.

## 테스트
- 단위·통합·컨트롤러 테스트를 추가해 취소 성공·실패 시나리오와 경계 조건을 검증했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->