### PR TITLE
refactor: 관심사 이름 유사도 로직 수정

### DIFF
--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -76,11 +76,11 @@ public class InterestService {
 
     List<Interest> interests = interestRepository.findAll();
     for (Interest interest : interests) {
-      if (isSimilarInterestName(interest.getName(), dto.name())) {
-        double similarity = calculateSimilarity(interest.getName(), dto.name());
+      SimilarityResult result = checkInterestNameSimilarity(interest.getName(), dto.name());
 
+      if (result.similar()) {
         log.warn("관심사 등록 실패 - 유사한 이름 존재, requestName={}, existingName={}, similarity={}",
-            dto.name(), interest.getName(), similarity);
+            dto.name(), interest.getName(), result.similarity());
 
         throw new InterestDuplicateNameException();
       }
@@ -304,6 +304,10 @@ public class InterestService {
         .orElseThrow(() -> new UserNotFoundException(userId));
   }
 
+  private record SimilarityResult(boolean similar, double similarity) {
+
+  }
+
   // 유니크 제약 위반 검증
   private boolean isDuplicateSubscriptionViolation(DataIntegrityViolationException e) {
     Throwable cause = e;
@@ -317,29 +321,31 @@ public class InterestService {
   }
 
   // 관심사 이름 유사도 판단
-  private boolean isSimilarInterestName(String existingName, String requestName) {
+  private SimilarityResult checkInterestNameSimilarity(String existingName, String requestName) {
     String existing = normalize(existingName);
     String request = normalize(requestName);
 
     // 완전 동일 이름은 차단
     if (existing.equals(request)) {
-      return true;
+      return new SimilarityResult(true, 1.0);
     }
 
     // 포함 관계는 허용
     // 예: 삼성 != 삼성전자, 주식 != 해외주식
     if (existing.contains(request) || request.contains(existing)) {
-      return false;
+      return new SimilarityResult(false, 0.0);
     }
 
     // 너무 짧은 이름은 유사도 검사하지 않음
     // 예: 주식 vs 주석 같은 실제 단어 과차단 방지
     if (existing.length() < 4 || request.length() < 4) {
-      return false;
+      return new SimilarityResult(false, 0.0);
     }
 
     // 길이가 충분한 경우에만 자모 분해 기반 유사도 검사
-    return calculateSimilarity(existing, request) >= 0.8;
+    double similarity = calculateSimilarity(existing, request);
+
+    return new SimilarityResult(similarity >= 0.8, similarity);
   }
 
   // 유사도 계산 메서드

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -59,10 +59,12 @@ public class InterestService {
 
     List<Interest> interests = interestRepository.findAll();
     for (Interest interest : interests) {
-      double similarity = calculateSimilarity(interest.getName(), dto.name());
-      if (similarity >= 0.8) {
+      if (isSimilarInterestName(interest.getName(), dto.name())) {
+        double similarity = calculateSimilarity(interest.getName(), dto.name());
+
         log.warn("관심사 등록 실패 - 유사한 이름 존재, requestName={}, existingName={}, similarity={}",
             dto.name(), interest.getName(), similarity);
+
         throw new InterestDuplicateNameException();
       }
     }
@@ -297,15 +299,41 @@ public class InterestService {
     return false;
   }
 
+  // 관심사 이름 유사도 판단
+  private boolean isSimilarInterestName(String existingName, String requestName) {
+    String existing = normalize(existingName);
+    String request = normalize(requestName);
+
+    // 완전 동일 이름은 차단
+    if (existing.equals(request)) {
+      return true;
+    }
+
+    // 포함 관계는 허용
+    // 예: 삼성 != 삼성전자, 주식 != 해외주식
+    if (existing.contains(request) || request.contains(existing)) {
+      return false;
+    }
+
+    // 너무 짧은 이름은 유사도 검사하지 않음
+    // 예: 주식 vs 주석 같은 실제 단어 과차단 방지
+    if (existing.length() < 4 || request.length() < 4) {
+      return false;
+    }
+
+    // 길이가 충분한 경우에만 자모 분해 기반 유사도 검사
+    return calculateSimilarity(existing, request) >= 0.8;
+  }
+
   // 유사도 계산 메서드
   private double calculateSimilarity(String a, String b) {
-    String normalizedA = normalize(a);
-    String normalizedB = normalize(b);
+    String normalizedA = decomposeKorean(normalize(a));
+    String normalizedB = decomposeKorean(normalize(b));
+
     int distance = levenshtein(normalizedA, normalizedB);
     int maxLength = Math.max(normalizedA.length(), normalizedB.length());
 
     if (maxLength == 0) {
-      // 둘 다 빈 문자열이면 동일한 것으로 간주함
       return 1.0;
     }
 
@@ -315,6 +343,49 @@ public class InterestService {
   // 문자열 정규화
   private String normalize(String s) {
     return s.trim().toLowerCase();
+  }
+
+  // 한글 음절을 초성/중성/종성으로 분해
+  private String decomposeKorean(String s) {
+    final char[] CHO = {
+        'ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅃ',
+        'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅉ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'
+    };
+
+    final char[] JUNG = {
+        'ㅏ', 'ㅐ', 'ㅑ', 'ㅒ', 'ㅓ', 'ㅔ', 'ㅕ', 'ㅖ', 'ㅗ',
+        'ㅘ', 'ㅙ', 'ㅚ', 'ㅛ', 'ㅜ', 'ㅝ', 'ㅞ', 'ㅟ', 'ㅠ',
+        'ㅡ', 'ㅢ', 'ㅣ'
+    };
+
+    final char[] JONG = {
+        '\0', 'ㄱ', 'ㄲ', 'ㄳ', 'ㄴ', 'ㄵ', 'ㄶ', 'ㄷ', 'ㄹ',
+        'ㄺ', 'ㄻ', 'ㄼ', 'ㄽ', 'ㄾ', 'ㄿ', 'ㅀ', 'ㅁ', 'ㅂ',
+        'ㅄ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'
+    };
+
+    StringBuilder result = new StringBuilder();
+
+    for (char ch : s.toCharArray()) {
+      if (ch >= '가' && ch <= '힣') {
+        int unicode = ch - '가';
+
+        int choIndex = unicode / (21 * 28);
+        int jungIndex = (unicode % (21 * 28)) / 28;
+        int jongIndex = unicode % 28;
+
+        result.append(CHO[choIndex]);
+        result.append(JUNG[jungIndex]);
+
+        if (jongIndex != 0) {
+          result.append(JONG[jongIndex]);
+        }
+      } else {
+        result.append(ch);
+      }
+    }
+
+    return result.toString();
   }
 
   // 레벤슈타인 알고리즘

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -48,6 +48,23 @@ public class InterestService {
   private final UserRepository userRepository;
   private final ApplicationEventPublisher eventPublisher;
 
+  private static final char[] CHO = {
+      'ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅃ',
+      'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅉ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'
+  };
+
+  private static final char[] JUNG = {
+      'ㅏ', 'ㅐ', 'ㅑ', 'ㅒ', 'ㅓ', 'ㅔ', 'ㅕ', 'ㅖ', 'ㅗ',
+      'ㅘ', 'ㅙ', 'ㅚ', 'ㅛ', 'ㅜ', 'ㅝ', 'ㅞ', 'ㅟ', 'ㅠ',
+      'ㅡ', 'ㅢ', 'ㅣ'
+  };
+
+  private static final char[] JONG = {
+      '\0', 'ㄱ', 'ㄲ', 'ㄳ', 'ㄴ', 'ㄵ', 'ㄶ', 'ㄷ', 'ㄹ',
+      'ㄺ', 'ㄻ', 'ㄼ', 'ㄽ', 'ㄾ', 'ㄿ', 'ㅀ', 'ㅁ', 'ㅂ',
+      'ㅄ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'
+  };
+
   public InterestDto createInterest(InterestRegisterRequest dto) {
     log.debug("관심사 등록 요청 - name={}, keywordCount={}",
         dto.name(), dto.keywords().size());
@@ -347,22 +364,6 @@ public class InterestService {
 
   // 한글 음절을 초성/중성/종성으로 분해
   private String decomposeKorean(String s) {
-    final char[] CHO = {
-        'ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅃ',
-        'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅉ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'
-    };
-
-    final char[] JUNG = {
-        'ㅏ', 'ㅐ', 'ㅑ', 'ㅒ', 'ㅓ', 'ㅔ', 'ㅕ', 'ㅖ', 'ㅗ',
-        'ㅘ', 'ㅙ', 'ㅚ', 'ㅛ', 'ㅜ', 'ㅝ', 'ㅞ', 'ㅟ', 'ㅠ',
-        'ㅡ', 'ㅢ', 'ㅣ'
-    };
-
-    final char[] JONG = {
-        '\0', 'ㄱ', 'ㄲ', 'ㄳ', 'ㄴ', 'ㄵ', 'ㄶ', 'ㄷ', 'ㄹ',
-        'ㄺ', 'ㄻ', 'ㄼ', 'ㄽ', 'ㄾ', 'ㄿ', 'ㅀ', 'ㅁ', 'ㅂ',
-        'ㅄ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'
-    };
 
     StringBuilder result = new StringBuilder();
 

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -48,18 +48,18 @@ public class InterestService {
   private final UserRepository userRepository;
   private final ApplicationEventPublisher eventPublisher;
 
-  private static final char[] CHO = {
+  private static final char[] CHOSEONG_JAMO = {
       'ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅃ',
       'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅉ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'
   };
 
-  private static final char[] JUNG = {
+  private static final char[] JUNGSEONG_JAMO = {
       'ㅏ', 'ㅐ', 'ㅑ', 'ㅒ', 'ㅓ', 'ㅔ', 'ㅕ', 'ㅖ', 'ㅗ',
       'ㅘ', 'ㅙ', 'ㅚ', 'ㅛ', 'ㅜ', 'ㅝ', 'ㅞ', 'ㅟ', 'ㅠ',
       'ㅡ', 'ㅢ', 'ㅣ'
   };
 
-  private static final char[] JONG = {
+  private static final char[] JONGSEONG_JAMO = {
       '\0', 'ㄱ', 'ㄲ', 'ㄳ', 'ㄴ', 'ㄵ', 'ㄶ', 'ㄷ', 'ㄹ',
       'ㄺ', 'ㄻ', 'ㄼ', 'ㄽ', 'ㄾ', 'ㄿ', 'ㅀ', 'ㅁ', 'ㅂ',
       'ㅄ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'
@@ -375,11 +375,11 @@ public class InterestService {
         int jungIndex = (unicode % (21 * 28)) / 28;
         int jongIndex = unicode % 28;
 
-        result.append(CHO[choIndex]);
-        result.append(JUNG[jungIndex]);
+        result.append(CHOSEONG_JAMO[choIndex]);
+        result.append(JUNGSEONG_JAMO[jungIndex]);
 
         if (jongIndex != 0) {
-          result.append(JONG[jongIndex]);
+          result.append(JONGSEONG_JAMO[jongIndex]);
         }
       } else {
         result.append(ch);

--- a/src/test/java/com/team3/monew/controller/InterestControllerTest.java
+++ b/src/test/java/com/team3/monew/controller/InterestControllerTest.java
@@ -123,7 +123,7 @@ class InterestControllerTest {
 
   @Test
   @DisplayName("유사한 관심사 이름이면 400 응답을 반환한다")
-  void shouldReturnBadRequest_whenInterestNameIsSimilar() throws Exception {
+  void shouldReturnConflict_whenInterestNameIsSimilar() throws Exception {
     // given
     given(interestService.createInterest(any()))
         .willThrow(new InterestDuplicateNameException());

--- a/src/test/java/com/team3/monew/controller/InterestControllerTest.java
+++ b/src/test/java/com/team3/monew/controller/InterestControllerTest.java
@@ -122,6 +122,27 @@ class InterestControllerTest {
   }
 
   @Test
+  @DisplayName("유사한 관심사 이름이면 400 응답을 반환한다")
+  void shouldReturnBadRequest_whenInterestNameIsSimilar() throws Exception {
+    // given
+    given(interestService.createInterest(any()))
+        .willThrow(new InterestDuplicateNameException());
+
+    String requestJson = """
+        {
+          "name": "삼셩전자",
+          "keywords": ["키워드"]
+        }
+        """;
+
+    // when & then
+    mockMvc.perform(post("/api/interests")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestJson))
+        .andExpect(status().isConflict());
+  }
+
+  @Test
   @DisplayName("관심사 키워드를 수정할 수 있다")
   void shouldUpdateInterestKeywords_whenValidRequest() throws Exception {
     // given

--- a/src/test/java/com/team3/monew/integration/InterestServiceIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/InterestServiceIntegrationTest.java
@@ -27,6 +27,8 @@ import jakarta.persistence.PersistenceContext;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -101,25 +103,197 @@ public class InterestServiceIntegrationTest extends IntegrationTestSupport {
         .isInstanceOf(InterestDuplicateNameException.class);
   }
 
-  @Test
-  @DisplayName("관심사 이름의 유사도가 80% 이상이면 등록에 실패한다")
-  void shouldFailToRegisterInterest_whenNameSimilar80percentOver() {
-    // given
-    InterestRegisterRequest request = new InterestRegisterRequest(
-        "apple",
-        List.of("keyword")
-    );
+  @Nested
+  @DisplayName("관심사 이름 유사도 검증 테스트")
+  class InterestNameSimilarityTest {
 
-    InterestRegisterRequest request2 = new InterestRegisterRequest(
-        "applf",
-        List.of("keyword")
-    );
+    @BeforeEach
+    void setUp() {
+      subscriptionRepository.deleteAll();
+      interestKeywordRepository.deleteAll();
+      interestRepository.deleteAll();
 
-    interestService.createInterest(request);
+      entityManager.flush();
+      entityManager.clear();
+    }
 
-    // when & then
-    assertThatThrownBy(() -> interestService.createInterest(request2))
-        .isInstanceOf(InterestDuplicateNameException.class);
+    @Test
+    @DisplayName("영어 관심사 이름의 유사도가 80% 이상이면 등록에 실패하고 DB에 저장되지 않는다")
+    void shouldFailToRegisterInterest_whenEnglishNameSimilar80percentOver() {
+      // given
+      InterestRegisterRequest appleRequest = new InterestRegisterRequest(
+          "apple",
+          List.of("keyword")
+      );
+
+      InterestRegisterRequest similarRequest = new InterestRegisterRequest(
+          "applf",
+          List.of("similar")
+      );
+
+      interestService.createInterest(appleRequest);
+
+      entityManager.flush();
+      entityManager.clear();
+
+      // when & then
+      assertThatThrownBy(() -> interestService.createInterest(similarRequest))
+          .isInstanceOf(InterestDuplicateNameException.class);
+
+      entityManager.flush();
+      entityManager.clear();
+
+      List<Interest> interests = interestRepository.findAll();
+      List<InterestKeyword> keywords = interestKeywordRepository.findAll();
+
+      assertThat(interests)
+          .extracting(Interest::getName)
+          .containsExactly("apple");
+
+      assertThat(keywords)
+          .extracting(InterestKeyword::getKeyword)
+          .containsExactly("keyword");
+    }
+
+    @Test
+    @DisplayName("한글 관심사 이름이 4글자 이상이고 자모 분해 기준 유사도가 80% 이상이면 등록에 실패하고 DB에 저장되지 않는다")
+    void shouldFailToRegisterInterest_whenKoreanNameSimilar80percentOver() {
+      // given
+      InterestRegisterRequest samsungRequest = new InterestRegisterRequest(
+          "삼성전자",
+          List.of("삼성", "전자")
+      );
+
+      InterestRegisterRequest similarRequest = new InterestRegisterRequest(
+          "삼셩전자",
+          List.of("오타", "유사이름")
+      );
+
+      interestService.createInterest(samsungRequest);
+
+      entityManager.flush();
+      entityManager.clear();
+
+      // when & then
+      assertThatThrownBy(() -> interestService.createInterest(similarRequest))
+          .isInstanceOf(InterestDuplicateNameException.class);
+
+      entityManager.flush();
+      entityManager.clear();
+
+      List<Interest> interests = interestRepository.findAll();
+      List<InterestKeyword> keywords = interestKeywordRepository.findAll();
+
+      assertThat(interests)
+          .extracting(Interest::getName)
+          .containsExactly("삼성전자");
+
+      assertThat(keywords)
+          .extracting(InterestKeyword::getKeyword)
+          .containsExactlyInAnyOrder("삼성", "전자");
+    }
+
+    @Test
+    @DisplayName("짧은 한글 관심사 이름은 유사해도 각각 별도 관심사로 저장된다")
+    void shouldRegisterBothInterests_whenKoreanNamesAreShortEvenIfSimilar() {
+      // given
+      InterestRegisterRequest stockRequest = new InterestRegisterRequest(
+          "주식",
+          List.of("코스피")
+      );
+
+      InterestRegisterRequest annotationRequest = new InterestRegisterRequest(
+          "주석",
+          List.of("문서")
+      );
+
+      // when
+      InterestDto stock = interestService.createInterest(stockRequest);
+      InterestDto annotation = interestService.createInterest(annotationRequest);
+
+      entityManager.flush();
+      entityManager.clear();
+
+      // then
+      assertThat(interestRepository.findById(stock.id())).isPresent();
+      assertThat(interestRepository.findById(annotation.id())).isPresent();
+
+      assertThat(interestRepository.findAll())
+          .extracting(Interest::getName)
+          .containsExactlyInAnyOrder("주식", "주석");
+
+      assertThat(interestKeywordRepository.findAll())
+          .extracting(InterestKeyword::getKeyword)
+          .containsExactlyInAnyOrder("코스피", "문서");
+    }
+
+    @Test
+    @DisplayName("포함 관계인 한글 관심사 이름은 각각 별도 관심사로 저장된다")
+    void shouldRegisterBothInterests_whenNameIsContainmentRelationship() {
+      // given
+      InterestRegisterRequest samsungRequest = new InterestRegisterRequest(
+          "삼성",
+          List.of("기업")
+      );
+
+      InterestRegisterRequest samsungElectronicsRequest = new InterestRegisterRequest(
+          "삼성전자",
+          List.of("반도체", "전자")
+      );
+
+      // when
+      InterestDto samsung = interestService.createInterest(samsungRequest);
+      InterestDto samsungElectronics = interestService.createInterest(samsungElectronicsRequest);
+
+      entityManager.flush();
+      entityManager.clear();
+
+      // then
+      assertThat(interestRepository.findById(samsung.id())).isPresent();
+      assertThat(interestRepository.findById(samsungElectronics.id())).isPresent();
+
+      assertThat(interestRepository.findAll())
+          .extracting(Interest::getName)
+          .containsExactlyInAnyOrder("삼성", "삼성전자");
+
+      assertThat(interestKeywordRepository.findAll())
+          .extracting(InterestKeyword::getKeyword)
+          .containsExactlyInAnyOrder("기업", "반도체", "전자");
+    }
+
+    @Test
+    @DisplayName("기존 관심사 이름이 요청 관심사 이름을 포함해도 각각 별도 관심사로 저장된다")
+    void shouldRegisterBothInterests_whenExistingNameContainsRequestName() {
+      // given
+      InterestRegisterRequest overseasStockRequest = new InterestRegisterRequest(
+          "해외주식",
+          List.of("미국주식", "나스닥")
+      );
+
+      InterestRegisterRequest stockRequest = new InterestRegisterRequest(
+          "주식",
+          List.of("코스피")
+      );
+
+      // when
+      InterestDto overseasStock = interestService.createInterest(overseasStockRequest);
+      InterestDto stock = interestService.createInterest(stockRequest);
+
+      entityManager.flush();
+      entityManager.clear();
+
+      // then
+      assertThat(interestRepository.findById(overseasStock.id())).isPresent();
+      assertThat(interestRepository.findById(stock.id())).isPresent();
+
+      assertThat(interestRepository.findAll())
+          .extracting(Interest::getName)
+          .containsExactlyInAnyOrder("해외주식", "주식");
+
+      assertThat(interestKeywordRepository.findAll())
+          .extracting(InterestKeyword::getKeyword)
+          .containsExactlyInAnyOrder("미국주식", "나스닥", "코스피");
+    }
   }
 
   @Test

--- a/src/test/java/com/team3/monew/service/InterestServiceTest.java
+++ b/src/test/java/com/team3/monew/service/InterestServiceTest.java
@@ -145,6 +145,163 @@ class InterestServiceTest {
   }
 
   @Test
+  @DisplayName("한글 관심사 이름이 4글자 이상이고 자모 분해 기준 유사도가 80% 이상이면 등록에 실패한다")
+  void shouldFailToRegisterInterest_whenKoreanNameSimilar80percentOver() {
+    // given
+    InterestRegisterRequest request = new InterestRegisterRequest(
+        "삼셩전자",
+        List.of("키워드")
+    );
+
+    Interest existingInterest = Interest.create("삼성전자");
+
+    given(interestRepository.existsByName("삼셩전자")).willReturn(false);
+    given(interestRepository.findAll()).willReturn(List.of(existingInterest));
+
+    // when & then
+    assertThatThrownBy(() -> interestService.createInterest(request))
+        .isInstanceOf(InterestDuplicateNameException.class);
+
+    then(interestRepository).should(never()).saveAndFlush(any());
+  }
+
+  @Test
+  @DisplayName("한글 관심사 이름이 4글자 미만이면 유사해도 등록할 수 있다")
+  void shouldRegisterInterest_whenKoreanNameIsShortEvenIfSimilar() {
+    // given
+    InterestRegisterRequest request = new InterestRegisterRequest(
+        "주석",
+        List.of("키워드")
+    );
+
+    Interest existingInterest = Interest.create("주식");
+    Interest savedInterest = Interest.create("주석");
+
+    InterestDto response = new InterestDto(
+        UUID.randomUUID(),
+        "주석",
+        List.of("키워드"),
+        0,
+        false
+    );
+
+    given(interestRepository.existsByName("주석")).willReturn(false);
+    given(interestRepository.findAll()).willReturn(List.of(existingInterest));
+    given(interestRepository.saveAndFlush(any(Interest.class))).willReturn(savedInterest);
+    given(interestMapper.toDto(savedInterest, false)).willReturn(response);
+
+    // when
+    InterestDto result = interestService.createInterest(request);
+
+    // then
+    assertThat(result.name()).isEqualTo("주석");
+
+    then(interestRepository).should().saveAndFlush(any(Interest.class));
+  }
+
+  @Test
+  @DisplayName("기존 관심사 이름과 포함 관계이면 유사도 검사 대상에서 제외되어 등록할 수 있다")
+  void shouldRegisterInterest_whenNameContainsExistingName() {
+    // given
+    InterestRegisterRequest request = new InterestRegisterRequest(
+        "삼성전자",
+        List.of("키워드")
+    );
+
+    Interest existingInterest = Interest.create("삼성");
+    Interest savedInterest = Interest.create("삼성전자");
+
+    InterestDto response = new InterestDto(
+        UUID.randomUUID(),
+        "삼성전자",
+        List.of("키워드"),
+        0,
+        false
+    );
+
+    given(interestRepository.existsByName("삼성전자")).willReturn(false);
+    given(interestRepository.findAll()).willReturn(List.of(existingInterest));
+    given(interestRepository.saveAndFlush(any(Interest.class))).willReturn(savedInterest);
+    given(interestMapper.toDto(savedInterest, false)).willReturn(response);
+
+    // when
+    InterestDto result = interestService.createInterest(request);
+
+    // then
+    assertThat(result.name()).isEqualTo("삼성전자");
+
+    then(interestRepository).should().saveAndFlush(any(Interest.class));
+  }
+
+  @Test
+  @DisplayName("요청 관심사 이름이 기존 관심사 이름을 포함해도 등록할 수 있다")
+  void shouldRegisterInterest_whenRequestNameContainsExistingName() {
+    // given
+    InterestRegisterRequest request = new InterestRegisterRequest(
+        "해외주식",
+        List.of("키워드")
+    );
+
+    Interest existingInterest = Interest.create("주식");
+    Interest savedInterest = Interest.create("해외주식");
+
+    InterestDto response = new InterestDto(
+        UUID.randomUUID(),
+        "해외주식",
+        List.of("키워드"),
+        0,
+        false
+    );
+
+    given(interestRepository.existsByName("해외주식")).willReturn(false);
+    given(interestRepository.findAll()).willReturn(List.of(existingInterest));
+    given(interestRepository.saveAndFlush(any(Interest.class))).willReturn(savedInterest);
+    given(interestMapper.toDto(savedInterest, false)).willReturn(response);
+
+    // when
+    InterestDto result = interestService.createInterest(request);
+
+    // then
+    assertThat(result.name()).isEqualTo("해외주식");
+
+    then(interestRepository).should().saveAndFlush(any(Interest.class));
+  }
+
+  @Test
+  @DisplayName("기존 관심사 이름이 요청 관심사 이름을 포함해도 등록할 수 있다")
+  void shouldRegisterInterest_whenExistingNameContainsRequestName() {
+    // given
+    InterestRegisterRequest request = new InterestRegisterRequest(
+        "주식",
+        List.of("키워드")
+    );
+
+    Interest existingInterest = Interest.create("해외주식");
+    Interest savedInterest = Interest.create("주식");
+
+    InterestDto response = new InterestDto(
+        UUID.randomUUID(),
+        "주식",
+        List.of("키워드"),
+        0,
+        false
+    );
+
+    given(interestRepository.existsByName("주식")).willReturn(false);
+    given(interestRepository.findAll()).willReturn(List.of(existingInterest));
+    given(interestRepository.saveAndFlush(any(Interest.class))).willReturn(savedInterest);
+    given(interestMapper.toDto(savedInterest, false)).willReturn(response);
+
+    // when
+    InterestDto result = interestService.createInterest(request);
+
+    // then
+    assertThat(result.name()).isEqualTo("주식");
+
+    then(interestRepository).should().saveAndFlush(any(Interest.class));
+  }
+
+  @Test
   @DisplayName("관심사 키워드를 수정할 수 있다")
   void shouldUpdateInterestKeyword_whenUpdateRequest() {
     // given


### PR DESCRIPTION
refactor: #220 

## 관련 이슈
- closes #220 

## 작업 내용
- refactor: 관심사 이름 유사도 검증 로직 개선
  - 한글 관심사 이름 유사도 계산 방식 개선
    - 기존: 문자열(char) 단위 레벤슈타인 거리 기반 계산
    - 문제: 한글은 음절 단위로 비교되어 유사도 정확도가 낮음 (ex. 주식 vs 주석 통과)
    - 개선: 한글을 초성/중성/종성으로 분해 후 자모 단위로 유사도 계산하도록 수정
  - 유사도 검증 정책 보완
    - 완전 동일 이름은 기존과 동일하게 차단
    - 관심사 이름 길이가 짧은 경우(4글자 미만) 유사도 검사 제외
      - 의도: 주식 / 주석 같은 정상 단어 과차단 방지
    - 포함 관계는 중복으로 간주하지 않도록 처리
      - 예: 삼성 ≠ 삼성전자, 주식 ≠ 해외주식

- test: 관심사 이름 유사도 관련 테스트 코드 추가
  - 한글 유사도 케이스 검증 (자모 분해 기반)
  - 짧은 단어 예외 케이스 검증
  - 포함 관계 허용 케이스 검증

## 변경 사항
- 주요 변경 사항을 작성해주세요.

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 관심사 이름 중복/유사 검사 로직 개선 — 한글 분해 기반 유사도 처리 적용, 짧은 이름과 포함 관계는 예외 처리하여 오탐 감소

* **테스트**
  * 관심사 등록 관련 단위·통합 테스트 확대 — 중복/유사 시나리오 및 포함관계·짧은 이름 케이스 검증 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->