### PR TITLE
feat: 뉴스기사 삭제

### DIFF
--- a/src/main/java/com/team3/monew/controller/ArticleController.java
+++ b/src/main/java/com/team3/monew/controller/ArticleController.java
@@ -8,10 +8,13 @@ import com.team3.monew.service.ArticleService;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.experimental.Delegate;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -30,5 +33,17 @@ public class ArticleController implements ArticleApi {
   ) {
     return ResponseEntity.status(HttpStatus.OK)
         .body(articleService.getArticleList(searchRequest, requestUserId));
+  }
+
+  @DeleteMapping("/{articleId}")
+  public ResponseEntity<Void> deleteArticle(@PathVariable UUID articleId) {
+    articleService.deleteArticle(articleId);
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
+
+  @DeleteMapping("/{articleId}/hard")
+  public ResponseEntity<Void> hardDeleteArticle(@PathVariable UUID articleId) {
+    articleService.hardDeleteArticle(articleId);
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 }

--- a/src/main/java/com/team3/monew/controller/ArticleController.java
+++ b/src/main/java/com/team3/monew/controller/ArticleController.java
@@ -8,7 +8,6 @@ import com.team3.monew.service.ArticleService;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import lombok.experimental.Delegate;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/team3/monew/controller/api/ArticleApi.java
+++ b/src/main/java/com/team3/monew/controller/api/ArticleApi.java
@@ -14,6 +14,7 @@ import jakarta.validation.Valid;
 import java.util.UUID;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 
 @Tag(name = "뉴스 기사 관리", description = "뉴스 기사 관련 API")
@@ -34,4 +35,23 @@ public interface ArticleApi {
       @RequestHeader(REQUEST_USER_ID_HEADER) UUID requestUserId
   );
 
+  @Operation(summary = "뉴스 기사 논리 삭제", description = "뉴스 기사를 논리적으로 삭제합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "204", description = "논리 삭제 성공"),
+      @ApiResponse(responseCode = "404", description = "뉴스 기사 정보 없음",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "500", description ="서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  ResponseEntity<Void> deleteArticle(@PathVariable UUID articleId);
+
+  @Operation(summary = "뉴스 기사 물리 삭제", description = "뉴스 기사를 물리적으로 삭제합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "204", description = "삭제 성공"),
+      @ApiResponse(responseCode = "404", description = "뉴스 기사 정보 없음",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "500", description ="서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  ResponseEntity<Void> hardDeleteArticle(@PathVariable UUID articleId);
 }

--- a/src/main/java/com/team3/monew/entity/CommentLike.java
+++ b/src/main/java/com/team3/monew/entity/CommentLike.java
@@ -1,45 +1,56 @@
 package com.team3.monew.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.Instant;
-import java.util.UUID;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Table(
-        name = "comment_likes",
-        uniqueConstraints = {
-                @UniqueConstraint(name = "uk_comment_likes_comment_id_user_id", columnNames = {"comment_id", "user_id"})
-        }
+    name = "comment_likes",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_comment_likes_comment_id_user_id", columnNames = {"comment_id",
+            "user_id"})
+    }
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CommentLike {
 
-    @Id
-    @GeneratedValue
-    private UUID id;
+  @Id
+  @GeneratedValue
+  private UUID id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "comment_id", nullable = false)
-    private Comment comment;
+  @OnDelete(action = OnDeleteAction.CASCADE)
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "comment_id", nullable = false)
+  private Comment comment;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
 
-    @Column(nullable = false)
-    private Instant createdAt;
+  @Column(nullable = false)
+  private Instant createdAt;
 
-    public static CommentLike create(Comment comment, User user) {
-        CommentLike commentLike = new CommentLike();
-        commentLike.comment = comment;
-        commentLike.user = user;
-        commentLike.createdAt = Instant.now();
+  public static CommentLike create(Comment comment, User user) {
+    CommentLike commentLike = new CommentLike();
+    commentLike.comment = comment;
+    commentLike.user = user;
+    commentLike.createdAt = Instant.now();
 
-        return commentLike;
-    }
+    return commentLike;
+  }
 }

--- a/src/main/java/com/team3/monew/repository/ArticleInterestRepository.java
+++ b/src/main/java/com/team3/monew/repository/ArticleInterestRepository.java
@@ -4,9 +4,15 @@ import com.team3.monew.entity.ArticleInterest;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ArticleInterestRepository extends JpaRepository<ArticleInterest, UUID> {
 
   List<ArticleInterest> findAllByInterestId(UUID interestId);
 
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query("DELETE FROM ArticleInterest ai WHERE ai.article.id = :articleId")
+  void deleteAllByArticleId(@Param("articleId") UUID articleId);
 }

--- a/src/main/java/com/team3/monew/repository/ArticleInterestRepository.java
+++ b/src/main/java/com/team3/monew/repository/ArticleInterestRepository.java
@@ -15,4 +15,6 @@ public interface ArticleInterestRepository extends JpaRepository<ArticleInterest
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query("DELETE FROM ArticleInterest ai WHERE ai.article.id = :articleId")
   void deleteAllByArticleId(@Param("articleId") UUID articleId);
+
+  List<ArticleInterest> findAllByArticleId(UUID articleId);
 }

