### PR TITLE
feat: 알림 전체 확인 기능

### DIFF
--- a/src/main/java/com/team3/monew/controller/NotificationController.java
+++ b/src/main/java/com/team3/monew/controller/NotificationController.java
@@ -14,7 +14,6 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -46,6 +45,13 @@ public class NotificationController implements NotificationApi {
       @RequestHeader(REQUEST_USER_ID_HEADER) UUID requestUserId,
       @PathVariable UUID notificationId) {
     notificationService.confirm(requestUserId, notificationId);
+    return ResponseEntity.noContent().build();
+  }
+
+  @PatchMapping()
+  public ResponseEntity<?> confirmAll(
+      @RequestHeader(REQUEST_USER_ID_HEADER) UUID requestUserId) {
+    notificationService.confirmAll(requestUserId);
     return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/team3/monew/controller/api/NotificationApi.java
+++ b/src/main/java/com/team3/monew/controller/api/NotificationApi.java
@@ -85,7 +85,7 @@ public interface NotificationApi {
   })
   @Parameter(name = REQUEST_USER_ID_HEADER, description = "요청자 ID")
   @PatchMapping()
-  public ResponseEntity<?> confirmAll(
+  ResponseEntity<?> confirmAll(
       @RequestHeader(REQUEST_USER_ID_HEADER) UUID requestUserId
   );
 }

