### PR TITLE
feat: 뉴스기사 단건 조회 구현

### DIFF
--- a/src/main/java/com/team3/monew/controller/ArticleController.java
+++ b/src/main/java/com/team3/monew/controller/ArticleController.java
@@ -34,6 +34,14 @@ public class ArticleController implements ArticleApi {
         .body(articleService.getArticleList(searchRequest, requestUserId));
   }
 
+  @GetMapping("/{articleId}")
+  public ResponseEntity<ArticleDto> getArticle(
+      @RequestHeader(REQUEST_USER_ID_HEADER) UUID requestUserId,
+      @PathVariable UUID articleId
+  ) {
+    return ResponseEntity.ok(articleService.getArticle(requestUserId, articleId));
+  }
+
   @DeleteMapping("/{articleId}")
   public ResponseEntity<Void> deleteArticle(@PathVariable UUID articleId) {
     articleService.deleteArticle(articleId);

--- a/src/main/java/com/team3/monew/controller/api/ArticleApi.java
+++ b/src/main/java/com/team3/monew/controller/api/ArticleApi.java
@@ -35,6 +35,19 @@ public interface ArticleApi {
       @RequestHeader(REQUEST_USER_ID_HEADER) UUID requestUserId
   );
 
+  @Operation(summary = "뉴스 기사 단건 조회", description = "조건에 맞는 뉴스 기사를 단건 조회합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(responseCode = "404", description = "해당 ID에 맞는 뉴스기사가 존재하지 않음",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  ResponseEntity<ArticleDto> getArticle(
+      @RequestHeader(REQUEST_USER_ID_HEADER) UUID requestUserId,
+      @PathVariable UUID articleId
+  );
+
   @Operation(summary = "뉴스 기사 논리 삭제", description = "뉴스 기사를 논리적으로 삭제합니다.")
   @ApiResponses({
       @ApiResponse(responseCode = "204", description = "논리 삭제 성공"),

--- a/src/main/java/com/team3/monew/controller/api/ArticleApi.java
+++ b/src/main/java/com/team3/monew/controller/api/ArticleApi.java
@@ -38,7 +38,7 @@ public interface ArticleApi {
   @Operation(summary = "뉴스 기사 단건 조회", description = "조건에 맞는 뉴스 기사를 단건 조회합니다.")
   @ApiResponses({
       @ApiResponse(responseCode = "200", description = "조회 성공"),
-      @ApiResponse(responseCode = "400", description = "잘못된 요청 (헤더 누락, articleId 형식 오류 등)",
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 (헤더 누락, articleId 형식 오류, 삭제된 기사 조회 등)",
           content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
       @ApiResponse(responseCode = "404", description = "해당 ID에 맞는 뉴스기사가 존재하지 않음",
           content = @Content(schema = @Schema(implementation = ErrorResponse.class))),

--- a/src/main/java/com/team3/monew/controller/api/ArticleApi.java
+++ b/src/main/java/com/team3/monew/controller/api/ArticleApi.java
@@ -38,6 +38,8 @@ public interface ArticleApi {
   @Operation(summary = "뉴스 기사 단건 조회", description = "조건에 맞는 뉴스 기사를 단건 조회합니다.")
   @ApiResponses({
       @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 (헤더 누락, articleId 형식 오류 등)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
       @ApiResponse(responseCode = "404", description = "해당 ID에 맞는 뉴스기사가 존재하지 않음",
           content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
       @ApiResponse(responseCode = "500", description = "서버 내부 오류",

--- a/src/main/java/com/team3/monew/repository/NewsSourceRepository.java
+++ b/src/main/java/com/team3/monew/repository/NewsSourceRepository.java
@@ -1,9 +1,11 @@
 package com.team3.monew.repository;
 
 import com.team3.monew.entity.NewsSource;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NewsSourceRepository extends JpaRepository<NewsSource, UUID> {
 
+  Optional<NewsSource> findByName(String name);
 }

--- a/src/main/java/com/team3/monew/service/ArticleService.java
+++ b/src/main/java/com/team3/monew/service/ArticleService.java
@@ -2,6 +2,7 @@ package com.team3.monew.service;
 
 import com.team3.monew.dto.article.ArticleDto;
 import com.team3.monew.dto.article.ArticleSearchRequest;
+import com.team3.monew.dto.article.ArticleViewDto;
 import com.team3.monew.dto.article.internal.ArticleCursor;
 import com.team3.monew.dto.article.internal.ArticleSearchCondition;
 import com.team3.monew.dto.pagination.CursorPageResponseDto;
@@ -35,6 +36,7 @@ public class ArticleService {
   private final ArticleMapper articleMapper;
   private final NewsArticleRepository newsArticleRepository;
   private final ArticleViewRepository articleViewRepository;
+  private final ArticleViewService articleViewService;
 
   private static final String CURSOR_DELIMITER = ", ";
   private final ArticleInterestRepository articleInterestRepository;
@@ -90,6 +92,16 @@ public class ArticleService {
         nextAfter, articleDtoList.size(), totalElements, hasNext);
   }
 
+  public ArticleDto getArticle(UUID userId, UUID articleId) {
+    log.debug("뉴스 단건 조회 요청 - articleId={}", articleId);
+    NewsArticle article = findArticleOrElseThrow(articleId);
+    // 단건 조회에도 조회수 등록을 위함
+    articleViewService.registerArticleView(article.getId(), userId);
+
+    log.debug("뉴스 단건 조회 성공 - articleId={}", article.getId());
+    return articleMapper.toDto(article, true);
+  }
+
   @Transactional
   public void deleteArticle(UUID articleId) {
     log.debug("뉴스기사 논리삭제 요청 - articleId={}", articleId);
@@ -142,6 +154,11 @@ public class ArticleService {
     } catch (DateTimeParseException | NumberFormatException e) {
       throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, Map.of("cursor", e.getMessage()));
     }
+  }
+
+  private NewsArticle findArticleOrElseThrow(UUID articleId) {
+    return newsArticleRepository.findById(articleId)
+        .orElseThrow(() -> new ArticleNotFoundException(articleId));
   }
 
   private NewsArticle getArticleOrThrow(UUID articleId) {

--- a/src/main/java/com/team3/monew/service/ArticleService.java
+++ b/src/main/java/com/team3/monew/service/ArticleService.java
@@ -92,6 +92,8 @@ public class ArticleService {
         nextAfter, articleDtoList.size(), totalElements, hasNext);
   }
 
+  // 조회수 등록 때문에 readOnly=true 불가능으로 어노테이션 추가함
+  @Transactional
   public ArticleDto getArticle(UUID userId, UUID articleId) {
     log.debug("뉴스 단건 조회 요청 - articleId={}", articleId);
     NewsArticle article = findArticleOrElseThrow(articleId);

--- a/src/main/java/com/team3/monew/service/ArticleService.java
+++ b/src/main/java/com/team3/monew/service/ArticleService.java
@@ -8,6 +8,7 @@ import com.team3.monew.dto.article.internal.ArticleSearchCondition;
 import com.team3.monew.dto.pagination.CursorPageResponseDto;
 import com.team3.monew.entity.NewsArticle;
 import com.team3.monew.exception.article.ArticleNotFoundException;
+import com.team3.monew.exception.article.DeletedArticleException;
 import com.team3.monew.global.enums.ErrorCode;
 import com.team3.monew.global.exception.BusinessException;
 import com.team3.monew.mapper.ArticleMapper;
@@ -96,7 +97,7 @@ public class ArticleService {
   @Transactional
   public ArticleDto getArticle(UUID userId, UUID articleId) {
     log.debug("뉴스 단건 조회 요청 - articleId={}", articleId);
-    NewsArticle article = findArticleOrElseThrow(articleId);
+    NewsArticle article = findActiveArticleOrElseThrow(articleId);
     // 단건 조회에도 조회수 등록을 위함
     articleViewService.registerArticleView(article.getId(), userId);
 
@@ -158,9 +159,16 @@ public class ArticleService {
     }
   }
 
-  private NewsArticle findArticleOrElseThrow(UUID articleId) {
-    return newsArticleRepository.findById(articleId)
+  private NewsArticle findActiveArticleOrElseThrow(UUID articleId) {
+    NewsArticle article = newsArticleRepository.findById(articleId)
         .orElseThrow(() -> new ArticleNotFoundException(articleId));
+
+    // 논리삭제 여부 판단
+    if (article.isDeleted()) {
+      throw new DeletedArticleException(articleId);
+    }
+
+    return article;
   }
 
   private NewsArticle getArticleOrThrow(UUID articleId) {

--- a/src/main/java/com/team3/monew/service/ArticleService.java
+++ b/src/main/java/com/team3/monew/service/ArticleService.java
@@ -101,8 +101,11 @@ public class ArticleService {
     // 단건 조회에도 조회수 등록을 위함
     articleViewService.registerArticleView(article.getId(), userId);
 
-    log.debug("뉴스 단건 조회 성공 - articleId={}", article.getId());
-    return articleMapper.toDto(article, true);
+    // registerArticleView()에서 벌크 업데이트 수행으로 기존 엔티티의 viewCount가 갱신되지 않아 재조회
+    NewsArticle updatedArticle = findActiveArticleOrElseThrow(articleId);
+
+    log.debug("뉴스 단건 조회 성공 - articleId={}", updatedArticle.getId());
+    return articleMapper.toDto(updatedArticle, true);
   }
 
   @Transactional

--- a/src/test/java/com/team3/monew/controller/ArticleControllerTest.java
+++ b/src/test/java/com/team3/monew/controller/ArticleControllerTest.java
@@ -116,6 +116,45 @@ class ArticleControllerTest {
     }
   }
 
+  @Nested
+  class GetArticle {
+
+    @Test
+    @DisplayName("유효한 기사ID와 요청자ID를 받으면 뉴스기사 단건을 반환한다")
+    void shouldGetArticle_whenArticleIdAndRequestUserIdAreValid() throws Exception {
+      // given
+      UUID articleId = articleDto.id();
+      UUID requestUserId = UUID.randomUUID();
+
+      given(articleService.getArticle(requestUserId, articleId)).willReturn(articleDto);
+
+      // when & then
+      mockMvc.perform(get(ARTICLES_BASE_URL + "/{articleId}", articleId)
+              .header(REQUEST_USER_ID_HEADER, requestUserId))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.id").value(articleId.toString()))
+          .andExpect(jsonPath("$.source").value(NewsSourceType.NAVER.name()))
+          .andExpect(jsonPath("$.sourceUrl").value(articleDto.sourceUrl()))
+          .andExpect(jsonPath("$.title").value(articleDto.title()))
+          .andExpect(jsonPath("$.summary").value(articleDto.summary()))
+          .andExpect(jsonPath("$.commentCount").value(articleDto.commentCount()))
+          .andExpect(jsonPath("$.viewCount").value(articleDto.viewCount()))
+          .andExpect(jsonPath("$.viewedByMe").value(articleDto.viewedByMe()));
+    }
+
+    @Test
+    @DisplayName("뉴스기사 단건 조회 시 헤더에 요청자ID가 없으면 오류를 반환한다")
+    void shouldReturnError_whenRequestUserIdHeaderIsMissingInGetArticle() throws Exception {
+      // given
+      UUID articleId = UUID.randomUUID();
+
+      // when & then
+      mockMvc.perform(get(ARTICLES_BASE_URL + "/{articleId}", articleId))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.details.header").value("Monew-Request-User-ID"));
+    }
+  }
+
 
   @Nested
   @DisplayName("뉴스기사 논리삭제")

--- a/src/test/java/com/team3/monew/controller/ArticleControllerTest.java
+++ b/src/test/java/com/team3/monew/controller/ArticleControllerTest.java
@@ -153,6 +153,21 @@ class ArticleControllerTest {
           .andExpect(status().isBadRequest())
           .andExpect(jsonPath("$.details.header").value("Monew-Request-User-ID"));
     }
+
+    @Test
+    @DisplayName("존재하지 않는 기사 ID로 조회하면 404를 반환한다")
+    void shouldThrowException_whenArticleDoesNotExists() throws Exception {
+      // given
+      UUID articleId = UUID.randomUUID();
+      UUID userId = UUID.randomUUID();
+      given(articleService.getArticle(userId, articleId))
+          .willThrow(new ArticleNotFoundException(articleId));
+
+      // when & then
+      mockMvc.perform(get(ARTICLES_BASE_URL + "/{articleId}", articleId)
+              .header(REQUEST_USER_ID_HEADER, userId))
+          .andExpect(status().isNotFound());
+    }
   }
 
 

--- a/src/test/java/com/team3/monew/integration/ArticleServiceIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/ArticleServiceIntegrationTest.java
@@ -147,20 +147,10 @@ public class ArticleServiceIntegrationTest extends IntegrationTestSupport {
   void shouldNotIncreaseViewCount_whenSameUserViewsTwice() throws Exception {
     // given
     User user = userRepository.saveAndFlush(
-        User.create("test@example.com", "tester", "test1234!")
+        User.create("view-test@example.com", "tester", "test1234!")
     );
     UUID userId = user.getId();
-
-    NewsSource source = newsSourceRepository.findAll().stream()
-        .filter(s -> s.getName().equals("NAVER"))
-        .findFirst()
-        .orElseThrow();
-
-    NewsArticle article = newsArticleRepository.saveAndFlush(
-        NewsArticle.create(source, "link", "제목", Instant.now(), "요약")
-    );
-
-    UUID articleId = article.getId();
+    UUID articleId = newsArticle.getId();
 
     // when
     mockMvc.perform(get("/api/articles/{articleId}", articleId)
@@ -181,23 +171,13 @@ public class ArticleServiceIntegrationTest extends IntegrationTestSupport {
   void shouldReturn400_whenArticleIsDeleted() throws Exception {
     // given
     User user = userRepository.saveAndFlush(
-        User.create("test@example.com", "tester", "test1234!")
+        User.create("deleted-article-test@example.com", "tester", "test1234!")
     );
     UUID userId = user.getId();
+    UUID articleId = newsArticle.getId();
 
-    NewsSource source = newsSourceRepository.findByName("NAVER")
-        .orElseThrow();
-
-    NewsArticle article = newsArticleRepository.saveAndFlush(
-        NewsArticle.create(source, "link-delete", "삭제된 기사",
-            Instant.now(), "요약")
-    );
-
-    UUID articleId = article.getId();
-
-    // ⭐ soft delete 상태로 변경
-    ReflectionTestUtils.setField(article, "deleteStatus", DeleteStatus.DELETED);
-    newsArticleRepository.saveAndFlush(article);
+    ReflectionTestUtils.setField(newsArticle, "deleteStatus", DeleteStatus.DELETED);
+    newsArticleRepository.saveAndFlush(newsArticle);
 
     // when & then
     mockMvc.perform(get("/api/articles/{articleId}", articleId)

--- a/src/test/java/com/team3/monew/integration/ArticleServiceIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/ArticleServiceIntegrationTest.java
@@ -49,6 +49,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -128,7 +129,7 @@ public class ArticleServiceIntegrationTest extends IntegrationTestSupport {
   @DisplayName("뉴스기사 목록 조회 통합 테스트에 성공합니다")
   void shouldReturnArticlePage_whenAPICalls() throws Exception {
     // when & then
-    mockMvc.perform(get(ARTICLES_BASE_URL)
+    mockMvc.perform(get("/api/articles")
             .header(REQUEST_USER_ID_HEADER, UUID.randomUUID())
             .param("keyword", "삼성 메모리")
             .param("sourceIn", NewsSourceType.NAVER.name())
@@ -173,6 +174,35 @@ public class ArticleServiceIntegrationTest extends IntegrationTestSupport {
     // then
     NewsArticle updated = newsArticleRepository.findById(articleId).orElseThrow();
     assertThat(updated.getViewCount()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("삭제된 기사 조회 시 400 오류가 발생한다")
+  void shouldReturn400_whenArticleIsDeleted() throws Exception {
+    // given
+    User user = userRepository.saveAndFlush(
+        User.create("test@example.com", "tester", "test1234!")
+    );
+    UUID userId = user.getId();
+
+    NewsSource source = newsSourceRepository.findByName("NAVER")
+        .orElseThrow();
+
+    NewsArticle article = newsArticleRepository.saveAndFlush(
+        NewsArticle.create(source, "link-delete", "삭제된 기사",
+            Instant.now(), "요약")
+    );
+
+    UUID articleId = article.getId();
+
+    // ⭐ soft delete 상태로 변경
+    ReflectionTestUtils.setField(article, "deleteStatus", DeleteStatus.DELETED);
+    newsArticleRepository.saveAndFlush(article);
+
+    // when & then
+    mockMvc.perform(get("/api/articles/{articleId}", articleId)
+            .header(REQUEST_USER_ID_HEADER, userId))
+        .andExpect(status().isBadRequest());
   }
 
   @Test

--- a/src/test/java/com/team3/monew/integration/ArticleServiceIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/ArticleServiceIntegrationTest.java
@@ -142,8 +142,8 @@ public class ArticleServiceIntegrationTest extends IntegrationTestSupport {
   }
 
   @Test
-  @DisplayName("뉴스기사 단건 조회 시 첫 조회에만 조회수가 증가한다")
-  void shouldIncreaseViewCountOnlyOnce_whenFirstView() throws Exception {
+  @DisplayName("뉴스기사 단건 조회 시 동일 사용자 재조회에서는 조회수가 증가하지 않는다")
+  void shouldNotIncreaseViewCount_whenSameUserViewsTwice() throws Exception {
     // given
     User user = userRepository.saveAndFlush(
         User.create("test@example.com", "tester", "test1234!")
@@ -162,6 +162,10 @@ public class ArticleServiceIntegrationTest extends IntegrationTestSupport {
     UUID articleId = article.getId();
 
     // when
+    mockMvc.perform(get("/api/articles/{articleId}", articleId)
+            .header(REQUEST_USER_ID_HEADER, userId))
+        .andExpect(status().isOk());
+
     mockMvc.perform(get("/api/articles/{articleId}", articleId)
             .header(REQUEST_USER_ID_HEADER, userId))
         .andExpect(status().isOk());

--- a/src/test/java/com/team3/monew/integration/ArticleServiceIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/ArticleServiceIntegrationTest.java
@@ -8,6 +8,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.team3.monew.dto.article.internal.enums.ArticleDirection;
 import com.team3.monew.dto.article.internal.enums.ArticleOrderBy;
+import com.team3.monew.entity.NewsArticle;
+import com.team3.monew.entity.NewsSource;
+import com.team3.monew.entity.User;
 import com.team3.monew.entity.ArticleInterest;
 import com.team3.monew.entity.ArticleView;
 import com.team3.monew.entity.Comment;
@@ -18,6 +21,11 @@ import com.team3.monew.entity.NewsSource;
 import com.team3.monew.entity.User;
 import com.team3.monew.entity.enums.DeleteStatus;
 import com.team3.monew.entity.enums.NewsSourceType;
+import com.team3.monew.repository.ArticleViewRepository;
+import com.team3.monew.repository.NewsArticleRepository;
+import com.team3.monew.repository.NewsSourceRepository;
+import com.team3.monew.repository.UserRepository;
+import com.team3.monew.service.ArticleService;
 import com.team3.monew.repository.ArticleInterestRepository;
 import com.team3.monew.repository.ArticleViewRepository;
 import com.team3.monew.repository.CommentLikeRepository;
@@ -27,6 +35,7 @@ import com.team3.monew.repository.NewsArticleRepository;
 import com.team3.monew.repository.NewsSourceRepository;
 import com.team3.monew.repository.UserRepository;
 import com.team3.monew.support.IntegrationTestSupport;
+import java.time.Instant;
 import jakarta.persistence.EntityManager;
 import java.time.Instant;
 import java.util.List;
@@ -95,7 +104,6 @@ public class ArticleServiceIntegrationTest extends IntegrationTestSupport {
     newsArticle.addArticleInterest(samsungInterest, "메모리");
     newsArticle.addArticleInterest(appleInterest, "아이폰");
     newsArticleRepository.save(newsArticle);
-
     User user1 = User.create("email@naver.com", "닉닉", "@qwer!!");
     User user2 = User.create("user2@gmail.com", "ha", "orange@1234");
     userRepository.saveAll(List.of(user1, user2));
@@ -131,6 +139,36 @@ public class ArticleServiceIntegrationTest extends IntegrationTestSupport {
         .andExpect(jsonPath("$.size").value(0))
         .andExpect(jsonPath("$.totalElements").value(0))
         .andExpect(jsonPath("$.hasNext").value(false));
+  }
+
+  @Test
+  @DisplayName("뉴스기사 단건 조회 시 첫 조회에만 조회수가 증가한다")
+  void shouldIncreaseViewCountOnlyOnce_whenFirstView() throws Exception {
+    // given
+    User user = userRepository.saveAndFlush(
+        User.create("test@example.com", "tester", "test1234!")
+    );
+    UUID userId = user.getId();
+
+    NewsSource source = newsSourceRepository.findAll().stream()
+        .filter(s -> s.getName().equals("NAVER"))
+        .findFirst()
+        .orElseThrow();
+
+    NewsArticle article = newsArticleRepository.saveAndFlush(
+        NewsArticle.create(source, "link", "제목", Instant.now(), "요약")
+    );
+
+    UUID articleId = article.getId();
+
+    // when
+    mockMvc.perform(get("/api/articles/{articleId}", articleId)
+            .header(REQUEST_USER_ID_HEADER, userId))
+        .andExpect(status().isOk());
+
+    // then
+    NewsArticle updated = newsArticleRepository.findById(articleId).orElseThrow();
+    assertThat(updated.getViewCount()).isEqualTo(1);
   }
 
   @Test

--- a/src/test/java/com/team3/monew/service/ArticleServiceTest.java
+++ b/src/test/java/com/team3/monew/service/ArticleServiceTest.java
@@ -355,6 +355,7 @@ class ArticleServiceTest {
       assertThat(actual)
           .usingRecursiveComparison()
           .isEqualTo(expected);
+      then(articleViewService).should().registerArticleView(articleId, userId);
     }
 
     @Test

--- a/src/test/java/com/team3/monew/service/ArticleServiceTest.java
+++ b/src/test/java/com/team3/monew/service/ArticleServiceTest.java
@@ -20,6 +20,7 @@ import com.team3.monew.entity.NewsSource;
 import com.team3.monew.entity.enums.DeleteStatus;
 import com.team3.monew.entity.enums.NewsSourceType;
 import com.team3.monew.exception.article.ArticleNotFoundException;
+import com.team3.monew.exception.article.DeletedArticleException;
 import com.team3.monew.global.exception.BusinessException;
 import com.team3.monew.mapper.ArticleMapper;
 import com.team3.monew.repository.ArticleInterestRepository;
@@ -371,6 +372,30 @@ class ArticleServiceTest {
       // when & then
       assertThrows(ArticleNotFoundException.class,
           () -> articleService.getArticle(userId, articleId));
+    }
+
+    @Test
+    @DisplayName("삭제된 기사 조회 시 예외가 발생한다")
+    void shouldThrowException_whenArticleIsDeleted() {
+      // given
+      UUID userId = UUID.randomUUID();
+      UUID articleId = UUID.randomUUID();
+
+      NewsArticle article = NewsArticle.create(naverSource, "link", "제목",
+          Instant.now(), "요약");
+      ReflectionTestUtils.setField(article, "id", articleId);
+
+      // SoftDeleteEntity의 삭제 상태를 테스트용으로 직접 세팅
+      ReflectionTestUtils.setField(article, "deleteStatus", DeleteStatus.DELETED);
+
+      given(newsArticleRepository.findById(articleId))
+          .willReturn(Optional.of(article));
+
+      // when & then
+      assertThrows(DeletedArticleException.class,
+          () -> articleService.getArticle(userId, articleId));
+
+      then(articleViewService).shouldHaveNoInteractions();
     }
   }
 

--- a/src/test/java/com/team3/monew/service/ArticleServiceTest.java
+++ b/src/test/java/com/team3/monew/service/ArticleServiceTest.java
@@ -62,6 +62,8 @@ class ArticleServiceTest {
   private ArticleInterestRepository articleInterestRepository;
   @Mock
   private CommentRepository commentRepository;
+  @Mock
+  private ArticleViewService articleViewService;
 
   @InjectMocks
   private ArticleService articleService;
@@ -322,6 +324,52 @@ class ArticleServiceTest {
       // when & then
       assertThrows(BusinessException.class,
           () -> articleService.getArticleList(request2, UUID.randomUUID()));
+    }
+  }
+
+  @Nested
+  @DisplayName("뉴스기사 단건 조회를 한다")
+  class GetArticle {
+
+    @Test
+    @DisplayName("정상적으로 단건 조회 시 조회 이력이 등록되고 기사 정보를 반환한다")
+    void shouldReturnArticle_whenValidRequest() {
+      // given
+      UUID userId = UUID.randomUUID();
+      UUID articleId = UUID.randomUUID();
+
+      NewsArticle article = NewsArticle.create(naverSource, "link", "제목",
+          Instant.now(), "요약");
+      ReflectionTestUtils.setField(article, "id", articleId);
+
+      given(newsArticleRepository.findById(articleId)).willReturn(java.util.Optional.of(article));
+      given(articleViewService.registerArticleView(articleId, userId))
+          .willReturn(null); // void로 바꾸면 이 줄 제거 가능
+
+      ArticleDto expected = articleMapper.toDto(article, true);
+
+      // when
+      ArticleDto actual = articleService.getArticle(userId, articleId);
+
+      // then
+      assertThat(actual)
+          .usingRecursiveComparison()
+          .isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 기사 조회 시 예외가 발생한다")
+    void shouldThrowException_whenArticleNotFound() {
+      // given
+      UUID userId = UUID.randomUUID();
+      UUID articleId = UUID.randomUUID();
+
+      given(newsArticleRepository.findById(articleId))
+          .willReturn(java.util.Optional.empty());
+
+      // when & then
+      assertThrows(ArticleNotFoundException.class,
+          () -> articleService.getArticle(userId, articleId));
     }
   }
 


### PR DESCRIPTION
## 관련 이슈
- closes #234 

## 작업 내용
- feat: 뉴스기사 단건 조회 기능 구현
  - ArticleController에 뉴스기사 단건 조회 API 추가
    - `GET /api/articles/{articleId}`
    - 요청 헤더(`Monew-Request-User-ID`)를 통해 사용자 식별
  - ArticleService에 단건 조회 메서드(getArticle) 구현
    - 기사 존재 여부 및 삭제 상태 검증
    - 조회 결과를 ArticleDto로 변환하여 반환

- feat: 기사 조회 이력 및 조회수 증가 로직 구현
  - ArticleViewService를 통해 조회 이력 관리 책임 분리
    - 동일 사용자의 재조회 시 기존 이력 갱신
    - 최초 조회 시 ArticleView 생성
  - 최초 조회 시에만 조회수 증가하도록 처리
    - DB update 쿼리를 통한 viewCount 증가
    - 중복 조회에 대한 조회수 증가 방지
  - DataIntegrityViolationException을 활용한 동시성 처리
    - 동시에 최초 조회 발생 시에도 조회수 중복 증가 방지

- refactor: 서비스 책임 분리 및 구조 개선
  - ArticleService → ArticleViewService로 조회 이력 관련 로직 위임
  - 단건 조회 흐름에서 읽기/쓰기 책임 명확히 분리
  - readOnly 트랜잭션 문제 해결을 위해 getArticle 메서드에 트랜잭션 설정 추가

- test: 뉴스기사 단건 조회 관련 테스트 코드 작성
  - 컨트롤러 슬라이스 테스트
    - 정상 요청 시 단건 조회 응답 검증
    - 요청자 ID 헤더 누락 시 예외 처리 검증
  - 통합 테스트
    - 단건 조회 시 조회수 증가 검증
    - 동일 사용자 재조회 시 조회수 증가 방지 검증
    - ArticleView 생성 여부 검증

## 변경 사항
- 주요 변경 사항을 작성해주세요.

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 단일 기사 조회 API 추가 — 기사 ID로 기사 내용 조회 가능
  * 조회 시 사용자별 조회 기록 등록 및 중복 조회수 누적 방지

* **버그 수정 / 동작 개선**
  * 삭제된 기사에 대한 적절한 오류 응답 처리 강화

* **테스트**
  * 컨트롤러·서비스 단위 테스트 및 통합 테스트 추가 — 조회 응답과 조회수 동작 검증
<!-- end of auto-generated comment: release notes by coderabbit.ai -->