### PR TITLE
refactor: 관심사 서비스 성능 개선 및 응답 일치

### DIFF
--- a/src/main/java/com/team3/monew/controller/InterestController.java
+++ b/src/main/java/com/team3/monew/controller/InterestController.java
@@ -92,6 +92,6 @@ public class InterestController implements InterestApi {
   public ResponseEntity<Void> cancelSubscribe(UUID userId, UUID interestId) {
     interestService.cancelSubscribe(userId, interestId);
 
-    return ResponseEntity.ok().build();
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/team3/monew/controller/InterestController.java
+++ b/src/main/java/com/team3/monew/controller/InterestController.java
@@ -36,11 +36,10 @@ public class InterestController implements InterestApi {
 
   @Override
   public ResponseEntity<InterestDto> update(
-      UUID userId,
       UUID interestId,
       @Valid @RequestBody InterestUpdateRequest dto
   ) {
-    InterestDto response = interestService.updateKeyword(userId, interestId, dto);
+    InterestDto response = interestService.updateKeyword(interestId, dto);
 
     return ResponseEntity.ok(response);
   }

--- a/src/main/java/com/team3/monew/controller/api/InterestApi.java
+++ b/src/main/java/com/team3/monew/controller/api/InterestApi.java
@@ -99,11 +99,6 @@ public interface InterestApi {
   })
   @PatchMapping("/{interestId}")
   ResponseEntity<InterestDto> update(
-      @Parameter(
-          description = "요청 사용자 ID",
-          required = true
-      )
-      @RequestHeader("Monew-Request-User-Id") UUID userId,
       @PathVariable UUID interestId,
       @RequestBody @Valid InterestUpdateRequest dto
   );

--- a/src/main/java/com/team3/monew/dto/interest/InterestDto.java
+++ b/src/main/java/com/team3/monew/dto/interest/InterestDto.java
@@ -4,10 +4,11 @@ import java.util.List;
 import java.util.UUID;
 
 public record InterestDto(
-        UUID id,
-        String name,
-        List<String> keywords,
-        int subscriberCount,
-        boolean subscribedByMe
+    UUID id,
+    String name,
+    List<String> keywords,
+    int subscriberCount,
+    Boolean subscribedByMe
 ) {
+
 }

--- a/src/main/java/com/team3/monew/entity/Interest.java
+++ b/src/main/java/com/team3/monew/entity/Interest.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.hibernate.annotations.BatchSize;
 
 @Entity
 @Table(name = "interests")
@@ -21,6 +22,7 @@ public class Interest extends BaseEntity {
   @Column(nullable = false)
   private int subscriberCount;
 
+  @BatchSize(size = 100)    // IN 쿼리로 묶어서 한 번에 가져오는 방식
   @OneToMany(mappedBy = "interest", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<InterestKeyword> keywords = new ArrayList<>();
 

--- a/src/main/java/com/team3/monew/mapper/InterestMapper.java
+++ b/src/main/java/com/team3/monew/mapper/InterestMapper.java
@@ -15,7 +15,7 @@ public interface InterestMapper {
 
   @Mapping(target = "keywords", source = "interest.keywords")
   @Mapping(target = "subscribedByMe", source = "subscribedByMe")
-  InterestDto toDto(Interest interest, boolean subscribedByMe);
+  InterestDto toDto(Interest interest, Boolean subscribedByMe);
 
   @Mapping(target = "interestId", source = "interest.id")
   @Mapping(target = "interestName", source = "interest.name")

--- a/src/main/java/com/team3/monew/repository/SubscriptionRepository.java
+++ b/src/main/java/com/team3/monew/repository/SubscriptionRepository.java
@@ -4,9 +4,11 @@ import com.team3.monew.entity.Subscription;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SubscriptionRepository extends JpaRepository<Subscription, UUID> {
 
@@ -25,4 +27,15 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, UUID
 
   @Query("select s.user.id as userId, s.interest.id as interestId from Subscription s where s.interest.id in :interestIds")
   List<SubscriptionInfo> findAllProjectedByInterestIdIn(Collection<UUID> interestIds);
+
+  @Query("""
+          select s.interest.id
+          from Subscription s
+          where s.user.id = :userId
+            and s.interest.id in :interestIds
+      """)
+  Set<UUID> findSubscribedInterestIds(
+      @Param("userId") UUID userId,
+      @Param("interestIds") List<UUID> interestIds
+  );
 }

--- a/src/main/java/com/team3/monew/repository/impl/InterestRepositoryImpl.java
+++ b/src/main/java/com/team3/monew/repository/impl/InterestRepositoryImpl.java
@@ -48,7 +48,7 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom {
         .where(buildSearchCondition(condition, interest))
         .fetchOne();
 
-    return count == null ? 0L : count.intValue();
+    return count == null ? 0L : count;
   }
 
   private BooleanBuilder buildSearchCondition(

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -159,7 +159,7 @@ public class InterestService {
     );
   }
 
-  public InterestDto updateKeyword(UUID userId, UUID interestId, InterestUpdateRequest dto) {
+  public InterestDto updateKeyword(UUID interestId, InterestUpdateRequest dto) {
     log.debug("관심사 키워드 수정 요청 - interestId={}, keywordCount={}",
         interestId, dto.keywords() == null ? 0 : dto.keywords().size());
 
@@ -195,9 +195,6 @@ public class InterestService {
       throw new InterestException(ErrorCode.INTEREST_KEYWORD_DUPLICATED);
     }
 
-    boolean subscribedByMe =
-        subscriptionRepository.existsByUserIdAndInterestId(userId, interestId);
-
     // 기존 키워드와 dto의 키워드중 중복되는게 있을 경우 지워지지 않는 경우를 대비
     interest.getKeywords().clear();
     interestRepository.flush();
@@ -205,9 +202,9 @@ public class InterestService {
     interest.updateKeywords(keywords);
 
     log.info("관심사 키워드 수정 성공 - interestId={}, updatedKeywordsCount={}, subscribedByMe={}",
-        interestId, keywords.size(), subscribedByMe);
+        interestId, keywords.size(), null);
 
-    return interestMapper.toDto(interest, subscribedByMe);
+    return interestMapper.toDto(interest, null);
   }
 
   public void deleteInterest(UUID interestId) {

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -21,6 +21,7 @@ import com.team3.monew.repository.SubscriptionRepository;
 import com.team3.monew.repository.UserRepository;
 import java.time.Instant;
 import java.util.Objects;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.exception.ConstraintViolationException;
@@ -130,11 +131,16 @@ public class InterestService {
       nextAfter = last.getCreatedAt();
     }
 
+    List<UUID> interestIds = content.stream()
+        .map(Interest::getId)
+        .toList();
+
+    Set<UUID> subscribedInterestIds =
+        subscriptionRepository.findSubscribedInterestIds(userId, interestIds);
+
     List<InterestDto> dtoList = content.stream()
         .map(interest -> {
-          // N+1 문제 발생 가능성 있지만 추후 성능 개선 시 수정 예정
-          boolean subscribedByMe =
-              subscriptionRepository.existsByUserIdAndInterestId(userId, interest.getId());
+          boolean subscribedByMe = subscribedInterestIds.contains(interest.getId());
           return interestMapper.toDto(interest, subscribedByMe);
         })
         .toList();

--- a/src/test/java/com/team3/monew/controller/InterestControllerTest.java
+++ b/src/test/java/com/team3/monew/controller/InterestControllerTest.java
@@ -525,7 +525,7 @@ class InterestControllerTest {
     // when & then
     mockMvc.perform(delete("/api/interests/{interestId}/subscriptions", interestId)
             .header(REQUEST_USER_HEADER, userId))
-        .andExpect(status().isOk());
+        .andExpect(status().isNoContent());
 
     then(interestService).should()
         .cancelSubscribe(userId, interestId);

--- a/src/test/java/com/team3/monew/controller/InterestControllerTest.java
+++ b/src/test/java/com/team3/monew/controller/InterestControllerTest.java
@@ -125,7 +125,6 @@ class InterestControllerTest {
   @DisplayName("관심사 키워드를 수정할 수 있다")
   void shouldUpdateInterestKeywords_whenValidRequest() throws Exception {
     // given
-    UUID userId = UUID.randomUUID();
     UUID interestId = UUID.randomUUID();
 
     InterestUpdateRequest request = new InterestUpdateRequest(
@@ -141,14 +140,12 @@ class InterestControllerTest {
     );
 
     given(interestService.updateKeyword(
-        eq(userId),
         eq(interestId),
         any(InterestUpdateRequest.class)
     )).willReturn(response);
 
     // when & then
     mockMvc.perform(patch("/api/interests/{interestId}", interestId)
-            .header(REQUEST_USER_HEADER, userId.toString())
             .contentType(MediaType.APPLICATION_JSON)
             .content(objMapper.writeValueAsString(request)))
         .andExpect(status().isOk())
@@ -157,8 +154,7 @@ class InterestControllerTest {
         .andExpect(jsonPath("$.name").value("주식"))
         .andExpect(jsonPath("$.keywords[0]").value("나스닥"))
         .andExpect(jsonPath("$.keywords[1]").value("애플"))
-        .andExpect(jsonPath("$.subscriberCount").value(0))
-        .andExpect(jsonPath("$.subscribedByMe").value(true));
+        .andExpect(jsonPath("$.subscriberCount").value(0));
   }
 
   @Test
@@ -178,39 +174,6 @@ class InterestControllerTest {
     mockMvc.perform(patch("/api/interests/{interestId}", interestId)
             .header(REQUEST_USER_HEADER, userId.toString())
             .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  @DisplayName("관심사 수정 요청 시 사용자 헤더가 없으면 실패한다")
-  void shouldFailUpdate_whenUserIdHeaderMissing() throws Exception {
-    // given
-    UUID interestId = UUID.randomUUID();
-    InterestUpdateRequest request = new InterestUpdateRequest(
-        List.of("나스닥", "애플")
-    );
-
-    // when & then
-    mockMvc.perform(patch("/api/interests/{interestId}", interestId)
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objMapper.writeValueAsString(request)))
-        .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  @DisplayName("관심사 수정 요청 시 헤더의 UUID 형식이 올바르지 않으면 실패한다")
-  void shouldFailUpdate_whenUserIdHeaderInvalidFormat() throws Exception {
-    // given
-    UUID interestId = UUID.randomUUID();
-    InterestUpdateRequest request = new InterestUpdateRequest(
-        List.of("나스닥", "애플")
-    );
-
-    // when & then
-    mockMvc.perform(patch("/api/interests/{interestId}", interestId)
-            .header(REQUEST_USER_HEADER, "not-uuid")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objMapper.writeValueAsString(request)))
         .andExpect(status().isBadRequest());
   }
 

--- a/src/test/java/com/team3/monew/integration/InterestServiceIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/InterestServiceIntegrationTest.java
@@ -135,7 +135,6 @@ public class InterestServiceIntegrationTest extends IntegrationTestSupport {
 
     // when
     interestService.updateKeyword(
-        UUID.randomUUID(), // userId는 의미 없음 (existsBy는 false로 처리됨)
         saved.id(),
         new InterestUpdateRequest(List.of("나스닥", "애플"))
     );
@@ -161,7 +160,6 @@ public class InterestServiceIntegrationTest extends IntegrationTestSupport {
 
     // when
     interestService.updateKeyword(
-        UUID.randomUUID(),
         saved.id(),
         new InterestUpdateRequest(List.of("물가"))
     );
@@ -188,7 +186,6 @@ public class InterestServiceIntegrationTest extends IntegrationTestSupport {
     // when & then
     assertThatThrownBy(() ->
         interestService.updateKeyword(
-            UUID.randomUUID(),
             saved.id(),
             new InterestUpdateRequest(null)
         )
@@ -209,7 +206,6 @@ public class InterestServiceIntegrationTest extends IntegrationTestSupport {
     // when & then
     assertThatThrownBy(() ->
         interestService.updateKeyword(
-            UUID.randomUUID(),
             saved.id(),
             new InterestUpdateRequest(List.of())
         )
@@ -230,7 +226,6 @@ public class InterestServiceIntegrationTest extends IntegrationTestSupport {
     // when & then
     assertThatThrownBy(() ->
         interestService.updateKeyword(
-            UUID.randomUUID(),
             saved.id(),
             new InterestUpdateRequest(List.of("정상", "   "))
         )
@@ -251,7 +246,6 @@ public class InterestServiceIntegrationTest extends IntegrationTestSupport {
     // when & then
     assertThatThrownBy(() ->
         interestService.updateKeyword(
-            UUID.randomUUID(),
             saved.id(),
             new InterestUpdateRequest(List.of("경제", "경제"))
         )

--- a/src/test/java/com/team3/monew/service/InterestServiceTest.java
+++ b/src/test/java/com/team3/monew/service/InterestServiceTest.java
@@ -169,11 +169,10 @@ class InterestServiceTest {
     );
 
     given(interestRepository.findById(interestId)).willReturn((Optional.of(interest)));
-    given(subscriptionRepository.existsByUserIdAndInterestId(userId, interestId)).willReturn(true);
-    given(interestMapper.toDto(interest, true)).willReturn(response);
+    given(interestMapper.toDto(interest, null)).willReturn(response);
 
     // when
-    InterestDto result = interestService.updateKeyword(userId, interestId, request);
+    InterestDto result = interestService.updateKeyword(interestId, request);
 
     // then
     assertThat(result.name()).isEqualTo("주식");
@@ -185,15 +184,13 @@ class InterestServiceTest {
         .containsExactly("수정", "키워드수정");
 
     then(interestRepository).should().findById(interestId);
-    then(subscriptionRepository).should().existsByUserIdAndInterestId(userId, interestId);
-    then(interestMapper).should().toDto(interest, true);
+    then(interestMapper).should().toDto(interest, null);
   }
 
   @Test
   @DisplayName("존재하지 않는 관심사는 키워드를 수정할 수 없다")
   void shouldFailToUpdateKeyword_whenInterestNotFound() {
     // given
-    UUID userId = UUID.randomUUID();
     UUID interestId = UUID.randomUUID();
 
     InterestUpdateRequest request = new InterestUpdateRequest(
@@ -203,7 +200,7 @@ class InterestServiceTest {
     given(interestRepository.findById(interestId)).willReturn(java.util.Optional.empty());
 
     // when & then
-    assertThatThrownBy(() -> interestService.updateKeyword(userId, interestId, request))
+    assertThatThrownBy(() -> interestService.updateKeyword(interestId, request))
         .isInstanceOf(InterestNotFoundException.class);
 
     then(subscriptionRepository).should(never()).existsByUserIdAndInterestId(any(), any());
@@ -214,7 +211,6 @@ class InterestServiceTest {
   @DisplayName("키워드 목록이 null이면 관심사 키워드 수정에 실패한다")
   void shouldFailToUpdateKeyword_whenKeywordsIsNull() {
     // given
-    UUID userId = UUID.randomUUID();
     UUID interestId = UUID.randomUUID();
 
     InterestUpdateRequest request = new InterestUpdateRequest(null);
@@ -225,7 +221,7 @@ class InterestServiceTest {
     given(interestRepository.findById(interestId)).willReturn(java.util.Optional.of(interest));
 
     // when & then
-    assertThatThrownBy(() -> interestService.updateKeyword(userId, interestId, request))
+    assertThatThrownBy(() -> interestService.updateKeyword(interestId, request))
         .isInstanceOf(InterestException.class);
 
     then(subscriptionRepository).should(never()).existsByUserIdAndInterestId(any(), any());
@@ -236,7 +232,6 @@ class InterestServiceTest {
   @DisplayName("키워드 목록이 비어 있으면 관심사 키워드 수정에 실패한다")
   void shouldFailToUpdateKeyword_whenKeywordsIsEmpty() {
     // given
-    UUID userId = UUID.randomUUID();
     UUID interestId = UUID.randomUUID();
 
     InterestUpdateRequest request = new InterestUpdateRequest(List.of());
@@ -247,7 +242,7 @@ class InterestServiceTest {
     given(interestRepository.findById(interestId)).willReturn(java.util.Optional.of(interest));
 
     // when & then
-    assertThatThrownBy(() -> interestService.updateKeyword(userId, interestId, request))
+    assertThatThrownBy(() -> interestService.updateKeyword(interestId, request))
         .isInstanceOf(InterestException.class);
 
     then(subscriptionRepository).should(never()).existsByUserIdAndInterestId(any(), any());
@@ -258,7 +253,6 @@ class InterestServiceTest {
   @DisplayName("공백 문자열이 포함된 키워드가 있으면 관심사 키워드 수정에 실패한다")
   void shouldFailToUpdateKeyword_whenKeywordContainsBlank() {
     // given
-    UUID userId = UUID.randomUUID();
     UUID interestId = UUID.randomUUID();
 
     InterestUpdateRequest request = new InterestUpdateRequest(
@@ -271,7 +265,7 @@ class InterestServiceTest {
     given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
 
     // when & then
-    assertThatThrownBy(() -> interestService.updateKeyword(userId, interestId, request))
+    assertThatThrownBy(() -> interestService.updateKeyword(interestId, request))
         .isInstanceOf(InterestException.class);
 
     then(subscriptionRepository).should(never()).existsByUserIdAndInterestId(any(), any());
@@ -282,7 +276,6 @@ class InterestServiceTest {
   @DisplayName("중복된 키워드가 있으면 관심사 키워드 수정에 실패한다")
   void shouldFailToUpdateKeyword_whenKeywordsDuplicated() {
     // given
-    UUID userId = UUID.randomUUID();
     UUID interestId = UUID.randomUUID();
 
     InterestUpdateRequest request = new InterestUpdateRequest(
@@ -295,7 +288,7 @@ class InterestServiceTest {
     given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
 
     // when & then
-    assertThatThrownBy(() -> interestService.updateKeyword(userId, interestId, request))
+    assertThatThrownBy(() -> interestService.updateKeyword(interestId, request))
         .isInstanceOf(InterestException.class);
 
     then(subscriptionRepository).should(never()).existsByUserIdAndInterestId(any(), any());

--- a/src/test/java/com/team3/monew/service/InterestServiceTest.java
+++ b/src/test/java/com/team3/monew/service/InterestServiceTest.java
@@ -23,6 +23,7 @@ import com.team3.monew.repository.UserRepository;
 import jakarta.persistence.criteria.CriteriaBuilder.In;
 import java.time.Instant;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -40,6 +41,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
@@ -349,9 +351,6 @@ class InterestServiceTest {
     given(interestRepository.searchByCondition(condition)).willReturn(result);
     given(interestRepository.countByCondition(condition)).willReturn(3L);
 
-    given(subscriptionRepository.existsByUserIdAndInterestId(any(), any()))
-        .willReturn(false);
-
     given(interestMapper.toDto(any(), anyBoolean()))
         .willAnswer(invocation ->
             new InterestDto(
@@ -397,9 +396,6 @@ class InterestServiceTest {
     given(interestRepository.searchByCondition(condition)).willReturn(result);
     given(interestRepository.countByCondition(condition)).willReturn(2L);
 
-    given(subscriptionRepository.existsByUserIdAndInterestId(any(), any()))
-        .willReturn(false);
-
     given(interestMapper.toDto(any(), anyBoolean()))
         .willReturn(new InterestDto(UUID.randomUUID(), "dummy", List.of(), 0, false));
 
@@ -440,8 +436,10 @@ class InterestServiceTest {
   void shouldSubscribedByMeIsTrue_whenSubscribing() {
     // given
     UUID userId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
 
     Interest interest = createInterest("economy");
+    ReflectionTestUtils.setField(interest, "id", interestId);
 
     InterestSearchCondition condition = new InterestSearchCondition(
         null, "name", "DESC", new InterestCursor(null, null), 10
@@ -450,15 +448,15 @@ class InterestServiceTest {
     given(interestRepository.searchByCondition(condition)).willReturn(List.of(interest));
     given(interestRepository.countByCondition(condition)).willReturn(1L);
 
-    given(subscriptionRepository.existsByUserIdAndInterestId(userId, interest.getId()))
-        .willReturn(true);
+    given(subscriptionRepository.findSubscribedInterestIds(eq(userId), eq(List.of(interestId))))
+        .willReturn(Set.of(interestId));
 
-    given(interestMapper.toDto(any(), eq(true)))
-        .willReturn(new InterestDto(interest.getId(), "economy", List.of(), 0, true));
+    given(interestMapper.toDto(eq(interest), eq(true)))
+        .willReturn(new InterestDto(interestId, "economy", List.of(), 0, true));
 
     // when
-    CursorPageResponseDto<InterestDto> response
-        = interestService.findAll(condition, userId);
+    CursorPageResponseDto<InterestDto> response =
+        interestService.findAll(condition, userId);
 
     // then
     assertThat(response.content().get(0).subscribedByMe()).isTrue();

--- a/src/test/java/com/team3/monew/service/InterestServiceTest.java
+++ b/src/test/java/com/team3/monew/service/InterestServiceTest.java
@@ -20,7 +20,6 @@ import com.team3.monew.mapper.InterestMapper;
 import com.team3.monew.repository.InterestRepository;
 import com.team3.monew.repository.SubscriptionRepository;
 import com.team3.monew.repository.UserRepository;
-import jakarta.persistence.criteria.CriteriaBuilder.In;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.Set;

--- a/src/test/java/com/team3/monew/service/InterestServiceTest.java
+++ b/src/test/java/com/team3/monew/service/InterestServiceTest.java
@@ -429,6 +429,7 @@ class InterestServiceTest {
     // then
     assertThat(response.content()).isEmpty();
     assertThat(response.hasNext()).isFalse();
+
   }
 
   @Test


### PR DESCRIPTION
## 관련 이슈
- closes #207 

## 작업 내용
- refactor: 관심사 목록 조회 N+1 문제 개선
  - 구독 여부 조회 시 반복 쿼리 제거
    - 기존: 각 관심사마다 existsByUserIdAndInterestId 호출로 N+1 발생
    - 개선: interestIds 기반으로 구독 목록을 한 번에 조회 후 Set으로 비교하도록 수정
  - 관심사 키워드 조회 N+1 완화
    - Interest 엔티티의 keywords 컬렉션에 @BatchSize(size = 100) 적용
    - LAZY 로딩 시 IN 쿼리 기반으로 묶어서 조회하도록 최적화
- refactor: 관심사 구독 취소시 200 응답 -> 204 응답으로 수정
- fix: 관심사 수정시 불필요한 헤더 포함 수정

## 변경 사항
- 주요 변경 사항을 작성해주세요.

## 테스트 내용
- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 리스트 조회 시 구독 상태 확인 방식을 배치로 전환해 성능 개선
  * 관련 컬렉션 조회에 배치 처리 적용

* **API 변경**
  * 관심사 업데이트 엔드포인트의 입력이 단순화됨 (사용자 ID 제거)
  * 구독 취소 응답 코드가 204 No Content로 변경
  * 구독 상태 필드(subscribedByMe)가 null 허용으로 변경

* **테스트**
  * 관련 단위/통합 테스트가 API 변경에 맞춰 수정됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->