--- a/src/main/java/com/team3/monew/repository/ArticleViewRepository.java
+++ b/src/main/java/com/team3/monew/repository/ArticleViewRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -17,4 +18,8 @@ public interface ArticleViewRepository extends JpaRepository<ArticleView, UUID> 
       @Param("userId") UUID userId);
 
   Optional<ArticleView> findByArticleIdAndUserId(UUID articleId, UUID userId);
+
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query("DELETE FROM ArticleView av WHERE av.article.id = :articleId")
+  void deleteAllByArticleId(@Param("articleId") UUID articleId);
 }

--- a/src/main/java/com/team3/monew/repository/ArticleViewRepository.java
+++ b/src/main/java/com/team3/monew/repository/ArticleViewRepository.java
@@ -2,6 +2,7 @@ package com.team3.monew.repository;
 
 import com.team3.monew.entity.ArticleView;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -22,4 +23,6 @@ public interface ArticleViewRepository extends JpaRepository<ArticleView, UUID> 
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query("DELETE FROM ArticleView av WHERE av.article.id = :articleId")
   void deleteAllByArticleId(@Param("articleId") UUID articleId);
+
+  List<ArticleView> findAllByArticleId(UUID articleId);
 }

--- a/src/main/java/com/team3/monew/repository/CommentRepository.java
+++ b/src/main/java/com/team3/monew/repository/CommentRepository.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -85,4 +86,8 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
       where c.id = :id
       """)
   Optional<Comment> findByIdWithArticleAndUser(@Param("id") UUID id);
+
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query("DELETE FROM Comment c WHERE c.article.id = :articleId")
+  void deleteAllByArticleId(@Param("articleId") UUID articleId);
 }

--- a/src/main/java/com/team3/monew/repository/CommentRepository.java
+++ b/src/main/java/com/team3/monew/repository/CommentRepository.java
@@ -90,4 +90,6 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query("DELETE FROM Comment c WHERE c.article.id = :articleId")
   void deleteAllByArticleId(@Param("articleId") UUID articleId);
+
+  List<Comment> findAllByArticleId(UUID articleId);
 }

--- a/src/main/java/com/team3/monew/service/ArticleService.java
+++ b/src/main/java/com/team3/monew/service/ArticleService.java
@@ -85,6 +85,14 @@ public class ArticleService {
         nextAfter, articleDtoList.size(), totalElements, hasNext);
   }
 
+  public void deleteArticle(UUID articleId) {
+
+  }
+
+  public void hardDeleteArticle(UUID articleId) {
+
+  }
+
   private ArticleCursor parseCursor(ArticleSearchRequest request) {
     String cursor = request.cursor();
     if (cursor == null || cursor.isEmpty()) {

--- a/src/main/java/com/team3/monew/service/ArticleService.java
+++ b/src/main/java/com/team3/monew/service/ArticleService.java
@@ -12,7 +12,6 @@ import com.team3.monew.global.exception.BusinessException;
 import com.team3.monew.mapper.ArticleMapper;
 import com.team3.monew.repository.ArticleInterestRepository;
 import com.team3.monew.repository.ArticleViewRepository;
-import com.team3.monew.repository.CommentLikeRepository;
 import com.team3.monew.repository.CommentRepository;
 import com.team3.monew.repository.NewsArticleRepository;
 import java.time.Instant;
@@ -39,7 +38,6 @@ public class ArticleService {
 
   private static final String CURSOR_DELIMITER = ", ";
   private final ArticleInterestRepository articleInterestRepository;
-  private final CommentLikeRepository commentLikeRepository;
   private final CommentRepository commentRepository;
 
   public CursorPageResponseDto<ArticleDto> getArticleList(

--- a/src/main/java/com/team3/monew/service/ArticleService.java
+++ b/src/main/java/com/team3/monew/service/ArticleService.java
@@ -94,7 +94,7 @@ public class ArticleService {
 
   @Transactional
   public void deleteArticle(UUID articleId) {
-    log.debug("뉴스기사 삭제 요청 - articleId={}", articleId);
+    log.debug("뉴스기사 논리삭제 요청 - articleId={}", articleId);
     NewsArticle article = getArticleOrThrow(articleId);
     if (article.isDeleted()) {
       throw new ArticleNotFoundException(articleId);
@@ -102,7 +102,7 @@ public class ArticleService {
 
     article.markDeleted();
     newsArticleRepository.save(article);
-    log.info("뉴스기사 삭제 성공 - articleId={}", articleId);
+    log.info("뉴스기사 논리삭제 성공 - articleId={}", articleId);
   }
 
   @Transactional

--- a/src/main/java/com/team3/monew/service/ArticleService.java
+++ b/src/main/java/com/team3/monew/service/ArticleService.java
@@ -10,14 +10,16 @@ import com.team3.monew.exception.article.ArticleNotFoundException;
 import com.team3.monew.global.enums.ErrorCode;
 import com.team3.monew.global.exception.BusinessException;
 import com.team3.monew.mapper.ArticleMapper;
+import com.team3.monew.repository.ArticleInterestRepository;
 import com.team3.monew.repository.ArticleViewRepository;
+import com.team3.monew.repository.CommentLikeRepository;
+import com.team3.monew.repository.CommentRepository;
 import com.team3.monew.repository.NewsArticleRepository;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +38,9 @@ public class ArticleService {
   private final ArticleViewRepository articleViewRepository;
 
   private static final String CURSOR_DELIMITER = ", ";
+  private final ArticleInterestRepository articleInterestRepository;
+  private final CommentLikeRepository commentLikeRepository;
+  private final CommentRepository commentRepository;
 
   public CursorPageResponseDto<ArticleDto> getArticleList(
       ArticleSearchRequest request, UUID requestUserId) {
@@ -103,9 +108,16 @@ public class ArticleService {
   @Transactional
   public void hardDeleteArticle(UUID articleId) {
     log.debug("뉴스기사 물리삭제 요청 - articleId={}", articleId);
-    NewsArticle article = getArticleOrThrow(articleId);
+    NewsArticle newsArticle = getArticleOrThrow(articleId);
 
-    newsArticleRepository.delete(article);
+    // 1. ArticleInterest 삭제
+    articleInterestRepository.deleteAllByArticleId(articleId);
+    // 2. ArticleViews 삭제
+    articleViewRepository.deleteAllByArticleId(articleId);
+    // 3. Comments 삭제
+    commentRepository.deleteAllByArticleId(articleId);
+
+    newsArticleRepository.delete(newsArticle);
     log.info("뉴스기사 물리삭제 성공 - articleId={}", articleId);
   }
 

--- a/src/main/java/com/team3/monew/service/ArticleService.java
+++ b/src/main/java/com/team3/monew/service/ArticleService.java
@@ -6,6 +6,7 @@ import com.team3.monew.dto.article.internal.ArticleCursor;
 import com.team3.monew.dto.article.internal.ArticleSearchCondition;
 import com.team3.monew.dto.pagination.CursorPageResponseDto;
 import com.team3.monew.entity.NewsArticle;
+import com.team3.monew.exception.article.ArticleNotFoundException;
 import com.team3.monew.global.enums.ErrorCode;
 import com.team3.monew.global.exception.BusinessException;
 import com.team3.monew.mapper.ArticleMapper;
@@ -16,6 +17,7 @@ import java.time.format.DateTimeParseException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -85,12 +87,26 @@ public class ArticleService {
         nextAfter, articleDtoList.size(), totalElements, hasNext);
   }
 
+  @Transactional
   public void deleteArticle(UUID articleId) {
+    log.debug("뉴스기사 삭제 요청 - articleId={}", articleId);
+    NewsArticle article = getArticleOrThrow(articleId);
+    if (article.isDeleted()) {
+      throw new ArticleNotFoundException(articleId);
+    }
 
+    article.markDeleted();
+    newsArticleRepository.save(article);
+    log.info("뉴스기사 삭제 성공 - articleId={}", articleId);
   }
 
+  @Transactional
   public void hardDeleteArticle(UUID articleId) {
+    log.debug("뉴스기사 물리삭제 요청 - articleId={}", articleId);
+    NewsArticle article = getArticleOrThrow(articleId);
 
+    newsArticleRepository.delete(article);
+    log.info("뉴스기사 물리삭제 성공 - articleId={}", articleId);
   }
 
   private ArticleCursor parseCursor(ArticleSearchRequest request) {
@@ -116,5 +132,10 @@ public class ArticleService {
     } catch (DateTimeParseException | NumberFormatException e) {
       throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, Map.of("cursor", e.getMessage()));
     }
+  }
+
+  private NewsArticle getArticleOrThrow(UUID articleId) {
+    return newsArticleRepository.findById(articleId)
+        .orElseThrow(() -> new ArticleNotFoundException(articleId));
   }
 }

--- a/src/test/java/com/team3/monew/controller/ArticleControllerTest.java
+++ b/src/test/java/com/team3/monew/controller/ArticleControllerTest.java
@@ -2,6 +2,8 @@ package com.team3.monew.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -9,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.team3.monew.dto.article.ArticleDto;
 import com.team3.monew.dto.pagination.CursorPageResponseDto;
 import com.team3.monew.entity.enums.NewsSourceType;
+import com.team3.monew.exception.article.ArticleNotFoundException;
 import com.team3.monew.service.ArticleService;
 import java.time.Instant;
 import java.util.List;
@@ -110,6 +113,102 @@ class ArticleControllerTest {
               .param("direction", "DesC")
               .param("limit", "1"))
           .andExpect(status().isOk());
+    }
+  }
+
+
+  @Nested
+  @DisplayName("뉴스기사 논리삭제")
+  class deleteArticle {
+
+    @Test
+    @DisplayName("논리 삭제에 성공하면 204 NoContent를 반환한다")
+    void shouldReturnNoContent_whenLogicalDeleteSucceeds() throws Exception {
+      // given
+      UUID articleId = UUID.randomUUID();
+
+      // when & then
+      mockMvc.perform(delete(ARTICLES_BASE_URL + "/{articleId}", articleId))
+          .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("삭제할 기사가 존재하지 않으면 404 NotFound를 반환한다")
+    void shouldReturnNotFound_whenArticleDoesNotExist() throws Exception {
+      // given
+      UUID articleId = UUID.randomUUID();
+      willThrow(new ArticleNotFoundException(articleId)).
+          given(articleService).deleteArticle(any(UUID.class));
+
+      // when & then
+      mockMvc.perform(delete(ARTICLES_BASE_URL + "/{articleId}", articleId))
+          .andExpect(status().isNotFound())
+          .andExpect(jsonPath("$.code").value("ARTICLE_NOT_FOUND"))
+          .andExpect(jsonPath("$.status").value("404"))
+          .andExpect(jsonPath("$.details.articleId").value(articleId.toString()));
+    }
+
+    @Test
+    @DisplayName("서버내부에서 오류가 발생하면 500 ServerError를 반환한다")
+    void shouldReturnInternalServerError_whenExceptionOccurs() throws Exception {
+      // given
+      UUID articleId = UUID.randomUUID();
+      willThrow(new RuntimeException())
+          .given(articleService).deleteArticle(any(UUID.class));
+
+      // when & then
+      mockMvc.perform(delete(ARTICLES_BASE_URL + "/{articleId}", articleId))
+          .andExpect(status().isInternalServerError())
+          .andExpect(jsonPath("$.code").value("INTERNAL_SERVER_ERROR"))
+          .andExpect(jsonPath("$.status").value("500"));
+    }
+  }
+
+
+  @Nested
+  @DisplayName("뉴스기사 물리삭제")
+  class hardDeleteArticle {
+
+    @Test
+    @DisplayName("물리 삭제에 성공하면 204 NoContent를 반환한다")
+    void shouldReturnNoContent_whenLogicalDeleteSucceeds() throws Exception {
+      // given
+      UUID articleId = UUID.randomUUID();
+
+      // when & then
+      mockMvc.perform(delete(ARTICLES_BASE_URL + "/{articleId}/hard", articleId))
+          .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("삭제할 기사가 존재하지 않으면 404 NotFound를 반환한다")
+    void shouldReturnNotFound_whenArticleDoesNotExist() throws Exception {
+      // given
+      UUID articleId = UUID.randomUUID();
+      willThrow(new ArticleNotFoundException(articleId)).
+          given(articleService).hardDeleteArticle(any(UUID.class));
+
+      // when & then
+      mockMvc.perform(delete(ARTICLES_BASE_URL + "/{articleId}/hard", articleId))
+          .andExpect(status().isNotFound())
+          .andExpect(jsonPath("$.code").value("ARTICLE_NOT_FOUND"))
+          .andExpect(jsonPath("$.status").value("404"))
+          .andExpect(jsonPath("$.details.articleId").value(articleId.toString()));
+    }
+
+    @Test
+    @DisplayName("서버내부에서 오류가 발생하면 500 ServerError를 반환한다")
+    void shouldReturnInternalServerError_whenExceptionOccurs() throws Exception {
+      // given
+      UUID articleId = UUID.randomUUID();
+      willThrow(new RuntimeException())
+          .given(articleService).hardDeleteArticle(any(UUID.class));
+
+      // when & then
+      mockMvc.perform(delete(ARTICLES_BASE_URL + "/{articleId}/hard", articleId))
+          .andExpect(status().isInternalServerError())
+          .andExpect(jsonPath("$.code").value("INTERNAL_SERVER_ERROR"))
+          .andExpect(jsonPath("$.status").value("500"));
     }
   }
 }

--- a/src/test/java/com/team3/monew/controller/ArticleControllerTest.java
+++ b/src/test/java/com/team3/monew/controller/ArticleControllerTest.java
@@ -119,7 +119,7 @@ class ArticleControllerTest {
 
   @Nested
   @DisplayName("뉴스기사 논리삭제")
-  class deleteArticle {
+  class DeleteArticle {
 
     @Test
     @DisplayName("논리 삭제에 성공하면 204 NoContent를 반환한다")
@@ -167,11 +167,11 @@ class ArticleControllerTest {
 
   @Nested
   @DisplayName("뉴스기사 물리삭제")
-  class hardDeleteArticle {
+  class HardDeleteArticle {
 
     @Test
     @DisplayName("물리 삭제에 성공하면 204 NoContent를 반환한다")
-    void shouldReturnNoContent_whenLogicalDeleteSucceeds() throws Exception {
+    void shouldReturnNoContent_whenHardDeleteSucceeds() throws Exception {
       // given
       UUID articleId = UUID.randomUUID();
 

--- a/src/test/java/com/team3/monew/integration/ArticleServiceIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/ArticleServiceIntegrationTest.java
@@ -114,19 +114,6 @@ public class ArticleServiceIntegrationTest extends IntegrationTestSupport {
     em.clear();
   }
 
-//  @AfterEach
-//  void tearDown() {
-//    commentLikeRepository.deleteAll();
-//    articleInterestRepository.deleteAll();
-//    interestRepository.deleteAll();
-//    userRepository.deleteAll();
-//    articleViewRepository.deleteAll();
-//    commentRepository.deleteAll();
-//    newsArticleRepository.deleteAll();
-//    newsSourceRepository.deleteAll();
-//  }
-
-
   @Test
   @DisplayName("뉴스기사 목록 조회 통합 테스트에 성공합니다")
   void shouldReturnArticlePage_whenAPICalls() throws Exception {

--- a/src/test/java/com/team3/monew/integration/ArticleServiceIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/ArticleServiceIntegrationTest.java
@@ -76,6 +76,7 @@ public class ArticleServiceIntegrationTest extends IntegrationTestSupport {
   private static final String ARTICLES_BASE_URL = "/api/articles";
 
   private NewsArticle newsArticle;
+  private UUID commentLikeId;
 
 
   @BeforeEach
@@ -107,8 +108,9 @@ public class ArticleServiceIntegrationTest extends IntegrationTestSupport {
     Comment u2comment = Comment.create(newsArticle, user2, "comment2");
     commentRepository.saveAll(List.of(u1comment, u2comment));
 
-    CommentLike u2commentLike = CommentLike.create(u2comment, user2);
-    commentLikeRepository.save(u2commentLike);
+    CommentLike u2CommentLike = CommentLike.create(u2comment, user2);
+    commentLikeRepository.save(u2CommentLike);
+    commentLikeId = u2CommentLike.getId();
 
     em.flush();
     em.clear();
@@ -173,9 +175,9 @@ public class ArticleServiceIntegrationTest extends IntegrationTestSupport {
     assertThat(articleViews).isEmpty();
 
     List<Comment> comments = commentRepository.findAllByArticleId(newsArticle.getId());
-    long commentLikeSize = commentLikeRepository.count();
+    Optional<CommentLike> commentLike = commentLikeRepository.findById(commentLikeId);
     assertThat(comments).isEmpty();
-    assertThat(commentLikeSize).isZero();
+    assertThat(commentLike).isEmpty();
   }
 
   @Test

--- a/src/test/java/com/team3/monew/integration/ArticleServiceIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/ArticleServiceIntegrationTest.java
@@ -1,15 +1,38 @@
 package com.team3.monew.integration;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.team3.monew.dto.article.internal.enums.ArticleDirection;
 import com.team3.monew.dto.article.internal.enums.ArticleOrderBy;
+import com.team3.monew.entity.ArticleInterest;
+import com.team3.monew.entity.ArticleView;
+import com.team3.monew.entity.Comment;
+import com.team3.monew.entity.CommentLike;
+import com.team3.monew.entity.Interest;
+import com.team3.monew.entity.NewsArticle;
+import com.team3.monew.entity.NewsSource;
+import com.team3.monew.entity.User;
+import com.team3.monew.entity.enums.DeleteStatus;
 import com.team3.monew.entity.enums.NewsSourceType;
-import com.team3.monew.service.ArticleService;
+import com.team3.monew.repository.ArticleInterestRepository;
+import com.team3.monew.repository.ArticleViewRepository;
+import com.team3.monew.repository.CommentLikeRepository;
+import com.team3.monew.repository.CommentRepository;
+import com.team3.monew.repository.InterestRepository;
+import com.team3.monew.repository.NewsArticleRepository;
+import com.team3.monew.repository.NewsSourceRepository;
+import com.team3.monew.repository.UserRepository;
 import com.team3.monew.support.IntegrationTestSupport;
+import jakarta.persistence.EntityManager;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -18,26 +41,97 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Transactional
 @ActiveProfiles("test")
 @Tag("integration")
 public class ArticleServiceIntegrationTest extends IntegrationTestSupport {
 
   @Autowired
-  private MockMvc mockMvc;
+  private NewsArticleRepository newsArticleRepository;
+  @Autowired
+  private NewsSourceRepository newsSourceRepository;
+  @Autowired
+  private InterestRepository interestRepository;
+  @Autowired
+  private ArticleViewRepository articleViewRepository;
+  @Autowired
+  private UserRepository userRepository;
+  @Autowired
+  private CommentRepository commentRepository;
+  @Autowired
+  private CommentLikeRepository commentLikeRepository;
+  @Autowired
+  private ArticleInterestRepository articleInterestRepository;
+  @Autowired
+  private EntityManager em;
 
   @Autowired
-  private ArticleService articleService;
+  private MockMvc mockMvc;
 
-  private final String REQUEST_USER_ID_HEADER = "Monew-Request-User-ID";
+  private static final String REQUEST_USER_ID_HEADER = "Monew-Request-User-ID";
+  private static final String ARTICLES_BASE_URL = "/api/articles";
+
+  private NewsArticle newsArticle;
+
+
+  @BeforeEach
+  void setUp() {
+    Interest samsungInterest = Interest.create("삼성");
+    Interest appleInterest = Interest.create("애플");
+    interestRepository.saveAll(List.of(samsungInterest, appleInterest));
+
+    NewsSource naverSource = NewsSource
+        .create(NewsSourceType.NAVER.name() + 1, NewsSourceType.NAVER, "baseUrl");
+    newsSourceRepository.save(naverSource);
+
+    newsArticle = NewsArticle
+        .create(naverSource, "link", "title", Instant.now(), "summary");
+    newsArticle.addArticleInterest(samsungInterest, "갤럭시");
+    newsArticle.addArticleInterest(samsungInterest, "메모리");
+    newsArticle.addArticleInterest(appleInterest, "아이폰");
+    newsArticleRepository.save(newsArticle);
+
+    User user1 = User.create("email@naver.com", "닉닉", "@qwer!!");
+    User user2 = User.create("user2@gmail.com", "ha", "orange@1234");
+    userRepository.saveAll(List.of(user1, user2));
+
+    ArticleView articleView1 = ArticleView.create(newsArticle, user1);
+    ArticleView articleView2 = ArticleView.create(newsArticle, user2);
+    articleViewRepository.saveAll(List.of(articleView1, articleView2));
+
+    Comment u1comment = Comment.create(newsArticle, user1, "comment1");
+    Comment u2comment = Comment.create(newsArticle, user2, "comment2");
+    commentRepository.saveAll(List.of(u1comment, u2comment));
+
+    CommentLike u2commentLike = CommentLike.create(u2comment, user2);
+    commentLikeRepository.save(u2commentLike);
+
+    em.flush();
+    em.clear();
+  }
+
+//  @AfterEach
+//  void tearDown() {
+//    commentLikeRepository.deleteAll();
+//    articleInterestRepository.deleteAll();
+//    interestRepository.deleteAll();
+//    userRepository.deleteAll();
+//    articleViewRepository.deleteAll();
+//    commentRepository.deleteAll();
+//    newsArticleRepository.deleteAll();
+//    newsSourceRepository.deleteAll();
+//  }
+
 
   @Test
   @DisplayName("뉴스기사 목록 조회 통합 테스트에 성공합니다")
   void shouldReturnArticlePage_whenAPICalls() throws Exception {
     // when & then
-    mockMvc.perform(get("/api/articles")
+    mockMvc.perform(get(ARTICLES_BASE_URL)
             .header(REQUEST_USER_ID_HEADER, UUID.randomUUID())
             .param("keyword", "삼성 메모리")
             .param("sourceIn", NewsSourceType.NAVER.name())
@@ -50,4 +144,77 @@ public class ArticleServiceIntegrationTest extends IntegrationTestSupport {
         .andExpect(jsonPath("$.hasNext").value(false));
   }
 
+  @Test
+  @DisplayName("뉴스기사 논리삭제 성공 시 204 반환과 함께 기사의 상태가 softDeleted 상태여야 한다")
+  void shouldReturnNoContentAndSoftDeleteArticle_whenDeleteSuccessful() throws Exception {
+    // when & then
+    mockMvc.perform(delete(ARTICLES_BASE_URL + "/{articleId}", newsArticle.getId()))
+        .andExpect(status().isNoContent());
+
+    NewsArticle findNewsArticle = newsArticleRepository.findById(newsArticle.getId())
+        .orElseThrow(RuntimeException::new);
+    assertThat(findNewsArticle)
+        .extracting("DeleteStatus").isEqualTo(DeleteStatus.DELETED);
+
+    List<ArticleInterest> articleInterests = articleInterestRepository
+        .findAllByArticleId(findNewsArticle.getId());
+    assertThat(articleInterests).isNotEmpty();
+
+    List<ArticleView> articleViews = articleViewRepository
+        .findAllByArticleId(findNewsArticle.getId());
+    assertThat(articleViews).isNotEmpty();
+
+    List<Comment> comments = commentRepository.findAllByArticleId(findNewsArticle.getId());
+    assertThat(comments).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("뉴스기사 물리삭제 성공 시 204 반환과 함께 기사는 DB에서 찾을 수 없어야 한다")
+  void shouldReturnNoContentAndDeleteArticle_whenDeletedPhysically() throws Exception {
+    // when & then
+    mockMvc.perform(delete(ARTICLES_BASE_URL + "/{articleId}/hard", newsArticle.getId()))
+        .andExpect(status().isNoContent());
+
+    Optional<NewsArticle> findNewsArticle = newsArticleRepository.findById(newsArticle.getId());
+    assertThat(findNewsArticle).isEmpty();
+
+    List<ArticleInterest> articleInterests = articleInterestRepository
+        .findAllByArticleId(newsArticle.getId());
+    assertThat(articleInterests).isEmpty();
+
+    List<ArticleView> articleViews = articleViewRepository
+        .findAllByArticleId(newsArticle.getId());
+    assertThat(articleViews).isEmpty();
+
+    List<Comment> comments = commentRepository.findAllByArticleId(newsArticle.getId());
+    assertThat(comments).isEmpty();
+  }
+
+  @Test
+  @DisplayName("논리삭제를 진행할 때 삭제할 기사가 존재하지 않으면 404 NotFound를 반환한다")
+  void shouldReturnNotFound_whenSoftDeletingNonExistentArticle() throws Exception {
+    // given
+    UUID articleId = UUID.randomUUID();
+
+    // when & then
+    mockMvc.perform(delete(ARTICLES_BASE_URL + "/{articleId}", articleId))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("ARTICLE_NOT_FOUND"))
+        .andExpect(jsonPath("$.status").value("404"))
+        .andExpect(jsonPath("$.details.articleId").value(articleId.toString()));
+  }
+
+  @Test
+  @DisplayName("물리삭제를 진행할 때 삭제할 기사가 존재하지 않으면 404 NotFound를 반환한다")
+  void shouldReturnNotFound_whenHardDeletingNonExistentArticle() throws Exception {
+    // given
+    UUID articleId = UUID.randomUUID();
+
+    // when & then
+    mockMvc.perform(delete(ARTICLES_BASE_URL + "/{articleId}/hard", articleId))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("ARTICLE_NOT_FOUND"))
+        .andExpect(jsonPath("$.status").value("404"))
+        .andExpect(jsonPath("$.details.articleId").value(articleId.toString()));
+  }
 }

--- a/src/test/java/com/team3/monew/integration/ArticleServiceIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/ArticleServiceIntegrationTest.java
@@ -140,8 +140,7 @@ public class ArticleServiceIntegrationTest extends IntegrationTestSupport {
 
     NewsArticle findNewsArticle = newsArticleRepository.findById(newsArticle.getId())
         .orElseThrow(RuntimeException::new);
-    assertThat(findNewsArticle)
-        .extracting("DeleteStatus").isEqualTo(DeleteStatus.DELETED);
+    assertThat(findNewsArticle.getDeleteStatus()).isEqualTo(DeleteStatus.DELETED);
 
     List<ArticleInterest> articleInterests = articleInterestRepository
         .findAllByArticleId(findNewsArticle.getId());
@@ -174,7 +173,9 @@ public class ArticleServiceIntegrationTest extends IntegrationTestSupport {
     assertThat(articleViews).isEmpty();
 
     List<Comment> comments = commentRepository.findAllByArticleId(newsArticle.getId());
+    long commentLikeSize = commentLikeRepository.count();
     assertThat(comments).isEmpty();
+    assertThat(commentLikeSize).isZero();
   }
 
   @Test

--- a/src/test/java/com/team3/monew/service/ArticleServiceTest.java
+++ b/src/test/java/com/team3/monew/service/ArticleServiceTest.java
@@ -7,7 +7,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.BDDMockito.willThrow;
 
 import com.team3.monew.dto.article.ArticleDto;
 import com.team3.monew.dto.article.ArticleSearchRequest;
@@ -335,8 +334,7 @@ class ArticleServiceTest {
     void shouldThrowArticleNotFoundException_whenArticleDoesNotExist() {
       // given
       UUID articleId = UUID.randomUUID();
-      willThrow(new ArticleNotFoundException(articleId)).
-          given(newsArticleRepository).findById(any(UUID.class));
+      given(newsArticleRepository.findById(any(UUID.class))).willReturn(Optional.empty());
 
       // when & then
       assertThrows(ArticleNotFoundException.class,
@@ -373,8 +371,7 @@ class ArticleServiceTest {
       // then
       ArgumentCaptor<NewsArticle> captor = ArgumentCaptor.forClass(NewsArticle.class);
       then(newsArticleRepository).should().save(captor.capture());
-      assertThat(captor.getValue())
-          .extracting("DeleteStatus").isEqualTo(DeleteStatus.DELETED);
+      assertThat(captor.getValue().getDeleteStatus()).isEqualTo(DeleteStatus.DELETED);
     }
   }
 
@@ -387,8 +384,7 @@ class ArticleServiceTest {
     void shouldThrowArticleNotFoundException_whenArticleDoesNotExist() {
       // given
       UUID articleId = UUID.randomUUID();
-      willThrow(new ArticleNotFoundException(articleId)).
-          given(newsArticleRepository).findById(any(UUID.class));
+      given(newsArticleRepository.findById(any(UUID.class))).willReturn(Optional.empty());
 
       // when & then
       assertThrows(ArticleNotFoundException.class,

--- a/src/test/java/com/team3/monew/service/ArticleServiceTest.java
+++ b/src/test/java/com/team3/monew/service/ArticleServiceTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
 
 import com.team3.monew.dto.article.ArticleDto;
 import com.team3.monew.dto.article.ArticleSearchRequest;
@@ -16,16 +18,21 @@ import com.team3.monew.dto.article.internal.enums.ArticleOrderBy;
 import com.team3.monew.dto.pagination.CursorPageResponseDto;
 import com.team3.monew.entity.NewsArticle;
 import com.team3.monew.entity.NewsSource;
+import com.team3.monew.entity.enums.DeleteStatus;
 import com.team3.monew.entity.enums.NewsSourceType;
+import com.team3.monew.exception.article.ArticleNotFoundException;
 import com.team3.monew.global.exception.BusinessException;
 import com.team3.monew.mapper.ArticleMapper;
+import com.team3.monew.repository.ArticleInterestRepository;
 import com.team3.monew.repository.ArticleViewRepository;
+import com.team3.monew.repository.CommentRepository;
 import com.team3.monew.repository.NewsArticleRepository;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,6 +42,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mapstruct.factory.Mappers;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -51,6 +59,10 @@ class ArticleServiceTest {
   private NewsArticleRepository newsArticleRepository;
   @Mock
   private ArticleViewRepository articleViewRepository;
+  @Mock
+  private ArticleInterestRepository articleInterestRepository;
+  @Mock
+  private CommentRepository commentRepository;
 
   @InjectMocks
   private ArticleService articleService;
@@ -311,6 +323,95 @@ class ArticleServiceTest {
       // when & then
       assertThrows(BusinessException.class,
           () -> articleService.getArticleList(request2, UUID.randomUUID()));
+    }
+  }
+
+  @Nested
+  @DisplayName("뉴스기사 삭제를 진행한다")
+  class deleteArticle {
+
+    @Test
+    @DisplayName("뉴스기사를 찾을 수 없으면 에러를 반환한다")
+    void shouldThrowArticleNotFoundException_whenArticleDoesNotExist() {
+      // given
+      UUID articleId = UUID.randomUUID();
+      willThrow(new ArticleNotFoundException(articleId)).
+          given(newsArticleRepository).findById(any(UUID.class));
+
+      // when & then
+      assertThrows(ArticleNotFoundException.class,
+          () -> articleService.deleteArticle(articleId));
+    }
+
+    @Test
+    @DisplayName("뉴스기사 상태가 deleted로 되어있는 상태라면 에러를 반환한다")
+    void shouldThrowArticleNotFoundException_whenArticleIsDeleted() {
+      // given
+      UUID articleId = UUID.randomUUID();
+      NewsArticle newsArticle = NewsArticle
+          .create(naverSource, "link", "title", Instant.now(), "summary");
+      ReflectionTestUtils.setField(newsArticle, "deleteStatus", DeleteStatus.DELETED);
+      given(newsArticleRepository.findById(any(UUID.class))).willReturn(Optional.of(newsArticle));
+
+      // when & then
+      assertThrows(ArticleNotFoundException.class,
+          () -> articleService.deleteArticle(articleId));
+    }
+
+    @Test
+    @DisplayName("뉴스기사 상태를 softDeleted로 만들고 저장한다")
+    void shouldSaveArticleAsDeleted_whenLogicalDeleteIsRequested() {
+      // given
+      UUID articleId = UUID.randomUUID();
+      NewsArticle newsArticle = NewsArticle
+          .create(naverSource, "link", "title", Instant.now(), "summary");
+      given(newsArticleRepository.findById(any(UUID.class))).willReturn(Optional.of(newsArticle));
+
+      // when
+      articleService.deleteArticle(articleId);
+
+      // then
+      ArgumentCaptor<NewsArticle> captor = ArgumentCaptor.forClass(NewsArticle.class);
+      then(newsArticleRepository).should().save(captor.capture());
+      assertThat(captor.getValue())
+          .extracting("DeleteStatus").isEqualTo(DeleteStatus.DELETED);
+    }
+  }
+
+  @Nested
+  @DisplayName("뉴스기사 물리삭제를 진행한다")
+  class hardDeleteArticle {
+
+    @Test
+    @DisplayName("뉴스기사를 찾을 수 없으면 에러를 반환한다")
+    void shouldThrowArticleNotFoundException_whenArticleDoesNotExist() {
+      // given
+      UUID articleId = UUID.randomUUID();
+      willThrow(new ArticleNotFoundException(articleId)).
+          given(newsArticleRepository).findById(any(UUID.class));
+
+      // when & then
+      assertThrows(ArticleNotFoundException.class,
+          () -> articleService.hardDeleteArticle(articleId));
+    }
+
+    @Test
+    @DisplayName("뉴스기사 삭제 시 연관된 모든 객체를 삭제하는 함수를 호출한다")
+    void shouldCallRelatedDataDeleteMethods_whenHardDeleting() {
+      // given
+      UUID articleId = UUID.randomUUID();
+      NewsArticle newsArticle = NewsArticle
+          .create(naverSource, "link", "title", Instant.now(), "summary");
+      given(newsArticleRepository.findById(any(UUID.class))).willReturn(Optional.of(newsArticle));
+
+      // when
+      articleService.hardDeleteArticle(articleId);
+
+      // then
+      then(articleInterestRepository).should().deleteAllByArticleId(articleId);
+      then(articleViewRepository).should().deleteAllByArticleId(articleId);
+      then(commentRepository).should().deleteAllByArticleId(articleId);
+      then(newsArticleRepository).should().delete(newsArticle);
     }
   }
 }


### PR DESCRIPTION
## 관련 이슈
- #49 
  - #222 
  - #223 
  - #224
  - #225

## 작업 내용
- 뉴사 기사 ID로 삭제
- 관련된 정보가 유지되도록 논리 삭제를 기본으로 설정
- 물리 삭제 시 관련된 정보 모두 삭제(/hard) 경로 추가

## 변경 사항
- 추가사항
  - ArticleApi: 논리/물리삭제 문서화
  - ArticleController: 논리/물리삭제 경로 추가
  - ArticleControllerTest: 컨트롤러 슬라이스 테스트 추가
  - ArticleService: 논리/물리 로직 추가
  - ArticleServiceTest: 논리/물리 단위테스트 추가
  - ArticleServiceIntegrationTest: 논리/물리삭제 통합테스트 추가
  - ArticleInterestRepository & ArticleViewRepository & CommentRepository
    - 테스트 검증용 함수 추가

- 변동사항
  - CommentLike: JPQ의 @OnDelete cascade 옵션 추가

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 기사 삭제 기능 추가: 기사 임시 삭제(soft delete) 및 완전 삭제(hard delete) 지원.
  * 완전 삭제 시 관련 댓글·조회·관심 데이터가 함께 제거됨.
  * 삭제 요청 성공 시 204 No Content 반환; 존재하지 않는 기사 요청은 404, 기타 오류는 500 응답 처리.

* **테스트**
  * 단위 및 통합 테스트 추가: soft/hard 삭제 흐름과 오류 응답 검증.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->