### PR TITLE
feat: 사용자 활동 내역 삭제, 수정 반영

### DIFF
--- a/src/main/java/com/team3/monew/document/UserActivityDocument.java
+++ b/src/main/java/com/team3/monew/document/UserActivityDocument.java
@@ -133,6 +133,10 @@ public class UserActivityDocument {
     subscriptions.removeIf(subscription -> Objects.equals(subscription.id(), subscriptionId));
   }
 
+  public void removeSubscriptionSummaryByInterestId(UUID interestId) {
+    subscriptions.removeIf(subscription -> Objects.equals(subscription.interestId(), interestId));
+  }
+
   private <T, ID> void addToRecentList(List<T> items, T newItem, Function<T, ID> idExtractor) {
     // 중복 제거
     items.removeIf(item -> Objects.equals(idExtractor.apply(item), idExtractor.apply(newItem)));

--- a/src/main/java/com/team3/monew/document/UserActivityDocument.java
+++ b/src/main/java/com/team3/monew/document/UserActivityDocument.java
@@ -121,6 +121,10 @@ public class UserActivityDocument {
         ).toList();
   }
 
+  public void removeArticleViewSummary(UUID articleId) {
+    articleViews.removeIf(articleView -> Objects.equals(articleView.articleId(), articleId));
+  }
+
   public void removeCommentLikeSummary(UUID commentLikeId) {
     commentLikes.removeIf(commentLike -> Objects.equals(commentLike.id(), commentLikeId));
   }

--- a/src/main/java/com/team3/monew/document/UserActivityDocument.java
+++ b/src/main/java/com/team3/monew/document/UserActivityDocument.java
@@ -121,6 +121,10 @@ public class UserActivityDocument {
         ).toList();
   }
 
+  public void removeCommentLikeSummary(UUID commentLikeId) {
+    commentLikes.removeIf(commentLike -> Objects.equals(commentLike.id(), commentLikeId));
+  }
+
 
   private <T, ID> void addToRecentList(List<T> items, T newItem, Function<T, ID> idExtractor) {
     // 중복 제거

--- a/src/main/java/com/team3/monew/document/UserActivityDocument.java
+++ b/src/main/java/com/team3/monew/document/UserActivityDocument.java
@@ -137,6 +137,20 @@ public class UserActivityDocument {
     subscriptions.removeIf(subscription -> Objects.equals(subscription.interestId(), interestId));
   }
 
+  public void updateKeywords(UUID interestId, List<String> keywords) {
+    subscriptions = subscriptions.stream()
+        .map(subscription -> subscription.interestId().equals(interestId)
+            ? new SubscriptionSummary(
+            subscription.id(),
+            subscription.interestId(),
+            subscription.interestName(),
+            keywords,
+            subscription.interestSubscriberCount(),
+            subscription.createdAt()
+            ) : subscription
+        ).toList();
+  }
+
   private <T, ID> void addToRecentList(List<T> items, T newItem, Function<T, ID> idExtractor) {
     // 중복 제거
     items.removeIf(item -> Objects.equals(idExtractor.apply(item), idExtractor.apply(newItem)));

--- a/src/main/java/com/team3/monew/document/UserActivityDocument.java
+++ b/src/main/java/com/team3/monew/document/UserActivityDocument.java
@@ -86,20 +86,22 @@ public class UserActivityDocument {
 
   public void updateNickname(String newNickname) {
     this.nickname = newNickname;
+  }
 
+  public void updateCommentNickname(String newNickname) {
     comments = comments.stream()
         .map(comment -> Objects.equals(comment.userId(), this.id)
-            ? new CommentSummary(
-            comment.id(),
-            comment.articleId(),
-            comment.articleTitle(),
-            comment.userId(),
-            newNickname,
-            comment.content(),
-            comment.likeCount(),
-            comment.createdAt()
-        ) : comment
-    ).collect(Collectors.toCollection(ArrayList::new));;
+                ? new CommentSummary(
+                comment.id(),
+                comment.articleId(),
+                comment.articleTitle(),
+                comment.userId(),
+                newNickname,
+                comment.content(),
+                comment.likeCount(),
+                comment.createdAt()
+            ) : comment
+        ).collect(Collectors.toCollection(ArrayList::new));
   }
 
   public void removeCommentSummary(UUID commentId) {

--- a/src/main/java/com/team3/monew/document/UserActivityDocument.java
+++ b/src/main/java/com/team3/monew/document/UserActivityDocument.java
@@ -101,7 +101,25 @@ public class UserActivityDocument {
     ).toList();
   }
 
-  // 삭제는 추후 구현
+  public void removeCommentSummary(UUID commentId) {
+    comments.removeIf(c -> Objects.equals(c.id(), commentId));
+  }
+
+  public void updateCommentContent(UUID commentId, String newContent) {
+    comments = comments.stream()
+        .map(comment -> Objects.equals(comment.id(), commentId)
+            ? new CommentSummary(
+            comment.id(),
+            comment.articleId(),
+            comment.articleTitle(),
+            comment.userId(),
+            comment.userNickname(),
+            newContent,
+            comment.likeCount(),
+            comment.createdAt()
+            ) : comment
+        ).toList();
+  }
 
 
   private <T, ID> void addToRecentList(List<T> items, T newItem, Function<T, ID> idExtractor) {

--- a/src/main/java/com/team3/monew/document/UserActivityDocument.java
+++ b/src/main/java/com/team3/monew/document/UserActivityDocument.java
@@ -83,6 +83,24 @@ public class UserActivityDocument {
     this.createdAt = createdAt;
   }
 
+  public void updateNickname(String newNickname) {
+    this.nickname = newNickname;
+
+    comments = comments.stream()
+        .map(comment -> Objects.equals(comment.userId(), this.id)
+            ? new CommentSummary(
+            comment.id(),
+            comment.articleId(),
+            comment.articleTitle(),
+            comment.userId(),
+            newNickname,
+            comment.content(),
+            comment.likeCount(),
+            comment.createdAt()
+        ) : comment
+    ).toList();
+  }
+
   // 삭제는 추후 구현
 
 

--- a/src/main/java/com/team3/monew/document/UserActivityDocument.java
+++ b/src/main/java/com/team3/monew/document/UserActivityDocument.java
@@ -129,6 +129,9 @@ public class UserActivityDocument {
     commentLikes.removeIf(commentLike -> Objects.equals(commentLike.id(), commentLikeId));
   }
 
+  public void removeSubscriptionSummary(UUID subscriptionId) {
+    subscriptions.removeIf(subscription -> Objects.equals(subscription.id(), subscriptionId));
+  }
 
   private <T, ID> void addToRecentList(List<T> items, T newItem, Function<T, ID> idExtractor) {
     // 중복 제거

--- a/src/main/java/com/team3/monew/document/UserActivityDocument.java
+++ b/src/main/java/com/team3/monew/document/UserActivityDocument.java
@@ -121,7 +121,7 @@ public class UserActivityDocument {
             comment.likeCount(),
             comment.createdAt()
             ) : comment
-        ).collect(Collectors.toCollection(ArrayList::new));;
+        ).collect(Collectors.toCollection(ArrayList::new));
   }
 
   public void removeArticleViewSummary(UUID articleId) {
@@ -151,7 +151,29 @@ public class UserActivityDocument {
             subscription.interestSubscriberCount(),
             subscription.createdAt()
             ) : subscription
-        ).collect(Collectors.toCollection(ArrayList::new));;
+        ).collect(Collectors.toCollection(ArrayList::new));
+  }
+
+  public void removeCommentLikeSummaryByCommentId(UUID commentId) {
+    commentLikes.removeIf(commentLike -> Objects.equals(commentLike.commentId(), commentId));
+  }
+
+  public void updateCommentLikeContent(UUID commentId, String newContent) {
+    commentLikes = commentLikes.stream()
+        .map(commentLike -> commentLike.commentId().equals(commentId)
+            ? new CommentLikeSummary(
+            commentLike.id(),
+            commentLike.createdAt(),
+            commentLike.commentId(),
+            commentLike.articleId(),
+            commentLike.articleTitle(),
+            commentLike.commentUserId(),
+            commentLike.commentUserNickname(),
+            newContent,
+            commentLike.commentLikeCount(),
+            commentLike.commentCreatedAt()
+            ) : commentLike
+        ).collect(Collectors.toCollection(ArrayList::new));
   }
 
   private <T, ID> void addToRecentList(List<T> items, T newItem, Function<T, ID> idExtractor) {

--- a/src/main/java/com/team3/monew/document/UserActivityDocument.java
+++ b/src/main/java/com/team3/monew/document/UserActivityDocument.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -98,7 +99,7 @@ public class UserActivityDocument {
             comment.likeCount(),
             comment.createdAt()
         ) : comment
-    ).toList();
+    ).collect(Collectors.toCollection(ArrayList::new));;
   }
 
   public void removeCommentSummary(UUID commentId) {
@@ -118,7 +119,7 @@ public class UserActivityDocument {
             comment.likeCount(),
             comment.createdAt()
             ) : comment
-        ).toList();
+        ).collect(Collectors.toCollection(ArrayList::new));;
   }
 
   public void removeArticleViewSummary(UUID articleId) {
@@ -144,11 +145,11 @@ public class UserActivityDocument {
             subscription.id(),
             subscription.interestId(),
             subscription.interestName(),
-            keywords,
+            List.copyOf(keywords),
             subscription.interestSubscriberCount(),
             subscription.createdAt()
             ) : subscription
-        ).toList();
+        ).collect(Collectors.toCollection(ArrayList::new));;
   }
 
   private <T, ID> void addToRecentList(List<T> items, T newItem, Function<T, ID> idExtractor) {

--- a/src/main/java/com/team3/monew/event/ArticleDeletedEvent.java
+++ b/src/main/java/com/team3/monew/event/ArticleDeletedEvent.java
@@ -1,0 +1,9 @@
+package com.team3.monew.event;
+
+import java.util.UUID;
+
+public record ArticleDeletedEvent(
+    UUID articleId
+) {
+
+}

--- a/src/main/java/com/team3/monew/event/CommentDeletedEvent.java
+++ b/src/main/java/com/team3/monew/event/CommentDeletedEvent.java
@@ -1,0 +1,10 @@
+package com.team3.monew.event;
+
+import java.util.UUID;
+
+public record CommentDeletedEvent(
+    UUID commentId,
+    UUID userId
+) {
+
+}

--- a/src/main/java/com/team3/monew/event/CommentUnlikedEvent.java
+++ b/src/main/java/com/team3/monew/event/CommentUnlikedEvent.java
@@ -1,0 +1,10 @@
+package com.team3.monew.event;
+
+import java.util.UUID;
+
+public record CommentUnlikedEvent(
+    UUID userId,
+    UUID commentLikeId
+) {
+
+}

--- a/src/main/java/com/team3/monew/event/CommentUnlikedEvent.java
+++ b/src/main/java/com/team3/monew/event/CommentUnlikedEvent.java
@@ -3,7 +3,7 @@ package com.team3.monew.event;
 import java.util.UUID;
 
 public record CommentUnlikedEvent(
-    UUID userId,
+    UUID actorUserId,
     UUID commentLikeId
 ) {
 

--- a/src/main/java/com/team3/monew/event/CommentUpdatedEvent.java
+++ b/src/main/java/com/team3/monew/event/CommentUpdatedEvent.java
@@ -1,0 +1,11 @@
+package com.team3.monew.event;
+
+import java.util.UUID;
+
+public record CommentUpdatedEvent(
+    UUID commentId,
+    UUID userId,
+    String content
+) {
+
+}

--- a/src/main/java/com/team3/monew/event/InterestDeletedEvent.java
+++ b/src/main/java/com/team3/monew/event/InterestDeletedEvent.java
@@ -1,0 +1,9 @@
+package com.team3.monew.event;
+
+import java.util.UUID;
+
+public record InterestDeletedEvent(
+    UUID interestId
+) {
+
+}

--- a/src/main/java/com/team3/monew/event/InterestKeywordUpdatedEvent.java
+++ b/src/main/java/com/team3/monew/event/InterestKeywordUpdatedEvent.java
@@ -1,0 +1,11 @@
+package com.team3.monew.event;
+
+import java.util.List;
+import java.util.UUID;
+
+public record InterestKeywordUpdatedEvent(
+    UUID interestId,
+    List<String> keywords
+) {
+
+}

--- a/src/main/java/com/team3/monew/event/SubscriptionCanceledEvent.java
+++ b/src/main/java/com/team3/monew/event/SubscriptionCanceledEvent.java
@@ -1,0 +1,10 @@
+package com.team3.monew.event;
+
+import java.util.UUID;
+
+public record SubscriptionCanceledEvent(
+    UUID userId,
+    UUID subscriptionId
+) {
+
+}

--- a/src/main/java/com/team3/monew/event/UserDeletedEvent.java
+++ b/src/main/java/com/team3/monew/event/UserDeletedEvent.java
@@ -1,0 +1,9 @@
+package com.team3.monew.event;
+
+import java.util.UUID;
+
+public record UserDeletedEvent(
+    UUID userId
+) {
+
+}

--- a/src/main/java/com/team3/monew/event/UserUpdatedEvent.java
+++ b/src/main/java/com/team3/monew/event/UserUpdatedEvent.java
@@ -1,0 +1,10 @@
+package com.team3.monew.event;
+
+import java.util.UUID;
+
+public record UserUpdatedEvent(
+    UUID userId,
+    String nickname
+) {
+
+}

--- a/src/main/java/com/team3/monew/listener/UserActivityEventListener.java
+++ b/src/main/java/com/team3/monew/listener/UserActivityEventListener.java
@@ -7,6 +7,7 @@ import com.team3.monew.event.CommentLikedEvent;
 import com.team3.monew.event.CommentRegisteredEvent;
 import com.team3.monew.event.CommentUnlikedEvent;
 import com.team3.monew.event.CommentUpdatedEvent;
+import com.team3.monew.event.InterestDeletedEvent;
 import com.team3.monew.event.SubscriptionCanceledEvent;
 import com.team3.monew.event.SubscriptionEvent;
 import com.team3.monew.event.UserDeletedEvent;
@@ -185,6 +186,17 @@ public class UserActivityEventListener {
   )
   public void handleSubscriptionCanceledEvent(SubscriptionCanceledEvent event) {
     userActivityService.removeSubscriptionSummary(event.userId(), event.subscriptionId());
+  }
+
+  @Async("userActivityTaskExecutor")
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  @Retryable(
+      retryFor = {TransientDataAccessException.class, CannotAcquireLockException.class},
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 1000)
+  )
+  public void handleInterestDeletedEvent(InterestDeletedEvent event) {
+    userActivityService.removeAllSubscriptionSummaryByInterest(event.interestId());
   }
 
   @Recover

--- a/src/main/java/com/team3/monew/listener/UserActivityEventListener.java
+++ b/src/main/java/com/team3/monew/listener/UserActivityEventListener.java
@@ -8,6 +8,7 @@ import com.team3.monew.event.CommentRegisteredEvent;
 import com.team3.monew.event.CommentUnlikedEvent;
 import com.team3.monew.event.CommentUpdatedEvent;
 import com.team3.monew.event.InterestDeletedEvent;
+import com.team3.monew.event.InterestKeywordUpdatedEvent;
 import com.team3.monew.event.SubscriptionCanceledEvent;
 import com.team3.monew.event.SubscriptionEvent;
 import com.team3.monew.event.UserDeletedEvent;
@@ -199,6 +200,17 @@ public class UserActivityEventListener {
     userActivityService.removeAllSubscriptionSummaryByInterest(event.interestId());
   }
 
+  @Async("userActivityTaskExecutor")
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  @Retryable(
+      retryFor = {TransientDataAccessException.class, CannotAcquireLockException.class},
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 1000)
+  )
+  public void handleInterestKeywordUpdatedEvent(InterestKeywordUpdatedEvent event) {
+    userActivityService.updateSubscriptionsByKeywords(event.interestId(), event.keywords());
+  }
+
   @Recover
   public void recover(Exception e, UserRegisteredEvent event) {
     log.error("사용자 활동 내역 UserRegistered Event 처리 실패: userId={}", event.userId(), e);
@@ -233,5 +245,11 @@ public class UserActivityEventListener {
   public void recover(Exception e, CommentUpdatedEvent event) {
     log.error("사용자 활동 내역 CommentUpdated Event 처리 실패: userId={} commentId={}",
         event.userId(), event.commentId(), e);
+  }
+
+  @Recover
+  public void recover(Exception e, InterestKeywordUpdatedEvent event) {
+    log.error("사용자 활동 내역 InterestKeywordUpdated Event 처리 실패: interestId={} keywords={}",
+        event.interestId(), event.keywords(), e);
   }
 }

--- a/src/main/java/com/team3/monew/listener/UserActivityEventListener.java
+++ b/src/main/java/com/team3/monew/listener/UserActivityEventListener.java
@@ -7,6 +7,7 @@ import com.team3.monew.event.CommentLikedEvent;
 import com.team3.monew.event.CommentRegisteredEvent;
 import com.team3.monew.event.CommentUnlikedEvent;
 import com.team3.monew.event.CommentUpdatedEvent;
+import com.team3.monew.event.SubscriptionCanceledEvent;
 import com.team3.monew.event.SubscriptionEvent;
 import com.team3.monew.event.UserDeletedEvent;
 import com.team3.monew.event.UserRegisteredEvent;
@@ -173,6 +174,17 @@ public class UserActivityEventListener {
   )
   public void handleArticleDeletedEvent(ArticleDeletedEvent event) {
     userActivityService.removeArticleViewSummary(event.articleId());
+  }
+
+  @Async("userActivityTaskExecutor")
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  @Retryable(
+      retryFor = {TransientDataAccessException.class, CannotAcquireLockException.class},
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 1000)
+  )
+  public void handleSubscriptionCanceledEvent(SubscriptionCanceledEvent event) {
+    userActivityService.removeSubscriptionSummary(event.userId(), event.subscriptionId());
   }
 
   @Recover