--- a/src/main/java/com/team3/monew/controller/api/NotificationApi.java
+++ b/src/main/java/com/team3/monew/controller/api/NotificationApi.java
@@ -4,6 +4,8 @@ import com.team3.monew.dto.notification.NotificationDto;
 import com.team3.monew.dto.pagination.CursorPageResponseDto;
 import com.team3.monew.global.response.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -35,6 +37,12 @@ public interface NotificationApi {
       @ApiResponse(responseCode = "500", description = "서버 내부 오류",
           content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
+  @Parameters({
+      @Parameter(name = REQUEST_USER_ID_HEADER, description = "요청자 ID"),
+      @Parameter(name = "cursor", description = "커서 값(알림 ID)"),
+      @Parameter(name = "after", description = "보조 커서 값(createdAt)"),
+      @Parameter(name = "limit", description = "커서 페이지 크기")
+  })
   @GetMapping
   ResponseEntity<CursorPageResponseDto<NotificationDto>> findAllNotConfirmed(
       @RequestHeader(REQUEST_USER_ID_HEADER) UUID requestUserId,
@@ -55,9 +63,29 @@ public interface NotificationApi {
       @ApiResponse(responseCode = "500", description = "서버 내부 오류",
           content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
+  @Parameters({
+      @Parameter(name = REQUEST_USER_ID_HEADER, description = "요청자 ID"),
+      @Parameter(name = "notificationId", description = "알림 ID")
+  })
   @PatchMapping("/{notificationId}")
   ResponseEntity<?> confirm(
       @RequestHeader(REQUEST_USER_ID_HEADER) UUID requestUserId,
       @PathVariable UUID notificationId
+  );
+
+  @Operation(summary = "전체 알림 확인", description = "전체 알림을 한번에 확인합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "204", description = "전체 알림 확인 성공"),
+      @ApiResponse(responseCode = "404", description = "사용자 정보 없음",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 (입력값 검증 실패)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  @Parameter(name = REQUEST_USER_ID_HEADER, description = "요청자 ID")
+  @PatchMapping()
+  public ResponseEntity<?> confirmAll(
+      @RequestHeader(REQUEST_USER_ID_HEADER) UUID requestUserId
   );
 }

--- a/src/main/java/com/team3/monew/repository/NotificationRepository.java
+++ b/src/main/java/com/team3/monew/repository/NotificationRepository.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface NotificationRepository extends JpaRepository<Notification, UUID> {
@@ -26,4 +27,13 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
       Instant after, Pageable pageable);
 
   Long countByUserIdAndIsConfirmedFalse(UUID userId);
+
+  @Modifying(clearAutomatically = true)
+  @Query("update Notification n "
+      + "set n.isConfirmed = true, "
+      + "n.confirmedAt = :confirmedAt, "
+      + "n.updatedAt = :confirmedAt "
+      + "where n.user.id = :userId and n.isConfirmed = false")
+  int confirmAllByUserId(UUID userId, Instant confirmedAt);
+
 }

--- a/src/main/java/com/team3/monew/repository/NotificationRepository.java
+++ b/src/main/java/com/team3/monew/repository/NotificationRepository.java
@@ -28,7 +28,7 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
 
   Long countByUserIdAndIsConfirmedFalse(UUID userId);
 
-  @Modifying(clearAutomatically = true)
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query("update Notification n "
       + "set n.isConfirmed = true, "
       + "n.confirmedAt = :confirmedAt, "

--- a/src/main/java/com/team3/monew/service/NotificationService.java
+++ b/src/main/java/com/team3/monew/service/NotificationService.java
@@ -137,7 +137,10 @@ public class NotificationService {
   }
 
   public void confirmAll(UUID requestUserId) {
-
+    log.debug("전체 알림 확인 시작: userId={}", requestUserId);
+    checkUserAvailable(requestUserId);
+    int count = notificationRepository.confirmAllByUserId(requestUserId, Instant.now());
+    log.info("전체 알림 확인 성공: userId={}, updatedNotificationsCount={}", requestUserId, count);
   }
 
   private String generateCommentLikedContent(String actorUserNickname) {
@@ -146,5 +149,12 @@ public class NotificationService {
 
   private String generateInterestNotificationContent(String interestName, Integer articleCount) {
     return interestName + "와 관련된 기사가 " + articleCount + "건 등록되었습니다.";
+  }
+
+  private void checkUserAvailable(UUID requestUserId) {
+    if (!userRepository.existsById(requestUserId)) {
+      throw new UserNotFoundException(requestUserId);
+    }
+    log.debug("유효한 사용자 검증 완료");
   }
 }

--- a/src/main/java/com/team3/monew/service/NotificationService.java
+++ b/src/main/java/com/team3/monew/service/NotificationService.java
@@ -121,9 +121,7 @@ public class NotificationService {
 
   public void confirm(UUID requestUserId, UUID notificationId) {
     log.debug("개별 알림 확인 시작: userId={}, notificationId={}", requestUserId, notificationId);
-    if (!userRepository.existsById(requestUserId)) {
-      throw new UserNotFoundException(requestUserId);
-    }
+    checkUserAvailable(requestUserId);
     log.debug("개별 알림 확인에서 사용자 유효성 확인 완료: userId={}, notificationId={}", requestUserId,
         notificationId);
     Notification notification = notificationRepository.findById(notificationId)

--- a/src/main/java/com/team3/monew/service/NotificationService.java
+++ b/src/main/java/com/team3/monew/service/NotificationService.java
@@ -136,6 +136,10 @@ public class NotificationService {
     log.info("개별 알림 확인 요청 성공: userId={}, notificationId={}", requestUserId, notificationId);
   }
 
+  public void confirmAll(UUID requestUserId) {
+
+  }
+
   private String generateCommentLikedContent(String actorUserNickname) {
     return actorUserNickname + "님이 나의 댓글을 좋아합니다.";
   }

--- a/src/test/java/com/team3/monew/controller/NotificationControllerTest.java
+++ b/src/test/java/com/team3/monew/controller/NotificationControllerTest.java
@@ -298,4 +298,31 @@ class NotificationControllerTest {
         .andExpect(jsonPath("$.details.userId").value(userId1.toString()))
         .andExpect(jsonPath("$.code").value("NOTIFICATION_CONFIRM_FORBIDDEN"));
   }
+
+  @Test
+  @DisplayName("사용자 아이디 헤더로 전체 알림 확인에 성공한다.(204)")
+  void shouldConfirmAllNotifications_whenUserIdIsGiven() throws Exception {
+
+    // when & then
+    mockMvc.perform(patch(NOTIFICATION_URL)
+            .header("Monew-Request-User-ID", userId1))
+        .andExpect(status().isNoContent());
+    then(notificationService).should().confirmAll(eq(userId1));
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 사용자 아이디로 전체 알림 확인을 시도하면, 전체 알림 확인 실패 응답을 보낸다.")
+  void shouldResponseErrorResponseToConfirmAll_whenUserNotFound() throws Exception {
+    // given
+    UUID notificationId = UUID.randomUUID();
+    willThrow(new UserNotFoundException(userId1))
+        .given(notificationService)
+        .confirmAll(eq(userId1));
+    // when & then
+    mockMvc.perform(patch(NOTIFICATION_URL)
+            .header("Monew-Request-User-ID", userId1))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.details.userId").value(userId1.toString()))
+        .andExpect(jsonPath("$.code").value("USER_NOT_FOUND"));
+  }
 }

--- a/src/test/java/com/team3/monew/controller/NotificationControllerTest.java
+++ b/src/test/java/com/team3/monew/controller/NotificationControllerTest.java
@@ -314,7 +314,6 @@ class NotificationControllerTest {
   @DisplayName("존재하지 않는 사용자 아이디로 전체 알림 확인을 시도하면, 전체 알림 확인 실패 응답을 보낸다.")
   void shouldResponseErrorResponseToConfirmAll_whenUserNotFound() throws Exception {
     // given
-    UUID notificationId = UUID.randomUUID();
     willThrow(new UserNotFoundException(userId1))
         .given(notificationService)
         .confirmAll(eq(userId1));

--- a/src/test/java/com/team3/monew/integration/NotificationIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/NotificationIntegrationTest.java
@@ -269,6 +269,7 @@ public class NotificationIntegrationTest {
     private Notification notification2;
     private Notification notification3;
     private Notification notification4;
+    private Notification notificationActor;
 
     private static final DateTimeFormatter formatter = DateTimeFormatter.ISO_INSTANT;
 
@@ -301,12 +302,16 @@ public class NotificationIntegrationTest {
           interest2.getId(), null);
       notification4 = Notification.create(subscriber, "content4", NotificationResourceType.COMMENT,
           comment.getId(), actor);//이미 확인된
+      notificationActor = Notification.create(actor, "content3", NotificationResourceType.INTEREST,
+          interest2.getId(), null);
       ReflectionTestUtils.setField(notification4, "isConfirmed", true);
+      ReflectionTestUtils.setField(notification4, "confirmedAt", Instant.now());
 
       notificationRepository.saveAndFlush(notification1);
       notificationRepository.saveAndFlush(notification2);
       notificationRepository.saveAndFlush(notification3);
       notificationRepository.saveAndFlush(notification4);
+      notificationRepository.saveAndFlush(notificationActor);
 
       em.clear();
       // 새로가져오기
@@ -393,7 +398,7 @@ public class NotificationIntegrationTest {
     }
 
     @Test
-    @DisplayName("이미 확인되 알림을 확인하면 성공응답이지만, 확인 시간이 변경되지 않는다.")
+    @DisplayName("이미 확인된 알림을 확인하면 성공응답이지만, 확인 시간이 변경되지 않는다.")
     void shouldConfirmNotificationAlreadyConfirmed_whenUserIdAndNotificationIdAreGiven()
         throws Exception {
       //given
@@ -470,5 +475,44 @@ public class NotificationIntegrationTest {
       assertFalse(updatedNotification.isConfirmed());
     }
 
+    @Test
+    @DisplayName("유효하지 않은 사용자 아이디로 전체 알림 확인에 실패한다.")
+    void shouldFailToConfirmAllNotifications_whenUserNotFound() throws Exception {
+      // given
+      UUID wrongUserId = UUID.randomUUID();
+
+      //when & then
+      mockMvc.perform(patch("/api/notifications")
+              .header("Monew-Request-User-ID", wrongUserId))
+          .andExpectAll(
+              status().isNotFound(),
+              jsonPath("$.details.userId").value(wrongUserId.toString())
+          );
+      Notification updatedNotification = notificationRepository.findById(notification1.getId())
+          .orElseThrow();
+      assertFalse(updatedNotification.isConfirmed());
+    }
+
+    @Test
+    @DisplayName("사용자 아이디로 전체 알림을 확인한다.")
+    void shouldConfirmAllNotifications_whenUserIdIsGiven() throws Exception {
+      // when & then
+      mockMvc.perform(patch("/api/notifications")
+              .header("Monew-Request-User-ID", subscriber.getId()))
+          .andExpect(status().isNoContent());
+
+      List<Notification> notifications = notificationRepository.findAll();
+
+      assertAll(
+          () -> assertThat(notifications.stream()
+              .filter(n -> n.getUser().getId().equals(subscriber.getId())))
+              .allMatch(Notification::isConfirmed),
+
+          //actor유저는 확인안됨 상태 유지
+          () -> assertThat(notifications.stream()
+              .filter(n -> n.getUser().getId().equals(actor.getId())))
+              .allMatch(n -> !n.isConfirmed())
+      );
+    }
   }
 }

--- a/src/test/java/com/team3/monew/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/team3/monew/repository/NotificationRepositoryTest.java
@@ -79,6 +79,7 @@ class NotificationRepositoryTest {
         NotificationResourceType.INTEREST,
         interestId2, null);
     ReflectionTestUtils.setField(confirmedNotification, "isConfirmed", true);
+    ReflectionTestUtils.setField(confirmedNotification, "confirmedAt", Instant.now());
 
     notificationRepository.saveAndFlush(likeNotification1);
     notificationRepository.saveAndFlush(likeNotification2);
@@ -159,5 +160,27 @@ class NotificationRepositoryTest {
         () -> assertThat(result.hasNext()).isFalse()
 
     );
+  }
+
+  @Test
+  @DisplayName("미확인 알림들만 확인으로 변경하고 변경된 행 개수를 반환한다.")
+  void shouldConfirmAllNotificationsUnConfirmedByUserId() {
+    // given
+    Instant now = Instant.now();
+
+    //when
+    int count = notificationRepository.confirmAllByUserId(user1.getId(), now);
+
+    em.flush();
+    em.clear();
+
+    assertAll(
+        () -> assertEquals(4, count),
+        () -> assertThat(notificationRepository.findAll().stream()
+            .filter(n -> n.getConfirmedAt() != null)
+            .filter(Notification::isConfirmed)
+            .count()).isEqualTo(5)//전체 확인 알람은 5개
+    );
+
   }
 }

--- a/src/test/java/com/team3/monew/service/NotificationServiceTest.java
+++ b/src/test/java/com/team3/monew/service/NotificationServiceTest.java
@@ -500,6 +500,8 @@ class NotificationServiceTest {
     assertThrows(UserNotFoundException.class, () -> {
       notificationService.confirmAll(userId1);
     });
+    then(notificationRepository).should(never())
+        .confirmAllByUserId(eq(userId1), any(Instant.class));
   }
 
   @Test

--- a/src/test/java/com/team3/monew/service/NotificationServiceTest.java
+++ b/src/test/java/com/team3/monew/service/NotificationServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 
 import com.team3.monew.dto.notification.CommentLikedNotificationRequest;
 import com.team3.monew.dto.notification.InterestNotificationRequest;
@@ -486,5 +487,34 @@ class NotificationServiceTest {
     assertTrue(likeNotification1.isConfirmed());
     assertEquals(likeNotification1.getConfirmedAt(),
         Instant.parse("2026-03-01T12:00:00Z"));//기존 확인 시간과 동일
+  }
+
+  @Test
+  @DisplayName("사용자 아이디가 존재하지 않을 때 전체 알림 확인 상태 변경에 실패한다.")
+  void shouldFailToConfirmAllNotifications_whenUserNotFound() {
+    // given
+    given(userRepository.existsById(userId1))
+        .willReturn(false);
+
+    // when & then
+    assertThrows(UserNotFoundException.class, () -> {
+      notificationService.confirmAll(userId1);
+    });
+  }
+
+  @Test
+  @DisplayName("유효한 사용자 아이디로 전체 미확인 알림의 확인 상태 변경에 성공한다.")
+  void shouldConfirmAllNotifications() {
+    // given
+    given(userRepository.existsById(userId1)).willReturn(true);
+    given(notificationRepository.confirmAllByUserId(eq(userId1), any(Instant.class)))
+        .willReturn(4);//4개 알림 확인 상태로 변경
+
+    // when
+    notificationService.confirmAll(userId1);
+
+    //then
+    then(notificationRepository).should(times(1))
+        .confirmAllByUserId(eq(userId1), any(Instant.class));
   }
 }

--- a/src/test/java/com/team3/monew/service/NotificationServiceTest.java
+++ b/src/test/java/com/team3/monew/service/NotificationServiceTest.java
@@ -516,6 +516,7 @@ class NotificationServiceTest {
     notificationService.confirmAll(userId1);
 
     //then
+    then(userRepository).should(times(1)).existsById(userId1);
     then(notificationRepository).should(times(1))
         .confirmAllByUserId(eq(userId1), any(Instant.class));
   }


### PR DESCRIPTION
## 관련 이슈
- 주요 이슈
  - closes #196 
- 서브 이슈
  - closes #200 
  - closes #201 
  - closes #202   

## 작업 내용
- [feat: 알림 전체 확인 컨트롤러 API 작성](https://github.com/sb10-part3-team3/sb10-MoNew-team3/commit/f5e3a4701368b9a287cb441981490d18012c6592) 
  - 슬라이스 테스트 작성
  - 컨트롤러 메서드 작성
  - 스웨거 문서 작성
  - closes: https://github.com/sb10-part3-team3/sb10-MoNew-team3/issues/200
- [feat: 알림 전체 확인 서비스 코드 작성](https://github.com/sb10-part3-team3/sb10-MoNew-team3/commit/e5281f6419a35ceafd15e2276826fb6c1e4c4e7a) 
  - 단위 테스트 작성
  - 전체 확인 서비스 계층 메서드 작성
  - 레포지토리 메서드 작성
  - 레포지토리 쿼리 메서드 슬라이스 테스트
  - closes: https://github.com/sb10-part3-team3/sb10-MoNew-team3/issues/201
- [test: 알림 전체 확인 통합 테스트 작성](https://github.com/sb10-part3-team3/sb10-MoNew-team3/commit/599acd63eebbef81c45910c6cb4b4f2f35a2c29c) 
  - closes: https://github.com/sb10-part3-team3/sb10-MoNew-team3/issues/202
- [refactor: NotificationService의 개별 알림 확인 메서드에서 사용자 검증 분리 메서드 활용으로 변경](https://github.com/sb10-part3-team3/sb10-MoNew-team3/commit/7310d12fc74426b75bb5c4b0973ab2d6466f2dcc) 

## 변경 사항
- 주요 변경 사항을 작성해주세요.

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자의 모든 미확인 알림을 한 번에 확인(일괄 확인)하는 PATCH 엔드포인트가 추가되어 성공 시 204(No Content)를 반환합니다.

* **문서**
  * 알림 관련 API 문서(요청 헤더 및 쿼리/경로 파라미터, 응답 코드)가 강화되어 사용성이 개선되었습니다.

* **테스트**
  * 컨트롤러·서비스·레포지토리의 단위 및 통합 테스트가 추가되어 일괄 확인 동작과 예외 매핑(유저 미존재 등)을 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->