--- a/src/main/java/com/team3/monew/listener/UserActivityEventListener.java
+++ b/src/main/java/com/team3/monew/listener/UserActivityEventListener.java
@@ -4,6 +4,7 @@ import com.team3.monew.event.ArticleViewEvent;
 import com.team3.monew.event.CommentDeletedEvent;
 import com.team3.monew.event.CommentLikedEvent;
 import com.team3.monew.event.CommentRegisteredEvent;
+import com.team3.monew.event.CommentUnlikedEvent;
 import com.team3.monew.event.CommentUpdatedEvent;
 import com.team3.monew.event.SubscriptionEvent;
 import com.team3.monew.event.UserDeletedEvent;
@@ -149,6 +150,17 @@ public class UserActivityEventListener {
   )
   public void handleCommentUpdatedEvent(CommentUpdatedEvent event) {
     userActivityService.updateCommentContent(event.userId(), event.commentId(), event.content());
+  }
+
+  @Async("userActivityTaskExecutor")
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  @Retryable(
+      retryFor = {TransientDataAccessException.class, CannotAcquireLockException.class},
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 1000)
+  )
+  public void handleCommentUnlikedEvent(CommentUnlikedEvent event) {
+    userActivityService.removeCommentLikeSummary(event.userId(), event.commentLikeId());
   }
 
   @Recover

--- a/src/main/java/com/team3/monew/listener/UserActivityEventListener.java
+++ b/src/main/java/com/team3/monew/listener/UserActivityEventListener.java
@@ -160,7 +160,7 @@ public class UserActivityEventListener {
       backoff = @Backoff(delay = 1000)
   )
   public void handleCommentUnlikedEvent(CommentUnlikedEvent event) {
-    userActivityService.removeCommentLikeSummary(event.userId(), event.commentLikeId());
+    userActivityService.removeCommentLikeSummary(event.actorUserId(), event.commentLikeId());
   }
 
   @Recover

--- a/src/main/java/com/team3/monew/listener/UserActivityEventListener.java
+++ b/src/main/java/com/team3/monew/listener/UserActivityEventListener.java
@@ -1,8 +1,10 @@
 package com.team3.monew.listener;
 
 import com.team3.monew.event.ArticleViewEvent;
+import com.team3.monew.event.CommentDeletedEvent;
 import com.team3.monew.event.CommentLikedEvent;
 import com.team3.monew.event.CommentRegisteredEvent;
+import com.team3.monew.event.CommentUpdatedEvent;
 import com.team3.monew.event.SubscriptionEvent;
 import com.team3.monew.event.UserDeletedEvent;
 import com.team3.monew.event.UserRegisteredEvent;
@@ -127,6 +129,28 @@ public class UserActivityEventListener {
     userActivityService.deleteUserActivity(event.userId());
   }
 
+  @Async("userActivityTaskExecutor")
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  @Retryable(
+      retryFor = {TransientDataAccessException.class, CannotAcquireLockException.class},
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 1000)
+  )
+  public void handleCommentDeletedEvent(CommentDeletedEvent event) {
+    userActivityService.removeCommentSummary(event.userId(), event.commentId());
+  }
+
+  @Async("userActivityTaskExecutor")
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  @Retryable(
+      retryFor = {TransientDataAccessException.class, CannotAcquireLockException.class},
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 1000)
+  )
+  public void handleCommentUpdatedEvent(CommentUpdatedEvent event) {
+    userActivityService.updateCommentContent(event.userId(), event.commentId(), event.content());
+  }
+
   @Recover
   public void recover(Exception e, UserRegisteredEvent event) {
     log.error("사용자 활동 내역 UserRegistered Event 처리 실패: userId={}", event.userId(), e);
@@ -155,5 +179,11 @@ public class UserActivityEventListener {
   @Recover
   public void recover(Exception e, UserUpdatedEvent event) {
     log.error("사용자 활동 내역 UserUpdated Event 처리 실패: userId={}", event.userId(), e);
+  }
+
+  @Recover
+  public void recover(Exception e, CommentUpdatedEvent event) {
+    log.error("사용자 활동 내역 CommentUpdated Event 처리 실패: userId={} commentId={}",
+        event.userId(), event.commentId(), e);
   }
 }

--- a/src/main/java/com/team3/monew/listener/UserActivityEventListener.java
+++ b/src/main/java/com/team3/monew/listener/UserActivityEventListener.java
@@ -1,5 +1,6 @@
 package com.team3.monew.listener;
 
+import com.team3.monew.event.ArticleDeletedEvent;
 import com.team3.monew.event.ArticleViewEvent;
 import com.team3.monew.event.CommentDeletedEvent;
 import com.team3.monew.event.CommentLikedEvent;
@@ -161,6 +162,17 @@ public class UserActivityEventListener {
   )
   public void handleCommentUnlikedEvent(CommentUnlikedEvent event) {
     userActivityService.removeCommentLikeSummary(event.actorUserId(), event.commentLikeId());
+  }
+
+  @Async("userActivityTaskExecutor")
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  @Retryable(
+      retryFor = {TransientDataAccessException.class, CannotAcquireLockException.class},
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 1000)
+  )
+  public void handleArticleDeletedEvent(ArticleDeletedEvent event) {
+    userActivityService.removeArticleViewSummary(event.articleId());
   }
 
   @Recover

--- a/src/main/java/com/team3/monew/listener/UserActivityEventListener.java
+++ b/src/main/java/com/team3/monew/listener/UserActivityEventListener.java
@@ -4,7 +4,9 @@ import com.team3.monew.event.ArticleViewEvent;
 import com.team3.monew.event.CommentLikedEvent;
 import com.team3.monew.event.CommentRegisteredEvent;
 import com.team3.monew.event.SubscriptionEvent;
+import com.team3.monew.event.UserDeletedEvent;
 import com.team3.monew.event.UserRegisteredEvent;
+import com.team3.monew.event.UserUpdatedEvent;
 import com.team3.monew.mapper.UserActivityMapper;
 import com.team3.monew.service.UserActivityService;
 import lombok.RequiredArgsConstructor;
@@ -97,6 +99,34 @@ public class UserActivityEventListener {
     userActivityService.updateArticleViewSummary(event.userId(), userActivityMapper.toArticleViewSummary(event));
   }
 
+  @Async("userActivityTaskExecutor")
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  @Retryable(
+      retryFor = {
+          TransientDataAccessException.class,
+          CannotAcquireLockException.class
+      },
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 1000)
+  )
+  public void handleUserUpdatedEvent(UserUpdatedEvent event) {
+    userActivityService.updateUserNickname(event.userId(), event.nickname());
+  }
+
+  @Async("userActivityTaskExecutor")
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  @Retryable(
+      retryFor = {
+          TransientDataAccessException.class,
+          CannotAcquireLockException.class
+      },
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 1000)
+  )
+  public void handleUserDeletedEvent(UserDeletedEvent event) {
+    userActivityService.deleteUserActivity(event.userId());
+  }
+
   @Recover
   public void recover(Exception e, UserRegisteredEvent event) {
     log.error("사용자 활동 내역 UserRegistered Event 처리 실패: userId={}", event.userId(), e);
@@ -120,5 +150,10 @@ public class UserActivityEventListener {
   @Recover
   public void recover(Exception e, ArticleViewEvent event) {
     log.error("사용자 활동 내역 ArticleView Event 처리 실패: userId={} articleId={}", event.userId(), event.articleId(), e);
+  }
+
+  @Recover
+  public void recover(Exception e, UserUpdatedEvent event) {
+    log.error("사용자 활동 내역 UserUpdated Event 처리 실패: userId={}", event.userId(), e);
   }
 }

--- a/src/main/java/com/team3/monew/repository/UserActivityRepository.java
+++ b/src/main/java/com/team3/monew/repository/UserActivityRepository.java
@@ -10,4 +10,7 @@ public interface UserActivityRepository extends MongoRepository<UserActivityDocu
 
   @Query("{ 'articleViews.articleId': ?0 }")
   List<UserActivityDocument> findAllByArticleViewsArticleId(UUID articleId);
+
+  @Query("{ 'subscriptions.interestId': ?0} ")
+  List<UserActivityDocument> findAllBySubscriptionsInterestId(UUID interestId);
 }

--- a/src/main/java/com/team3/monew/repository/UserActivityRepository.java
+++ b/src/main/java/com/team3/monew/repository/UserActivityRepository.java
@@ -13,4 +13,7 @@ public interface UserActivityRepository extends MongoRepository<UserActivityDocu
 
   @Query("{ 'subscriptions.interestId': ?0} ")
   List<UserActivityDocument> findAllBySubscriptionsInterestId(UUID interestId);
+
+  @Query("{ 'comments.userId':  ?0} ")
+  List<UserActivityDocument> findAllByCommentsUserId(UUID userId);
 }

--- a/src/main/java/com/team3/monew/repository/UserActivityRepository.java
+++ b/src/main/java/com/team3/monew/repository/UserActivityRepository.java
@@ -1,9 +1,13 @@
 package com.team3.monew.repository;
 
 import com.team3.monew.document.UserActivityDocument;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 
 public interface UserActivityRepository extends MongoRepository<UserActivityDocument, UUID> {
 
+  @Query("{ 'articleViews.articleId': ?0 }")
+  List<UserActivityDocument> findAllByArticleViewsArticleId(UUID articleId);
 }

--- a/src/main/java/com/team3/monew/repository/UserActivityRepository.java
+++ b/src/main/java/com/team3/monew/repository/UserActivityRepository.java
@@ -16,4 +16,7 @@ public interface UserActivityRepository extends MongoRepository<UserActivityDocu
 
   @Query("{ 'comments.userId':  ?0} ")
   List<UserActivityDocument> findAllByCommentsUserId(UUID userId);
+
+  @Query("{ 'commentLikes.commentId': ?0 }")
+  List<UserActivityDocument> findAllByCommentLikesCommentId(UUID commentId);
 }

--- a/src/main/java/com/team3/monew/service/CommentService.java
+++ b/src/main/java/com/team3/monew/service/CommentService.java
@@ -10,8 +10,11 @@ import com.team3.monew.entity.CommentLike;
 import com.team3.monew.entity.NewsArticle;
 import com.team3.monew.entity.User;
 import com.team3.monew.entity.enums.NotificationResourceType;
+import com.team3.monew.event.CommentDeletedEvent;
 import com.team3.monew.event.CommentRegisteredEvent;
 import com.team3.monew.event.CommentLikedEvent;
+import com.team3.monew.event.CommentUnlikedEvent;
+import com.team3.monew.event.CommentUpdatedEvent;
 import com.team3.monew.exception.article.ArticleNotFoundException;
 import com.team3.monew.exception.article.DeletedArticleException;
 import com.team3.monew.exception.comment.CommentException;
@@ -112,6 +115,13 @@ public class CommentService {
 
     comment.updateContent(request.content());
     log.info("Comment updated: commentId={}, requestUserId={}", commentId, requestUserId);
+    eventPublisher.publishEvent(
+        new CommentUpdatedEvent(
+            comment.getId(),
+            comment.getUser().getId(),
+            comment.getContent()
+        )
+    );
     return commentMapper.toDto(comment, false);
   }
 
@@ -123,6 +133,7 @@ public class CommentService {
     comment.markDeleted();
     newsArticleRepository.decrementCommentCountById(comment.getArticle().getId());
     log.info("Comment deleted: commentId={}", commentId);
+    eventPublisher.publishEvent(new CommentDeletedEvent(comment.getId(), comment.getUser().getId()));
   }
 
   @Transactional
@@ -142,6 +153,7 @@ public class CommentService {
     );
     commentRepository.delete(comment);
     log.info("Comment hard deleted: commentId={}", commentId);
+    eventPublisher.publishEvent(new CommentDeletedEvent(comment.getId(), comment.getUser().getId()));
   }
 
   public CursorPageResponseCommentDto findComments(
@@ -226,6 +238,7 @@ public class CommentService {
     comment.decreaseLikeCount();
     commentLikeRepository.delete(commentLike);
     log.info("Comment unliked: commentId={}, requestUserId={}", commentId, requestUserId);
+    eventPublisher.publishEvent(new CommentUnlikedEvent(commentLike.getId(), requestUserId));
   }
 
   // 조회 파라미터를 검증하고 내부 검색 조건으로 변환한다.

--- a/src/main/java/com/team3/monew/service/CommentService.java
+++ b/src/main/java/com/team3/monew/service/CommentService.java
@@ -238,7 +238,12 @@ public class CommentService {
     comment.decreaseLikeCount();
     commentLikeRepository.delete(commentLike);
     log.info("Comment unliked: commentId={}, requestUserId={}", commentId, requestUserId);
-    eventPublisher.publishEvent(new CommentUnlikedEvent(commentLike.getId(), requestUserId));
+    eventPublisher.publishEvent(
+        new CommentUnlikedEvent(
+          requestUserId,
+          commentLike.getId()
+        )
+    );
   }
 
   // 조회 파라미터를 검증하고 내부 검색 조건으로 변환한다.

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -10,6 +10,7 @@ import com.team3.monew.entity.Interest;
 import com.team3.monew.entity.Subscription;
 import com.team3.monew.entity.User;
 import com.team3.monew.event.InterestDeletedEvent;
+import com.team3.monew.event.InterestKeywordUpdatedEvent;
 import com.team3.monew.event.SubscriptionCanceledEvent;
 import com.team3.monew.event.SubscriptionEvent;
 import com.team3.monew.exception.interest.InterestDuplicateNameException;
@@ -206,6 +207,7 @@ public class InterestService {
     log.info("관심사 키워드 수정 성공 - interestId={}, updatedKeywordsCount={}, subscribedByMe={}",
         interestId, keywords.size(), null);
 
+    eventPublisher.publishEvent(new InterestKeywordUpdatedEvent(interestId, keywords));
     return interestMapper.toDto(interest, null);
   }
 

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -9,6 +9,7 @@ import com.team3.monew.dto.pagination.CursorPageResponseDto;
 import com.team3.monew.entity.Interest;
 import com.team3.monew.entity.Subscription;
 import com.team3.monew.entity.User;
+import com.team3.monew.event.InterestDeletedEvent;
 import com.team3.monew.event.SubscriptionCanceledEvent;
 import com.team3.monew.event.SubscriptionEvent;
 import com.team3.monew.exception.interest.InterestDuplicateNameException;
@@ -215,6 +216,7 @@ public class InterestService {
     interestRepository.delete(interest);
 
     log.info("관심사 삭제 성공 - interestId={}", interestId);
+    eventPublisher.publishEvent(new InterestDeletedEvent(interestId));
   }
 
   public SubscriptionDto subscribe(UUID userId, UUID interestId) {

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -9,6 +9,7 @@ import com.team3.monew.dto.pagination.CursorPageResponseDto;
 import com.team3.monew.entity.Interest;
 import com.team3.monew.entity.Subscription;
 import com.team3.monew.entity.User;
+import com.team3.monew.event.SubscriptionCanceledEvent;
 import com.team3.monew.event.SubscriptionEvent;
 import com.team3.monew.exception.interest.InterestDuplicateNameException;
 import com.team3.monew.exception.interest.InterestException;
@@ -260,6 +261,9 @@ public class InterestService {
     interestRepository.decreaseSubscriberCount(interestId);
 
     log.info("관심사 구독 취소 성공 - interestId={}", interestId);
+    eventPublisher.publishEvent(
+        new SubscriptionCanceledEvent(userId, subscription.getId())
+    );
   }
 
   private Interest findInterestOrElseThrow(UUID interestId) {

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -151,6 +151,13 @@ public class UserActivityService {
     }
     userActivityDocument.removeCommentSummary(commentId);
     userActivityRepository.save(userActivityDocument);
+
+    // 삭제 처리하는 사용자가 쓴 댓글이 다른 사람의 좋아요 댓글에 있는 경우
+    List<UserActivityDocument> documents = userActivityRepository.findAllByCommentLikesCommentId(commentId);
+    documents.forEach(document -> {
+      document.removeCommentLikeSummaryByCommentId(commentId);
+      userActivityRepository.save(document);
+    });
     log.debug("사용자 활동 내역 댓글 삭제 성공: userId={} commentId={}", userId, commentId);
   }
 
@@ -169,6 +176,13 @@ public class UserActivityService {
     }
     userActivityDocument.updateCommentContent(commentId, newContent);
     userActivityRepository.save(userActivityDocument);
+
+    // 다른 사람 활동내역 좋아요 댓글에도 수정 반영
+    List<UserActivityDocument> documents = userActivityRepository.findAllByCommentLikesCommentId(commentId);
+    documents.forEach(document -> {
+      document.updateCommentLikeContent(commentId, newContent);
+      userActivityRepository.save(document);
+    });
     log.debug("사용자 활동 내역 댓글 수정 성공: userId={} commentId={}", userId, commentId);
   }
 

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -8,10 +8,13 @@ import com.team3.monew.document.UserActivityDocument;
 import com.team3.monew.document.UserActivityRequest;
 import com.team3.monew.dto.useractivity.UserActivityDto;
 import com.team3.monew.exception.useractivity.UserActivityConflictException;
+import com.team3.monew.exception.useractivity.UserActivityException;
 import com.team3.monew.exception.useractivity.UserActivityNotFoundException;
+import com.team3.monew.global.enums.ErrorCode;
 import com.team3.monew.mapper.UserActivityMapper;
 import com.team3.monew.repository.UserActivityRepository;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -193,6 +196,17 @@ public class UserActivityService {
     log.debug("사용자 활동 내역 관심사 삭제에 따른 구독 삭제 성공: interestId={}",interestId);
   }
 
+  public void updateSubscriptionsByKeywords(UUID interestId, List<String> keywords) {
+    log.debug("사용자 활동 내역 관심사 키워드 업데이트 시작: interestId={}",interestId);
+    List<UserActivityDocument> userActivityDocuments =
+        userActivityRepository.findAllBySubscriptionsInterestId(interestId);
+    userActivityDocuments.forEach(userActivityDocument -> {
+      userActivityDocument.updateKeywords(interestId, keywords);
+      userActivityRepository.save(userActivityDocument);
+    });
+    log.debug("사용자 활동 내역 관심사 키워드 업데이트 성공: interestId={}",interestId);
+  }
+
   @Recover
   public void recoverUpdateSubscriptionSummary(
       OptimisticLockingFailureException e,
@@ -261,5 +275,16 @@ public class UserActivityService {
   ) {
     log.error("댓글 수정 활동 내역 업데이트 최종 실패: userId={}, commentId={}", userId, commentId, e);
     throw new UserActivityConflictException(userId);
+  }
+
+  @Recover
+  public void recoverUpdateSubscriptionsByKeywords(
+      OptimisticLockingFailureException e,
+      UUID interestId,
+      List<String> keywords
+  ) {
+    log.error("댓글 수정 활동 내역 업데이트 최종 실패: interestId={}, keywords={}", interestId, keywords, e);
+    throw new UserActivityException(ErrorCode.USER_ACTIVITY_CONFLICT,
+        Map.of("interestId", interestId, "keywords", keywords));
   }
 }

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -151,6 +151,15 @@ public class UserActivityService {
     log.debug("사용자 활동 내역 댓글 수정 성공: userId={} commentId={}", userId, commentId);
   }
 
+  public void removeCommentLikeSummary(UUID userId, UUID commentLikeId) {
+    log.debug("사용자 활동 내역 댓글 좋아요 삭제 시작: userId={} commentLikeId={}", userId, commentLikeId);
+    UserActivityDocument userActivityDocument = userActivityRepository.findById(userId)
+        .orElseThrow(() -> new UserActivityNotFoundException(userId));
+    userActivityDocument.removeCommentLikeSummary(commentLikeId);
+    userActivityRepository.save(userActivityDocument);
+    log.debug("사용자 활동 내역 댓글 좋아요 삭제 성공: userId={} commentLikeId={}", userId, commentLikeId);
+  }
+
   @Recover
   public void recoverUpdateSubscriptionSummary(
       OptimisticLockingFailureException e,

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -135,7 +135,11 @@ public class UserActivityService {
   public void removeCommentSummary(UUID userId, UUID commentId) {
     log.debug("사용자 활동 내역 댓글 삭제 시작: userId={} commentId={}", userId, commentId);
     UserActivityDocument userActivityDocument = userActivityRepository.findById(userId)
-        .orElseThrow(() -> new UserActivityNotFoundException(userId));
+        .orElse(null);
+    if (userActivityDocument == null) {
+      log.debug("사용자 활동 내역 문서가 이미 없어 댓글 삭제를 건너뜁니다: userId={} commentId={}", userId, commentId);
+      return;
+    }
     userActivityDocument.removeCommentSummary(commentId);
     userActivityRepository.save(userActivityDocument);
     log.debug("사용자 활동 내역 댓글 삭제 성공: userId={} commentId={}", userId, commentId);
@@ -149,7 +153,11 @@ public class UserActivityService {
   public void updateCommentContent(UUID userId, UUID commentId, String newContent) {
     log.debug("사용자 활동 내역 댓글 수정 시작: userId={} commentId={}", userId, commentId);
     UserActivityDocument userActivityDocument = userActivityRepository.findById(userId)
-        .orElseThrow(() -> new UserActivityNotFoundException(userId));
+        .orElse(null);
+    if (userActivityDocument == null) {
+      log.debug("사용자 활동 내역 문서가 이미 없어 댓글 수정를 건너뜁니다: userId={} commentId={}", userId, commentId);
+      return;
+    }
     userActivityDocument.updateCommentContent(commentId, newContent);
     userActivityRepository.save(userActivityDocument);
     log.debug("사용자 활동 내역 댓글 수정 성공: userId={} commentId={}", userId, commentId);
@@ -158,7 +166,11 @@ public class UserActivityService {
   public void removeCommentLikeSummary(UUID userId, UUID commentLikeId) {
     log.debug("사용자 활동 내역 댓글 좋아요 삭제 시작: userId={} commentLikeId={}", userId, commentLikeId);
     UserActivityDocument userActivityDocument = userActivityRepository.findById(userId)
-        .orElseThrow(() -> new UserActivityNotFoundException(userId));
+        .orElse(null);
+    if (userActivityDocument == null) {
+      log.debug("사용자 활동 내역 문서가 이미 없어 좋아요 삭제를 건너뜁니다: userId={} commentLikeId={}", userId, commentLikeId);
+      return;
+    }
     userActivityDocument.removeCommentLikeSummary(commentLikeId);
     userActivityRepository.save(userActivityDocument);
     log.debug("사용자 활동 내역 댓글 좋아요 삭제 성공: userId={} commentLikeId={}", userId, commentLikeId);
@@ -179,7 +191,11 @@ public class UserActivityService {
   public void removeSubscriptionSummary(UUID userId, UUID subscriptionId) {
     log.debug("사용자 활동 내역 구독 삭제 시작: userId={} subscriptionId={}", userId, subscriptionId);
     UserActivityDocument userActivityDocument = userActivityRepository.findById(userId)
-            .orElseThrow(() -> new UserActivityNotFoundException(userId));
+        .orElse(null);
+    if (userActivityDocument == null) {
+      log.debug("사용자 활동 내역 문서가 이미 없어 구독 삭제를 건너뜁니다: userId={} subscriptionId={}", userId, subscriptionId);
+      return;
+    }
     userActivityDocument.removeSubscriptionSummary(subscriptionId);
     userActivityRepository.save(userActivityDocument);
     log.debug("사용자 활동 내역 구독 삭제 성공: userId={} subscriptionId={}", userId, subscriptionId);

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -212,6 +212,11 @@ public class UserActivityService {
     log.debug("사용자 활동 내역 관심사 삭제에 따른 구독 삭제 성공: interestId={}",interestId);
   }
 
+  @Retryable(
+      retryFor = OptimisticLockingFailureException.class,
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 100)
+  )
   public void updateSubscriptionsByKeywords(UUID interestId, List<String> keywords) {
     log.debug("사용자 활동 내역 관심사 키워드 업데이트 시작: interestId={}",interestId);
     List<UserActivityDocument> userActivityDocuments =

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -108,6 +108,26 @@ public class UserActivityService {
     log.debug("사용자 활동 내역 기사 뷰 업데이트 성공: userId={} articleViewId={}", userId, articleViewSummary.id());
   }
 
+  @Retryable(
+      retryFor = OptimisticLockingFailureException.class,
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 100)
+  )
+  public void updateUserNickname(UUID userId, String newNickname) {
+    log.debug("사용자 활동 내역 닉네임 업데이트 시작: userId={}", userId);
+    UserActivityDocument userActivityDocument = userActivityRepository.findById(userId)
+        .orElseThrow(() -> new UserActivityNotFoundException(userId));
+    userActivityDocument.updateNickname(newNickname);
+    userActivityRepository.save(userActivityDocument);
+    log.debug("사용자 활동 내역 닉네임 업데이트 성공: userId={}", userId);
+  }
+
+  public void deleteUserActivity(UUID userId) {
+    log.debug("사용자 활동 내역 삭제 시작: userId={}", userId);
+    userActivityRepository.deleteById(userId);
+    log.debug("사용자 활동 내역 삭제 성공: userId={}", userId);
+  }
+
   @Recover
   public void recoverUpdateSubscriptionSummary(
       OptimisticLockingFailureException e,
@@ -149,6 +169,16 @@ public class UserActivityService {
   ) {
     log.error("기사 뷰 요약 업데이트 최종 실패: userId={}, articleViewId={}",
         userId, summary.id(), e);
+    throw new UserActivityConflictException(userId);
+  }
+
+  @Recover
+  public void recoverUpdateUserNickname(
+      OptimisticLockingFailureException e,
+      UUID userId,
+      String newNickname
+  ) {
+    log.error("사용자 활동 내역 닉네임 업데이트 최종 실패: userId={}", userId, e);
     throw new UserActivityConflictException(userId);
   }
 

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -182,6 +182,17 @@ public class UserActivityService {
     log.debug("사용자 활동 내역 구독 삭제 성공: userId={} subscriptionId={}", userId, subscriptionId);
   }
 
+  public void removeAllSubscriptionSummaryByInterest(UUID interestId) {
+    log.debug("사용자 활동 내역 관심사 삭제에 따른 구독 삭제 시작: interestId={}",interestId);
+    List<UserActivityDocument> userActivityDocuments =
+        userActivityRepository.findAllBySubscriptionsInterestId(interestId);
+    userActivityDocuments.forEach(userActivityDocument -> {
+      userActivityDocument.removeSubscriptionSummaryByInterestId(interestId);
+      userActivityRepository.save(userActivityDocument);
+    });
+    log.debug("사용자 활동 내역 관심사 삭제에 따른 구독 삭제 성공: interestId={}",interestId);
+  }
+
   @Recover
   public void recoverUpdateSubscriptionSummary(
       OptimisticLockingFailureException e,

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -122,7 +122,16 @@ public class UserActivityService {
     UserActivityDocument userActivityDocument = userActivityRepository.findById(userId)
         .orElseThrow(() -> new UserActivityNotFoundException(userId));
     userActivityDocument.updateNickname(newNickname);
+    userActivityDocument.updateCommentNickname(newNickname);
     userActivityRepository.save(userActivityDocument);
+
+    // 닉네임 변경하는 user가 작성한 모든 댓글 가져오고 닉네임 변경
+    List<UserActivityDocument> documents = userActivityRepository.findAllByCommentsUserId(userId);
+    documents.forEach(document -> {
+      document.updateCommentNickname(newNickname);
+      userActivityRepository.save(document);
+    });
+
     log.debug("사용자 활동 내역 닉네임 업데이트 성공: userId={}", userId);
   }
 

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -173,6 +173,15 @@ public class UserActivityService {
     log.debug("사용자 활동 내역 기사 뷰 삭제 성공: articleId={}", articleId);
   }
 
+  public void removeSubscriptionSummary(UUID userId, UUID subscriptionId) {
+    log.debug("사용자 활동 내역 구독 삭제 시작: userId={} subscriptionId={}", userId, subscriptionId);
+    UserActivityDocument userActivityDocument = userActivityRepository.findById(userId)
+            .orElseThrow(() -> new UserActivityNotFoundException(userId));
+    userActivityDocument.removeSubscriptionSummary(subscriptionId);
+    userActivityRepository.save(userActivityDocument);
+    log.debug("사용자 활동 내역 구독 삭제 성공: userId={} subscriptionId={}", userId, subscriptionId);
+  }
+
   @Recover
   public void recoverUpdateSubscriptionSummary(
       OptimisticLockingFailureException e,

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -11,6 +11,7 @@ import com.team3.monew.exception.useractivity.UserActivityConflictException;
 import com.team3.monew.exception.useractivity.UserActivityNotFoundException;
 import com.team3.monew.mapper.UserActivityMapper;
 import com.team3.monew.repository.UserActivityRepository;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -158,6 +159,18 @@ public class UserActivityService {
     userActivityDocument.removeCommentLikeSummary(commentLikeId);
     userActivityRepository.save(userActivityDocument);
     log.debug("사용자 활동 내역 댓글 좋아요 삭제 성공: userId={} commentLikeId={}", userId, commentLikeId);
+  }
+
+  public void removeArticleViewSummary(UUID articleId) {
+    log.debug("사용자 활동 내역 기사 뷰 삭제 시작: articleId={}", articleId);
+    List<UserActivityDocument> userActivityDocuments =
+        userActivityRepository.findAllByArticleViewsArticleId(articleId);
+
+    userActivityDocuments.forEach(userActivityDocument -> {
+      userActivityDocument.removeArticleViewSummary(articleId);
+      userActivityRepository.save(userActivityDocument);
+    });
+    log.debug("사용자 활동 내역 기사 뷰 삭제 성공: articleId={}", articleId);
   }
 
   @Recover

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -128,6 +128,29 @@ public class UserActivityService {
     log.debug("사용자 활동 내역 삭제 성공: userId={}", userId);
   }
 
+  public void removeCommentSummary(UUID userId, UUID commentId) {
+    log.debug("사용자 활동 내역 댓글 삭제 시작: userId={} commentId={}", userId, commentId);
+    UserActivityDocument userActivityDocument = userActivityRepository.findById(userId)
+        .orElseThrow(() -> new UserActivityNotFoundException(userId));
+    userActivityDocument.removeCommentSummary(commentId);
+    userActivityRepository.save(userActivityDocument);
+    log.debug("사용자 활동 내역 댓글 삭제 성공: userId={} commentId={}", userId, commentId);
+  }
+
+  @Retryable(
+      retryFor = OptimisticLockingFailureException.class,
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 100)
+  )
+  public void updateCommentContent(UUID userId, UUID commentId, String newContent) {
+    log.debug("사용자 활동 내역 댓글 수정 시작: userId={} commentId={}", userId, commentId);
+    UserActivityDocument userActivityDocument = userActivityRepository.findById(userId)
+        .orElseThrow(() -> new UserActivityNotFoundException(userId));
+    userActivityDocument.updateCommentContent(commentId, newContent);
+    userActivityRepository.save(userActivityDocument);
+    log.debug("사용자 활동 내역 댓글 수정 성공: userId={} commentId={}", userId, commentId);
+  }
+
   @Recover
   public void recoverUpdateSubscriptionSummary(
       OptimisticLockingFailureException e,
@@ -185,5 +208,16 @@ public class UserActivityService {
   private UserActivityDocument getOrCreate(UUID userId) {
     return userActivityRepository.findById(userId)
         .orElseGet(() -> UserActivityDocument.empty(userId));
+  }
+
+  @Recover
+  public void recoverUpdateCommentContent(
+      OptimisticLockingFailureException e,
+      UUID userId,
+      UUID commentId,
+      String newContent
+  ) {
+    log.error("댓글 수정 활동 내역 업데이트 최종 실패: userId={}, commentId={}", userId, commentId, e);
+    throw new UserActivityConflictException(userId);
   }
 }

--- a/src/main/java/com/team3/monew/service/UserService.java
+++ b/src/main/java/com/team3/monew/service/UserService.java
@@ -6,6 +6,7 @@ import com.team3.monew.dto.user.UserDto;
 import com.team3.monew.dto.user.UserUpdateRequest;
 import com.team3.monew.entity.User;
 import com.team3.monew.event.UserRegisteredEvent;
+import com.team3.monew.event.UserUpdatedEvent;
 import com.team3.monew.exception.user.AuthException;
 import com.team3.monew.exception.user.DuplicateEmailException;
 import com.team3.monew.exception.user.UserNotFoundException;
@@ -81,6 +82,9 @@ public class UserService {
     User updatedUser = userRepository.save(findUser);
 
     log.debug("사용자 수정 성공: targetUserId={}, newNickname={},", userId, updatedUser.getNickname());
+    applicationEventPublisher.publishEvent(
+        new UserUpdatedEvent(updatedUser.getId(), updatedUser.getNickname())
+    );
     return userMapper.toDto(updatedUser);
   }
 

--- a/src/test/java/com/team3/monew/listener/UserActivityEventListenerTest.java
+++ b/src/test/java/com/team3/monew/listener/UserActivityEventListenerTest.java
@@ -374,7 +374,7 @@ class UserActivityEventListenerTest {
   }
 
   @Test
-  @DisplayName("리스너가 관심사 삭제 이벤트를 받으면 서비스의 관심사의 모든 구독 삭제 메서드를 호출한다.")
+  @DisplayName("리스너가 구독 취소 이벤트를 받으면 서비스의 구독 요약 삭제 메서드를 호출한다.")
   void shouldCallRemoveAllSubscriptionSummaryByInterestMethod_whenListenInterestDeletedEvent() {
     // given
     UUID interestId = UUID.randomUUID();

--- a/src/test/java/com/team3/monew/listener/UserActivityEventListenerTest.java
+++ b/src/test/java/com/team3/monew/listener/UserActivityEventListenerTest.java
@@ -9,11 +9,20 @@ import com.team3.monew.document.CommentLikeSummary;
 import com.team3.monew.document.CommentSummary;
 import com.team3.monew.document.SubscriptionSummary;
 import com.team3.monew.document.UserActivityRequest;
+import com.team3.monew.event.ArticleDeletedEvent;
 import com.team3.monew.event.ArticleViewEvent;
+import com.team3.monew.event.CommentDeletedEvent;
 import com.team3.monew.event.CommentLikedEvent;
 import com.team3.monew.event.CommentRegisteredEvent;
+import com.team3.monew.event.CommentUnlikedEvent;
+import com.team3.monew.event.CommentUpdatedEvent;
+import com.team3.monew.event.InterestDeletedEvent;
+import com.team3.monew.event.InterestKeywordUpdatedEvent;
+import com.team3.monew.event.SubscriptionCanceledEvent;
 import com.team3.monew.event.SubscriptionEvent;
+import com.team3.monew.event.UserDeletedEvent;
 import com.team3.monew.event.UserRegisteredEvent;
+import com.team3.monew.event.UserUpdatedEvent;
 import com.team3.monew.mapper.UserActivityMapper;
 import com.team3.monew.service.UserActivityService;
 import java.time.Instant;
@@ -246,5 +255,154 @@ class UserActivityEventListenerTest {
     then(userActivityMapper).should(times(1)).toArticleViewSummary(event);
     then(userActivityService).should(times(1))
         .updateArticleViewSummary(userId, summary);
+  }
+
+  @Test
+  @DisplayName("리스너가 사용자 삭제 이벤트를 받으면 서비스의 사용자 활동 내역 삭제 메서드를 호출한다.")
+  void shouldCallDeleteUserActivityMethod_whenListenUserDeletedEvent() {
+    // given
+    UUID userId = UUID.randomUUID();
+
+    UserDeletedEvent event = new UserDeletedEvent(userId);
+
+    // when
+    userActivityEventListener.handleUserDeletedEvent(event);
+
+    // then
+    then(userActivityService).should(times(1)).deleteUserActivity(userId);
+  }
+
+  @Test
+  @DisplayName("리스너가 사용자 수정 이벤트를 받으면 서비스의 닉네임 업데이트 메서드를 호출한다.")
+  void shouldCallUpdateUserNicknameMethod_whenListenUserUpdatedEvent() {
+    // given
+    UUID userId = UUID.randomUUID();
+    String newNickname = "newTester";
+
+    UserUpdatedEvent event = new UserUpdatedEvent(userId, newNickname);
+
+    // when
+    userActivityEventListener.handleUserUpdatedEvent(event);
+
+    // then
+    then(userActivityService).should(times(1)).updateUserNickname(userId, newNickname);
+  }
+
+  @Test
+  @DisplayName("리스너가 댓글 삭제 이벤트를 받으면 서비스의 댓글 삭제 메서드를 호출한다.")
+  void shouldCallRemoveCommentSummaryMethod_whenListenCommentDeletedEvent() {
+    // given
+    UUID commentId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+
+    CommentDeletedEvent event = new CommentDeletedEvent(commentId, userId);
+
+    // when
+    userActivityEventListener.handleCommentDeletedEvent(event);
+
+    // then
+    then(userActivityService).should(times(1))
+        .removeCommentSummary(userId, commentId);
+  }
+
+  @Test
+  @DisplayName("리스너가 댓글 수정 이벤트를 받으면 서비스의 댓글 수정 메서드를 호출한다.")
+  void shouldCallUpdateCommentContentMethod_whenListenCommentUpdatedEvent() {
+    // given
+    UUID commentId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    String newContent = "수정된 댓글 내용";
+
+    CommentUpdatedEvent event = new CommentUpdatedEvent(commentId, userId, newContent);
+
+    // when
+    userActivityEventListener.handleCommentUpdatedEvent(event);
+
+    // then
+    then(userActivityService).should(times(1))
+        .updateCommentContent(userId, commentId, newContent);
+  }
+
+  @Test
+  @DisplayName("리스너가 댓글 좋아요 취소 이벤트를 받으면 서비스의 댓글 좋아요 삭제 메서드를 호출한다.")
+  void shouldCallRemoveCommentLikeSummaryMethod_whenListenCommentUnlikedEvent() {
+    // given
+    UUID commentLikeId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+
+    CommentUnlikedEvent event = new CommentUnlikedEvent(userId, commentLikeId);
+
+    // when
+    userActivityEventListener.handleCommentUnlikedEvent(event);
+
+    // then
+    then(userActivityService).should(times(1))
+        .removeCommentLikeSummary(userId, commentLikeId);
+  }
+
+  @Test
+  @DisplayName("리스너가 기사 삭제 이벤트를 받으면 서비스의 기사 뷰 삭제 메서드를 호출한다.")
+  void shouldCallRemoveArticleViewSummaryMethod_whenListenArticleDeletedEvent() {
+    // given
+    UUID articleId = UUID.randomUUID();
+
+    ArticleDeletedEvent event = new ArticleDeletedEvent(articleId);
+
+    // when
+    userActivityEventListener.handleArticleDeletedEvent(event);
+
+    // then
+    then(userActivityService).should(times(1))
+        .removeArticleViewSummary(articleId);
+  }
+
+  @Test
+  @DisplayName("리스너가 관심사 삭제 이벤트를 받으면 서비스의 관심사의 구독 모든 구독 삭제 메서드를 호출한다.")
+  void shouldCallRemoveSubscriptionSummaryMethod_whenListenSubscriptionCanceledEvent() {
+    // given
+    UUID subscriptionId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+
+    SubscriptionCanceledEvent event = new SubscriptionCanceledEvent(userId, subscriptionId);
+
+    // when
+    userActivityEventListener.handleSubscriptionCanceledEvent(event);
+
+    // then
+    then(userActivityService).should(times(1))
+        .removeSubscriptionSummary(userId, subscriptionId);
+  }
+
+  @Test
+  @DisplayName("리스너가 관심사 삭제 이벤트를 받으면 서비스의 관심사의 모든 구독 삭제 메서드를 호출한다.")
+  void shouldCallRemoveAllSubscriptionSummaryByInterestMethod_whenListenInterestDeletedEvent() {
+    // given
+    UUID interestId = UUID.randomUUID();
+
+    InterestDeletedEvent event = new InterestDeletedEvent(interestId);
+
+    // when
+    userActivityEventListener.handleInterestDeletedEvent(event);
+
+    // then
+    then(userActivityService).should(times(1))
+        .removeAllSubscriptionSummaryByInterest(interestId);
+  }
+
+  @Test
+  @DisplayName("리스너가 관심사 키워드 수정 이벤트를 받으면 활동 내역 서비스의 관심사의 키워드 수정 메서드를 호출한다.")
+  void shouldCallUpdateSubscriptionsByKeywordsByInterestMethod_whenListenInterestKeywordUpdatedEvent() {
+    // given
+    UUID interestId = UUID.randomUUID();
+    List<String> keywords = List.of("keyword1", "keyword2");
+
+    InterestKeywordUpdatedEvent event = new InterestKeywordUpdatedEvent(interestId, keywords);
+
+    // when
+    userActivityEventListener.handleInterestKeywordUpdatedEvent(event);
+
+    // then
+    then(userActivityService).should(times(1))
+        .updateSubscriptionsByKeywords(interestId, keywords);
   }
 }

--- a/src/test/java/com/team3/monew/service/CommentServiceTest.java
+++ b/src/test/java/com/team3/monew/service/CommentServiceTest.java
@@ -12,6 +12,7 @@ import com.team3.monew.entity.User;
 import com.team3.monew.entity.enums.DeleteStatus;
 import com.team3.monew.entity.enums.NotificationResourceType;
 import com.team3.monew.event.CommentLikedEvent;
+import com.team3.monew.event.CommentUnlikedEvent;
 import com.team3.monew.exception.article.ArticleNotFoundException;
 import com.team3.monew.exception.article.DeletedArticleException;
 import com.team3.monew.exception.comment.CommentLikeAlreadyExistsException;
@@ -814,7 +815,7 @@ class CommentServiceTest {
             // then
             assertThat(comment.getLikeCount()).isZero();
             then(commentLikeRepository).should().delete(commentLike);
-            then(eventPublisher).shouldHaveNoInteractions();
+            then(eventPublisher).should().publishEvent(any(CommentUnlikedEvent.class));
         }
 
         @Test

--- a/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
+++ b/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
@@ -844,7 +844,7 @@ class UserActivityServiceTest {
   }
 
   @Test
-  @DisplayName("관심사 삭제 시 활동 내역에서 해당 관심사의 구독 정보를 삭제합니다.")
+  @DisplayName("관심사 키워드 업데이트 시 활동 내역에서 해당 관심사의 키워드를 업데이트합니다.")
   void shouldRemoveAllSubscriptionSummary_whenInterestDeleted() {
     // given
     UUID interestId = UUID.randomUUID();

--- a/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
+++ b/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
@@ -518,7 +518,7 @@ class UserActivityServiceTest {
     UserActivityDocument document = UserActivityDocument.create(
         userId,
         "test@test.com",
-        "tester",
+        newNickname,
         createdAt
     );
 
@@ -536,6 +536,7 @@ class UserActivityServiceTest {
     document.addCommentSummary(comment);
 
     given(userActivityRepository.findById(userId)).willReturn(Optional.of(document));
+    given(userActivityRepository.findAllByCommentsUserId(userId)).willReturn(List.of());
 
     // when
     userActivityService.updateUserNickname(userId, newNickname);

--- a/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
+++ b/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
@@ -466,4 +466,493 @@ class UserActivityServiceTest {
     assertEquals(1, savedDocument.getArticleViews().size());
     assertEquals(summary, savedDocument.getArticleViews().get(0));
   }
+
+  @Test
+  @DisplayName("사용자 삭제 이벤트 처리 시 활동 내역 문서 삭제에 성공합니다.")
+  void shouldDeleteUserActivity() {
+    // given
+    // when
+    userActivityService.deleteUserActivity(userId);
+
+    // then
+    then(userActivityRepository).should().deleteById(userId);
+  }
+
+  @Test
+  @DisplayName("사용자 닉네임 수정 시 활동 내역 문서 닉네임 업데이트에 성공합니다.")
+  void shouldUpdateUserNickname() {
+    // given
+    String newNickname = "newTester";
+
+    UserActivityDocument document = UserActivityDocument.create(
+        userId,
+        "test@test.com",
+        "tester",
+        createdAt
+    );
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(document));
+
+    // when
+    userActivityService.updateUserNickname(userId, newNickname);
+
+    // then
+    ArgumentCaptor<UserActivityDocument> documentCaptor =
+        ArgumentCaptor.forClass(UserActivityDocument.class);
+
+    then(userActivityRepository).should().save(documentCaptor.capture());
+
+    UserActivityDocument savedDocument = documentCaptor.getValue();
+
+    assertNotNull(savedDocument);
+    assertEquals(userId, savedDocument.getId());
+    assertEquals(newNickname, savedDocument.getNickname());
+  }
+
+  @Test
+  @DisplayName("사용자 닉네임 수정 시 본인이 작성한 댓글의 닉네임도 함께 업데이트됩니다.")
+  void shouldUpdateNicknameInCommentSummaries() {
+    // given
+    String newNickname = "newTester";
+
+    UserActivityDocument document = UserActivityDocument.create(
+        userId,
+        "test@test.com",
+        "tester",
+        createdAt
+    );
+
+    CommentSummary comment = new CommentSummary(
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        "기사 제목",
+        userId,
+        "tester",
+        "댓글 내용",
+        0,
+        createdAt
+    );
+
+    document.addCommentSummary(comment);
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(document));
+
+    // when
+    userActivityService.updateUserNickname(userId, newNickname);
+
+    // then
+    ArgumentCaptor<UserActivityDocument> documentCaptor =
+        ArgumentCaptor.forClass(UserActivityDocument.class);
+
+    then(userActivityRepository).should().save(documentCaptor.capture());
+
+    UserActivityDocument savedDocument = documentCaptor.getValue();
+
+    assertNotNull(savedDocument);
+    assertEquals(userId, savedDocument.getId());
+    assertEquals(newNickname, savedDocument.getNickname());
+    assertEquals(1, savedDocument.getComments().size());
+    assertEquals(newNickname, savedDocument.getComments().get(0).userNickname());
+  }
+
+  @Test
+  @DisplayName("사용자 닉네임 수정 시 문서가 없으면 예외가 발생합니다.")
+  void shouldThrowExceptionWhenUserActivityNotFoundOnUpdateNickname() {
+    // given
+    String newNickname = "newTester";
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThrows(
+        UserActivityNotFoundException.class,
+        () -> userActivityService.updateUserNickname(userId, newNickname)
+    );
+
+    then(userActivityRepository).should(never()).save(any());
+  }
+
+  @Test
+  @DisplayName("댓글 삭제 시 활동 내역 댓글 목록에서 해당 댓글을 제거합니다.")
+  void shouldRemoveCommentSummary() {
+    // given
+    UUID commentId = UUID.randomUUID();
+
+    UserActivityDocument document = UserActivityDocument.create(
+        userId,
+        "test@test.com",
+        "tester",
+        createdAt
+    );
+
+    CommentSummary summary = new CommentSummary(
+        commentId,
+        UUID.randomUUID(),
+        "기사 제목",
+        userId,
+        "tester",
+        "댓글 내용",
+        0,
+        createdAt
+    );
+
+    document.addCommentSummary(summary);
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(document));
+
+    // when
+    userActivityService.removeCommentSummary(userId, commentId);
+
+    // then
+    ArgumentCaptor<UserActivityDocument> documentCaptor =
+        ArgumentCaptor.forClass(UserActivityDocument.class);
+
+    then(userActivityRepository).should().save(documentCaptor.capture());
+
+    UserActivityDocument savedDocument = documentCaptor.getValue();
+
+    assertNotNull(savedDocument);
+    assertEquals(userId, savedDocument.getId());
+    assertEquals(0, savedDocument.getComments().size());
+  }
+
+  @Test
+  @DisplayName("댓글 삭제 시 문서가 없으면 예외가 발생합니다.")
+  void shouldThrowExceptionWhenUserActivityNotFoundOnRemoveCommentSummary() {
+    // given
+    UUID commentId = UUID.randomUUID();
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThrows(
+        UserActivityNotFoundException.class,
+        () -> userActivityService.removeCommentSummary(userId, commentId)
+    );
+
+    then(userActivityRepository).should(never()).save(any());
+  }
+
+  @Test
+  @DisplayName("댓글 수정 시 활동 내역 댓글 목록의 내용을 업데이트합니다.")
+  void shouldUpdateCommentContent() {
+    // given
+    UUID commentId = UUID.randomUUID();
+    String newContent = "수정된 댓글 내용";
+
+    UserActivityDocument document = UserActivityDocument.create(
+        userId,
+        "test@test.com",
+        "tester",
+        createdAt
+    );
+
+    CommentSummary summary = new CommentSummary(
+        commentId,
+        UUID.randomUUID(),
+        "기사 제목",
+        userId,
+        "tester",
+        "기존 댓글 내용",
+        0,
+        createdAt
+    );
+
+    document.addCommentSummary(summary);
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(document));
+
+    // when
+    userActivityService.updateCommentContent(userId, commentId, newContent);
+
+    // then
+    ArgumentCaptor<UserActivityDocument> documentCaptor =
+        ArgumentCaptor.forClass(UserActivityDocument.class);
+
+    then(userActivityRepository).should().save(documentCaptor.capture());
+
+    UserActivityDocument savedDocument = documentCaptor.getValue();
+
+    assertNotNull(savedDocument);
+    assertEquals(userId, savedDocument.getId());
+    assertEquals(1, savedDocument.getComments().size());
+    assertEquals(newContent, savedDocument.getComments().get(0).content());
+  }
+
+  @Test
+  @DisplayName("댓글 수정 시 문서가 없으면 예외가 발생합니다.")
+  void shouldThrowExceptionWhenUserActivityNotFoundOnUpdateCommentContent() {
+    // given
+    UUID commentId = UUID.randomUUID();
+    String newContent = "수정된 댓글 내용";
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThrows(
+        UserActivityNotFoundException.class,
+        () -> userActivityService.updateCommentContent(userId, commentId, newContent)
+    );
+
+    then(userActivityRepository).should(never()).save(any());
+  }
+
+  @Test
+  @DisplayName("댓글 좋아요 취소 시 활동 내역 좋아요 목록에서 해당 항목을 제거합니다.")
+  void shouldRemoveCommentLikeSummary() {
+    // given
+    UUID commentLikeId = UUID.randomUUID();
+
+    UserActivityDocument document = UserActivityDocument.create(
+        userId,
+        "test@test.com",
+        "tester",
+        createdAt
+    );
+
+    CommentLikeSummary summary = new CommentLikeSummary(
+        commentLikeId,
+        createdAt,
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        "기사 제목",
+        UUID.randomUUID(),
+        "commentWriter",
+        "댓글 내용",
+        1,
+        createdAt
+    );
+
+    document.addCommentLikeSummary(summary);
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(document));
+
+    // when
+    userActivityService.removeCommentLikeSummary(userId, commentLikeId);
+
+    // then
+    ArgumentCaptor<UserActivityDocument> documentCaptor =
+        ArgumentCaptor.forClass(UserActivityDocument.class);
+
+    then(userActivityRepository).should().save(documentCaptor.capture());
+
+    UserActivityDocument savedDocument = documentCaptor.getValue();
+
+    assertNotNull(savedDocument);
+    assertEquals(userId, savedDocument.getId());
+    assertEquals(0, savedDocument.getCommentLikes().size());
+  }
+
+  @Test
+  @DisplayName("댓글 좋아요 취소 시 문서가 없으면 예외가 발생합니다.")
+  void shouldThrowExceptionWhenUserActivityNotFoundOnRemoveCommentLikeSummary() {
+    // given
+    UUID commentLikeId = UUID.randomUUID();
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThrows(
+        UserActivityNotFoundException.class,
+        () -> userActivityService.removeCommentLikeSummary(userId, commentLikeId)
+    );
+
+    then(userActivityRepository).should(never()).save(any());
+  }
+
+  @Test
+  @DisplayName("뉴스 기사 삭제 시 활동 내역에서 해당 기사 뷰를 삭제합니다.")
+  void shouldRemoveArticleView_whenArticleRemoved() {
+    //given
+    UUID articleId = UUID.randomUUID();
+
+    UserActivityDocument document = UserActivityDocument.create(
+        userId,
+        "test@test.com",
+        "tester",
+        createdAt
+    );
+
+    ArticleViewSummary articleViewSummary = new ArticleViewSummary(
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        Instant.now(),
+        articleId,
+        "source1",
+        "sourceUrl1",
+        "title1",
+        Instant.now(),
+        "summary1",
+        1,
+        100
+    );
+
+    document.addArticleViewSummary(articleViewSummary);
+    given(userActivityRepository.findAllByArticleViewsArticleId(articleId)).willReturn(List.of(document));
+
+    // when
+    userActivityService.removeArticleViewSummary(articleId);
+
+    // then
+    ArgumentCaptor<UserActivityDocument> documentCaptor =
+        ArgumentCaptor.forClass(UserActivityDocument.class);
+    then(userActivityRepository).should().save(documentCaptor.capture());
+
+    UserActivityDocument savedDocument = documentCaptor.getValue();
+    assertNotNull(savedDocument);
+    assertEquals(userId, savedDocument.getId());
+    assertEquals(0, savedDocument.getArticleViews().size());
+  }
+
+  @Test
+  @DisplayName("구독 해제 시 활동 내역의 구독 목록에서 해당 구독을 삭제합니다.")
+  void shouldRemoveSubscriptionSummary_whenSubscriptionCanceled() {
+    //given
+    UUID subscriptionId = UUID.randomUUID();
+
+    UserActivityDocument document = UserActivityDocument.create(
+        userId,
+        "test@test.com",
+        "tester",
+        createdAt
+    );
+
+    SubscriptionSummary subscriptionSummary = new SubscriptionSummary(
+        subscriptionId,
+        UUID.randomUUID(),
+        "interest1",
+        List.of("keyword1"),
+        1,
+        Instant.now()
+    );
+
+    document.addSubscriptionSummary(subscriptionSummary);
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(document));
+
+    // when
+    userActivityService.removeSubscriptionSummary(userId, subscriptionId);
+
+    // then
+    ArgumentCaptor<UserActivityDocument> documentCaptor =
+        ArgumentCaptor.forClass(UserActivityDocument.class);
+    then(userActivityRepository).should().save(documentCaptor.capture());
+
+    UserActivityDocument savedDocument = documentCaptor.getValue();
+    assertNotNull(savedDocument);
+    assertEquals(userId, savedDocument.getId());
+    assertEquals(0, savedDocument.getSubscriptions().size());
+  }
+
+  @Test
+  @DisplayName("관심사 삭제 시 활동 내역에서 해당 관심사의 구독 정보를 삭제합니다.")
+  void shouldRemoveAllSubscriptionSummary_whenInterestDeleted() {
+    // given
+    UUID interestId = UUID.randomUUID();
+    UUID userId2 = UUID.randomUUID();
+
+    UserActivityDocument document1 = UserActivityDocument.create(
+        userId,
+        "test@test.com",
+        "tester",
+        createdAt
+    );
+
+    SubscriptionSummary subscriptionSummary1 = new SubscriptionSummary(
+        UUID.randomUUID(),
+        interestId,
+        "interest1",
+        List.of("keyword1"),
+        1,
+        Instant.now()
+    );
+
+    UserActivityDocument document2 = UserActivityDocument.create(
+        userId2,
+        "test2@test.com",
+        "tester2",
+        Instant.now()
+    );
+
+    SubscriptionSummary subscriptionSummary2 = new SubscriptionSummary(
+        UUID.randomUUID(),
+        interestId,
+        "interest2",
+        List.of("keyword2"),
+        1,
+        Instant.now()
+    );
+
+    document1.addSubscriptionSummary(subscriptionSummary1);
+    document2.addSubscriptionSummary(subscriptionSummary2);
+    given(userActivityRepository.findAllBySubscriptionsInterestId(interestId))
+        .willReturn(List.of(document1, document2));
+
+    // when
+    userActivityService.removeAllSubscriptionSummaryByInterest(interestId);
+
+    // then
+    ArgumentCaptor<UserActivityDocument> documentCaptor =
+        ArgumentCaptor.forClass(UserActivityDocument.class);
+    then(userActivityRepository).should(times(2)).save(documentCaptor.capture());
+
+    List<UserActivityDocument> savedDocuments = documentCaptor.getAllValues();
+    assertNotNull(savedDocuments);
+    assertEquals(2, savedDocuments.size());
+    assertTrue(savedDocuments.stream()
+        .allMatch(doc -> doc.getSubscriptions().isEmpty()));
+  }
+
+  @Test
+  @DisplayName("관심사 삭제 시 활동 내역에서 해당 관심사의 구독 정보를 삭제합니다.")
+  void shouldUpdatedAllSubscriptionKeywordsSummary_whenInterestKeywordsUpdated() {
+    // given
+    UUID interestId = UUID.randomUUID();
+    UUID userId2 = UUID.randomUUID();
+    List<String> keywords = List.of("newKeyword1", "newKeyword2");
+
+    UserActivityDocument document1 = UserActivityDocument.create(
+        userId,
+        "test@test.com",
+        "tester",
+        createdAt
+    );
+
+    UserActivityDocument document2 = UserActivityDocument.create(
+        userId2,
+        "test2@test.com",
+        "tester2",
+        Instant.now()
+    );
+
+    SubscriptionSummary subscriptionSummary1 = new SubscriptionSummary(
+        UUID.randomUUID(),
+        interestId,
+        "interest1",
+        List.of("keyword1"),
+        1,
+        Instant.now()
+    );
+
+
+    document1.addSubscriptionSummary(subscriptionSummary1);
+    document2.addSubscriptionSummary(subscriptionSummary1);
+    given(userActivityRepository.findAllBySubscriptionsInterestId(interestId))
+        .willReturn(List.of(document1, document2));
+
+    // when
+    userActivityService.updateSubscriptionsByKeywords(interestId, keywords);
+
+    // then
+    ArgumentCaptor<UserActivityDocument> documentCaptor =
+        ArgumentCaptor.forClass(UserActivityDocument.class);
+    then(userActivityRepository).should(times(2)).save(documentCaptor.capture());
+
+    List<UserActivityDocument> savedDocuments = documentCaptor.getAllValues();
+    assertNotNull(savedDocuments);
+    assertEquals(2, savedDocuments.size());
+
+    savedDocuments.forEach(savedDocument ->
+        assertEquals(keywords, savedDocument.getSubscriptions().get(0).interestKeywords())
+    );
+  }
 }

--- a/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
+++ b/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
@@ -618,6 +618,73 @@ class UserActivityServiceTest {
   }
 
   @Test
+  @DisplayName("댓글 삭제 시 다른 유저의 활동 내역 좋아요 목록에서도 해당 댓글의 좋아요를 제거합니다.")
+  void shouldRemoveCommentLikeSummaryFromOtherUserActivity_whenCommentDeleted() {
+    // given
+    UUID commentId = UUID.randomUUID();
+    UUID otherUserId = UUID.randomUUID();
+
+    UserActivityDocument userActivityDocument = UserActivityDocument.create(
+        userId,
+        "test@test.com",
+        "tester",
+        createdAt
+    );
+
+    CommentSummary commentSummary = new CommentSummary(
+        commentId,
+        UUID.randomUUID(),
+        "기사 제목",
+        userId,
+        "tester",
+        "댓글 내용",
+        0,
+        createdAt
+    );
+
+    UserActivityDocument otherUserActivityDocument = UserActivityDocument.create(
+        otherUserId,
+        "other@test.com",
+        "otherTester",
+        createdAt
+    );
+
+    CommentLikeSummary commentLikeSummary = new CommentLikeSummary(
+        UUID.randomUUID(),
+        createdAt,
+        commentId,         // 삭제될 댓글 ID
+        UUID.randomUUID(),
+        "기사 제목",
+        userId,
+        "tester",
+        "댓글 내용",
+        1,
+        createdAt
+    );
+
+    userActivityDocument.addCommentSummary(commentSummary);
+    otherUserActivityDocument.addCommentLikeSummary(commentLikeSummary);
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(userActivityDocument));
+    given(userActivityRepository.findAllByCommentLikesCommentId(commentId))
+        .willReturn(List.of(otherUserActivityDocument));
+
+    // when
+    userActivityService.removeCommentSummary(userId, commentId);
+
+    // then
+    ArgumentCaptor<UserActivityDocument> documentCaptor =
+        ArgumentCaptor.forClass(UserActivityDocument.class);
+
+    then(userActivityRepository).should(times(2)).save(documentCaptor.capture());
+
+    List<UserActivityDocument> savedDocuments = documentCaptor.getAllValues();
+
+    assertEquals(0, savedDocuments.get(0).getComments().size());
+    assertEquals(0, savedDocuments.get(1).getCommentLikes().size());
+  }
+
+  @Test
   @DisplayName("댓글 삭제 시 문서가 없으면 예외가 발생합니다.")
   void shouldThrowExceptionWhenUserActivityNotFoundOnRemoveCommentSummary() {
     // given
@@ -676,6 +743,74 @@ class UserActivityServiceTest {
     assertEquals(userId, savedDocument.getId());
     assertEquals(1, savedDocument.getComments().size());
     assertEquals(newContent, savedDocument.getComments().get(0).content());
+  }
+
+  @Test
+  @DisplayName("댓글 수정 시 다른 유저의 활동 내역 좋아요 목록의 댓글 내용도 함께 업데이트됩니다.")
+  void shouldUpdateCommentLikeContentFromOtherUserActivity_whenCommentUpdated() {
+    // given
+    UUID commentId = UUID.randomUUID();
+    UUID otherUserId = UUID.randomUUID();
+    String newContent = "수정된 댓글 내용";
+
+    UserActivityDocument userActivityDocument = UserActivityDocument.create(
+        userId,
+        "test@test.com",
+        "tester",
+        createdAt
+    );
+
+    CommentSummary commentSummary = new CommentSummary(
+        commentId,
+        UUID.randomUUID(),
+        "기사 제목",
+        userId,
+        "tester",
+        "기존 댓글 내용",
+        0,
+        createdAt
+    );
+
+    UserActivityDocument otherUserActivityDocument = UserActivityDocument.create(
+        otherUserId,
+        "other@test.com",
+        "otherTester",
+        createdAt
+    );
+
+    CommentLikeSummary commentLikeSummary = new CommentLikeSummary(
+        UUID.randomUUID(),
+        createdAt,
+        commentId,         // 수정될 댓글 ID
+        UUID.randomUUID(),
+        "기사 제목",
+        userId,
+        "tester",
+        "기존 댓글 내용",
+        1,
+        createdAt
+    );
+
+    userActivityDocument.addCommentSummary(commentSummary);
+    otherUserActivityDocument.addCommentLikeSummary(commentLikeSummary);
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(userActivityDocument));
+    given(userActivityRepository.findAllByCommentLikesCommentId(commentId))
+        .willReturn(List.of(otherUserActivityDocument));
+
+    // when
+    userActivityService.updateCommentContent(userId, commentId, newContent);
+
+    // then
+    ArgumentCaptor<UserActivityDocument> documentCaptor =
+        ArgumentCaptor.forClass(UserActivityDocument.class);
+
+    then(userActivityRepository).should(times(2)).save(documentCaptor.capture());
+
+    List<UserActivityDocument> savedDocuments = documentCaptor.getAllValues();
+
+    assertEquals(newContent, savedDocuments.get(0).getComments().get(0).content());
+    assertEquals(newContent, savedDocuments.get(1).getCommentLikes().get(0).commentContent());
   }
 
   @Test

--- a/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
+++ b/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
@@ -624,12 +624,10 @@ class UserActivityServiceTest {
 
     given(userActivityRepository.findById(userId)).willReturn(Optional.empty());
 
-    // when & then
-    assertThrows(
-        UserActivityNotFoundException.class,
-        () -> userActivityService.removeCommentSummary(userId, commentId)
-    );
+    // when
+    userActivityService.removeCommentSummary(userId, commentId);
 
+    // then
     then(userActivityRepository).should(never()).save(any());
   }
 
@@ -688,12 +686,10 @@ class UserActivityServiceTest {
 
     given(userActivityRepository.findById(userId)).willReturn(Optional.empty());
 
-    // when & then
-    assertThrows(
-        UserActivityNotFoundException.class,
-        () -> userActivityService.updateCommentContent(userId, commentId, newContent)
-    );
+    // when
+    userActivityService.updateCommentContent(userId, commentId, newContent);
 
+    // then
     then(userActivityRepository).should(never()).save(any());
   }
 
@@ -744,19 +740,17 @@ class UserActivityServiceTest {
   }
 
   @Test
-  @DisplayName("댓글 좋아요 취소 시 문서가 없으면 예외가 발생합니다.")
+  @DisplayName("댓글 좋아요 취소 시 문서가 없으면 정상 종료합니다.")
   void shouldThrowExceptionWhenUserActivityNotFoundOnRemoveCommentLikeSummary() {
     // given
     UUID commentLikeId = UUID.randomUUID();
 
     given(userActivityRepository.findById(userId)).willReturn(Optional.empty());
 
-    // when & then
-    assertThrows(
-        UserActivityNotFoundException.class,
-        () -> userActivityService.removeCommentLikeSummary(userId, commentLikeId)
-    );
+    // when
+    userActivityService.removeCommentLikeSummary(userId, commentLikeId);
 
+    // then
     then(userActivityRepository).should(never()).save(any());
   }
 

--- a/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
+++ b/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
@@ -685,8 +685,8 @@ class UserActivityServiceTest {
   }
 
   @Test
-  @DisplayName("댓글 삭제 시 문서가 없으면 예외가 발생합니다.")
-  void shouldThrowExceptionWhenUserActivityNotFoundOnRemoveCommentSummary() {
+  @DisplayName("댓글 삭제 시 문서가 문서가 없으면 정상 종료합니다.")
+  void shouldDoNothingWhenUserActivityNotFoundOnRemoveCommentSummary() {
     // given
     UUID commentId = UUID.randomUUID();
 
@@ -814,8 +814,8 @@ class UserActivityServiceTest {
   }
 
   @Test
-  @DisplayName("댓글 수정 시 문서가 없으면 예외가 발생합니다.")
-  void shouldThrowExceptionWhenUserActivityNotFoundOnUpdateCommentContent() {
+  @DisplayName("댓글 수정 시 문서가 문서가 없으면 정상 종료합니다.")
+  void shouldDoNothingWhenUserActivityNotFoundOnUpdateCommentContent() {
     // given
     UUID commentId = UUID.randomUUID();
     String newContent = "수정된 댓글 내용";
@@ -877,7 +877,7 @@ class UserActivityServiceTest {
 
   @Test
   @DisplayName("댓글 좋아요 취소 시 문서가 없으면 정상 종료합니다.")
-  void shouldThrowExceptionWhenUserActivityNotFoundOnRemoveCommentLikeSummary() {
+  void shouldDoNothingWhenUserActivityNotFoundOnRemoveCommentLikeSummary() {
     // given
     UUID commentLikeId = UUID.randomUUID();
 


### PR DESCRIPTION
## 관련 이슈
- closes #210 
- closes #211 , #212 , #213 , #214 , #215 , #216 , #217 

## 작업 내용
- 사용자 수정 및 삭제 이벤트 반영
#211 
- 댓글 수정 및 삭제 이벤트 반영
#212 
- 좋아요 취소 이벤트 반영
#213 
- 기사 삭제 이벤트 반영
#214 
- 관심사 구독 해제 및 삭제 이벤트 반영
#215 
- 관심사 키워드 수정 이벤트 반영
#216 
- 테스트 코드 작성
#217 

## 변경 사항
- 사용자 수정, 댓글 수정/삭제, 좋아요 취소, 기사 삭제, 관심사 구독 해제/삭제, 관심사 키워드 수정 부분에 이벤트 발행 코드 추가

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 모든 기능들이 수정/삭제 발생 -> 이벤트 ->  활동 내역 서비스에서 처리하는 것으로 반복되는 형태입니다.
- 일단 논리 삭제, 물리 삭제 둘다 활동 내역에서는 삭제되게 구현하였습니다.
- 키워드 삭제는 따로 없고 다 수정으로 처리하는 것으로 확인했습니다.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 닉네임 변경이 기존 댓글/좋아요/구독 요약 등에 전파되어 자동 반영
  * 댓글 수정·삭제, 좋아요 취소, 기사 삭제, 구독 취소, 관심사 삭제·키워드 변경 관련 이벤트 발행 및 비동기 처리(재시도·복구 로직 포함)
  * 기사·관심사·댓글 관련 활동을 ID 기준으로 일괄 조회·삭제 및 키워드 기반 구독 업데이트 지원

* **테스트**
  * 이벤트 리스너 및 사용자 활동 서비스에 대한 단위 테스트 대폭 확장 및 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->