### PR TITLE
feat: 사용자 삭제 구현

### DIFF
--- a/src/main/java/com/team3/monew/batch/job/UserDeleteBatchConfig.java
+++ b/src/main/java/com/team3/monew/batch/job/UserDeleteBatchConfig.java
@@ -1,0 +1,66 @@
+package com.team3.monew.batch.job;
+
+import com.team3.monew.batch.tasklet.UserDeleteTasklet;
+import jakarta.annotation.PostConstruct;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class UserDeleteBatchConfig {
+
+  private final JobRepository jobRepository;
+  private final PlatformTransactionManager transactionManager;
+  private final UserDeleteTasklet userDeleteTasklet;
+
+  @Value("${batch.user.delete.batch-size:100}")
+  private int batchSize;
+
+  @Value("${batch.user.delete.retention-days:1}")
+  private int retentionDays;
+
+  @PostConstruct
+  void validate() {
+    if (batchSize <= 0) throw new IllegalArgumentException("배치 사이즈는 0보다 커야합니다.");
+    if (retentionDays <= 0) throw new IllegalArgumentException("삭제 주기는 0보다 커야힙니다.");
+  }
+
+  @Bean
+  public Job userDeleteJob() {
+    return new JobBuilder("userDeleteJob", jobRepository)
+        .start(deleteUserStep(null))
+        .build();
+  }
+
+  @Bean
+  @JobScope
+  public Step deleteUserStep(
+      @Value("#{jobParameters['runTime']}") LocalDateTime runTime
+  ) {
+
+    Instant targetDate = (runTime != null ? runTime : LocalDateTime.now())
+        .atZone(ZoneId.systemDefault())
+        .toInstant()
+        .minus(retentionDays, ChronoUnit.DAYS);
+
+    return new StepBuilder("deleteUserStep", jobRepository)
+        .tasklet((contribution, chunkContext) ->
+            userDeleteTasklet.execute(targetDate, batchSize), transactionManager)
+        .build();
+  }
+}

--- a/src/main/java/com/team3/monew/batch/scheduler/UserDeleteScheduler.java
+++ b/src/main/java/com/team3/monew/batch/scheduler/UserDeleteScheduler.java
@@ -1,0 +1,44 @@
+package com.team3.monew.batch.scheduler;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class UserDeleteScheduler {
+
+  private final JobLauncher jobLauncher;
+  private final Job userDeleteJob;
+
+  @Scheduled(cron = "${batch.user.delete.cron:0 0 2 * * *}")
+  public void run() {
+    try {
+      log.info("User 삭제 배치 시작");
+
+      JobParameters params = new JobParametersBuilder()
+          .addLocalDateTime("runTime", LocalDateTime.now())
+          .toJobParameters();
+
+      JobExecution execution = jobLauncher.run(userDeleteJob, params);
+
+      if (execution.getStatus() == BatchStatus.COMPLETED) {
+        log.info("User 삭제 배치 완료");
+      } else {
+        log.error("User 삭제 배치 실패: {}", execution.getStatus());
+      }
+
+    } catch (Exception e) {
+      log.error("User 삭제 배치 실행 실패", e);
+    }
+  }
+}

--- a/src/main/java/com/team3/monew/batch/tasklet/UserDeleteTasklet.java
+++ b/src/main/java/com/team3/monew/batch/tasklet/UserDeleteTasklet.java
@@ -1,0 +1,53 @@
+package com.team3.monew.batch.tasklet;
+
+import com.team3.monew.repository.CommentLikeRepository;
+import com.team3.monew.repository.CommentRepository;
+import com.team3.monew.repository.NotificationRepository;
+import com.team3.monew.repository.SubscriptionRepository;
+import com.team3.monew.repository.UserActivityRepository;
+import com.team3.monew.repository.UserRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserDeleteTasklet {
+
+  private final UserRepository userRepository;
+  private final NotificationRepository notificationRepository;
+  private final CommentLikeRepository commentLikeRepository;
+  private final CommentRepository commentRepository;
+  private final SubscriptionRepository subscriptionRepository;
+  private final UserActivityRepository userActivityRepository;
+
+  public RepeatStatus execute(Instant targetDate, int batchSize) {
+
+    List<UUID> userIds = userRepository.findDeletableUserIds(
+        targetDate,
+        PageRequest.of(0, batchSize)
+    );
+
+    if (userIds.isEmpty()) {
+      return RepeatStatus.FINISHED;
+    }
+
+    notificationRepository.deleteByUserIds(userIds);
+    commentLikeRepository.deleteByUserIds(userIds);
+    commentRepository.deleteByUserIds(userIds);
+    subscriptionRepository.deleteByUserIds(userIds);
+
+    userActivityRepository.deleteByIdIn(userIds);
+    userActivityRepository.removeEmbeddedCommentsByUserIds(userIds);
+
+    int deleted = userRepository.deleteSoftDeletedUsers(targetDate, batchSize);
+    log.debug("deleted count={}", deleted);
+    return deleted > 0 ? RepeatStatus.CONTINUABLE : RepeatStatus.FINISHED;
+  }
+}

--- a/src/main/java/com/team3/monew/batch/tasklet/UserDeleteTasklet.java
+++ b/src/main/java/com/team3/monew/batch/tasklet/UserDeleteTasklet.java
@@ -1,5 +1,6 @@
 package com.team3.monew.batch.tasklet;
 
+import com.team3.monew.repository.ArticleViewRepository;
 import com.team3.monew.repository.CommentLikeRepository;
 import com.team3.monew.repository.CommentRepository;
 import com.team3.monew.repository.NotificationRepository;
@@ -26,6 +27,7 @@ public class UserDeleteTasklet {
   private final CommentRepository commentRepository;
   private final SubscriptionRepository subscriptionRepository;
   private final UserActivityRepository userActivityRepository;
+  private final ArticleViewRepository articleViewRepository;
 
   public RepeatStatus execute(Instant targetDate, int batchSize) {
 
@@ -42,6 +44,7 @@ public class UserDeleteTasklet {
     commentLikeRepository.deleteByUserIds(userIds);
     commentRepository.deleteByUserIds(userIds);
     subscriptionRepository.deleteByUserIds(userIds);
+    articleViewRepository.deleteByUserIds(userIds);
 
     userActivityRepository.deleteByIdIn(userIds);
     userActivityRepository.removeEmbeddedCommentsByUserIds(userIds);

--- a/src/main/java/com/team3/monew/batch/tasklet/UserDeleteTasklet.java
+++ b/src/main/java/com/team3/monew/batch/tasklet/UserDeleteTasklet.java
@@ -49,7 +49,7 @@ public class UserDeleteTasklet {
     userActivityRepository.deleteByIdIn(userIds);
     userActivityRepository.removeEmbeddedCommentsByUserIds(userIds);
 
-    int deleted = userRepository.deleteSoftDeletedUsers(targetDate, batchSize);
+    int deleted = userRepository.deleteByIds(userIds);
     log.debug("deleted count={}", deleted);
     return deleted > 0 ? RepeatStatus.CONTINUABLE : RepeatStatus.FINISHED;
   }

--- a/src/main/java/com/team3/monew/controller/UserController.java
+++ b/src/main/java/com/team3/monew/controller/UserController.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -46,5 +47,17 @@ public class UserController implements UserApi {
       @Valid @RequestBody UserUpdateRequest userUpdateRequest
   ) {
     return ResponseEntity.ok(userService.updateUser(userId, userUpdateRequest));
+  }
+
+  @DeleteMapping("/{userId}")
+  public ResponseEntity<Void> deleteUser(@PathVariable UUID userId) {
+    userService.deleteUser(userId);
+    return ResponseEntity.ok().build();
+  }
+
+  @DeleteMapping("/{userId}/hard")
+  public ResponseEntity<Void> hardDeleteUser(@PathVariable UUID userId) {
+    userService.hardDeleteUser(userId);
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/team3/monew/controller/UserController.java
+++ b/src/main/java/com/team3/monew/controller/UserController.java
@@ -52,12 +52,12 @@ public class UserController implements UserApi {
   @DeleteMapping("/{userId}")
   public ResponseEntity<Void> deleteUser(@PathVariable UUID userId) {
     userService.deleteUser(userId);
-    return ResponseEntity.ok().build();
+    return ResponseEntity.noContent().build();
   }
 
   @DeleteMapping("/{userId}/hard")
   public ResponseEntity<Void> hardDeleteUser(@PathVariable UUID userId) {
     userService.hardDeleteUser(userId);
-    return ResponseEntity.ok().build();
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/team3/monew/controller/api/UserApi.java
+++ b/src/main/java/com/team3/monew/controller/api/UserApi.java
@@ -47,4 +47,20 @@ public interface UserApi {
       @PathVariable UUID userId,
       @Valid @RequestBody UserUpdateRequest userUpdateRequest
   );
+
+  @Operation(summary = "사용자 논리 삭제", description = "사용자를 논리적으로 삭제합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "204", description = "사용자 삭제 성공"),
+      @ApiResponse(responseCode = "404", description = "사용자 정보 없음"),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  ResponseEntity<Void> deleteUser(@PathVariable UUID userId);
+
+  @Operation(summary = "사용자 물리 삭제", description = "사용자를 물리적으로 삭제합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "204", description = "사용자 삭제 성공"),
+      @ApiResponse(responseCode = "404", description = "사용자 정보 없음"),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  ResponseEntity<Void> hardDeleteUser(@PathVariable UUID userId);
 }

--- a/src/main/java/com/team3/monew/entity/User.java
+++ b/src/main/java/com/team3/monew/entity/User.java
@@ -71,6 +71,6 @@ public class User extends SoftDeleteEntity {
     @Override
     public void markDeleted() {
         super.markDeleted();
-        this.purgeScheduledAt = Instant.now().plus(1, ChronoUnit.DAYS);
+        this.purgeScheduledAt = getDeletedAt().plus(1, ChronoUnit.DAYS);
     }
 }

--- a/src/main/java/com/team3/monew/entity/User.java
+++ b/src/main/java/com/team3/monew/entity/User.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.time.temporal.ChronoUnit;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -65,5 +66,11 @@ public class User extends SoftDeleteEntity {
             throw new InvalidNicknameException();
         }
         this.nickname = nickname;
+    }
+
+    @Override
+    public void markDeleted() {
+        super.markDeleted();
+        this.purgeScheduledAt = Instant.now().plus(1, ChronoUnit.DAYS);
     }
 }

--- a/src/main/java/com/team3/monew/repository/ArticleViewRepository.java
+++ b/src/main/java/com/team3/monew/repository/ArticleViewRepository.java
@@ -24,11 +24,11 @@ public interface ArticleViewRepository extends JpaRepository<ArticleView, UUID> 
   @Query("DELETE FROM ArticleView av WHERE av.article.id = :articleId")
   void deleteAllByArticleId(@Param("articleId") UUID articleId);
 
-  List<ArticleView> findAllByArticleId(UUID articleId);
+  List<ArticleView> findAllByArticleId(@Param("articleId") UUID articleId);
 
-  void deleteAllByUserId(UUID userId);
+  void deleteAllByUserId(@Param("userId") UUID userId);
 
   @Modifying
   @Query("DELETE FROM ArticleView av WHERE av.user.id IN :userIds")
-  void deleteByUserIds(List<UUID> userIds);
+  void deleteByUserIds(@Param("userIds") List<UUID> userIds);
 }

--- a/src/main/java/com/team3/monew/repository/ArticleViewRepository.java
+++ b/src/main/java/com/team3/monew/repository/ArticleViewRepository.java
@@ -25,4 +25,10 @@ public interface ArticleViewRepository extends JpaRepository<ArticleView, UUID> 
   void deleteAllByArticleId(@Param("articleId") UUID articleId);
 
   List<ArticleView> findAllByArticleId(UUID articleId);
+
+  void deleteAllByUserId(UUID userId);
+
+  @Modifying
+  @Query("DELETE FROM ArticleView av WHERE av.user.id IN :userIds")
+  void deleteByUserIds(List<UUID> userIds);
 }

--- a/src/main/java/com/team3/monew/repository/CommentLikeRepository.java
+++ b/src/main/java/com/team3/monew/repository/CommentLikeRepository.java
@@ -29,9 +29,9 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, UUID> 
       @Param("commentIds") List<UUID> commentIds
   );
 
-  void deleteAllByUserId(UUID userId);
+  void deleteAllByUserId(@Param("userId") UUID userId);
 
   @Modifying
   @Query("DELETE FROM CommentLike cl WHERE cl.user.id IN :userIds")
-  void deleteByUserIds(List<UUID> userIds);
+  void deleteByUserIds(@Param("userIds") List<UUID> userIds);
 }

--- a/src/main/java/com/team3/monew/repository/CommentLikeRepository.java
+++ b/src/main/java/com/team3/monew/repository/CommentLikeRepository.java
@@ -27,4 +27,6 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, UUID> 
       @Param("userId") UUID userId,
       @Param("commentIds") List<UUID> commentIds
   );
+
+  void deleteAllByUserId(UUID userId);
 }

--- a/src/main/java/com/team3/monew/repository/CommentLikeRepository.java
+++ b/src/main/java/com/team3/monew/repository/CommentLikeRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -29,4 +30,8 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, UUID> 
   );
 
   void deleteAllByUserId(UUID userId);
+
+  @Modifying
+  @Query("DELETE FROM CommentLike cl WHERE cl.user.id IN :userIds")
+  void deleteByUserIds(List<UUID> userIds);
 }

--- a/src/main/java/com/team3/monew/repository/CommentRepository.java
+++ b/src/main/java/com/team3/monew/repository/CommentRepository.java
@@ -94,4 +94,8 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
   List<Comment> findAllByArticleId(UUID articleId);
 
   void deleteAllByUserId(UUID userId);
+
+  @Modifying
+  @Query("DELETE FROM Comment c WHERE c.user.id IN :userIds")
+  void deleteByUserIds(List<UUID> userIds);
 }

--- a/src/main/java/com/team3/monew/repository/CommentRepository.java
+++ b/src/main/java/com/team3/monew/repository/CommentRepository.java
@@ -92,4 +92,6 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
   void deleteAllByArticleId(@Param("articleId") UUID articleId);
 
   List<Comment> findAllByArticleId(UUID articleId);
+
+  void deleteAllByUserId(UUID userId);
 }

--- a/src/main/java/com/team3/monew/repository/CommentRepository.java
+++ b/src/main/java/com/team3/monew/repository/CommentRepository.java
@@ -91,11 +91,11 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
   @Query("DELETE FROM Comment c WHERE c.article.id = :articleId")
   void deleteAllByArticleId(@Param("articleId") UUID articleId);
 
-  List<Comment> findAllByArticleId(UUID articleId);
+  List<Comment> findAllByArticleId(@Param("articleId") UUID articleId);
 
-  void deleteAllByUserId(UUID userId);
+  void deleteAllByUserId(@Param("userId") UUID userId);
 
   @Modifying
   @Query("DELETE FROM Comment c WHERE c.user.id IN :userIds")
-  void deleteByUserIds(List<UUID> userIds);
+  void deleteByUserIds(@Param("userIds") List<UUID> userIds);
 }

--- a/src/main/java/com/team3/monew/repository/NotificationRepository.java
+++ b/src/main/java/com/team3/monew/repository/NotificationRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NotificationRepository extends JpaRepository<Notification, UUID> {
 
@@ -46,9 +47,9 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
       + "limit :batchSize)", nativeQuery = true)
   int deleteOldConfirmedNotifications(Instant targetDate, int batchSize);
 
-  void deleteAllByUserId(UUID userId);
+  void deleteAllByUserId(@Param("userId") UUID userId);
 
   @Modifying
   @Query("DELETE FROM Notification n WHERE n.user.id IN :userIds")
-  void deleteByUserIds(List<UUID> userIds);
+  void deleteByUserIds(@Param("userIds") List<UUID> userIds);
 }

--- a/src/main/java/com/team3/monew/repository/NotificationRepository.java
+++ b/src/main/java/com/team3/monew/repository/NotificationRepository.java
@@ -44,4 +44,6 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
       + "and confirmed_at <= :targetDate "
       + "limit :batchSize)", nativeQuery = true)
   int deleteOldConfirmedNotifications(Instant targetDate, int batchSize);
+
+  void deleteAllByUserId(UUID userId);
 }

--- a/src/main/java/com/team3/monew/repository/NotificationRepository.java
+++ b/src/main/java/com/team3/monew/repository/NotificationRepository.java
@@ -3,6 +3,7 @@ package com.team3.monew.repository;
 import com.team3.monew.entity.Notification;
 import com.team3.monew.entity.enums.NotificationResourceType;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -46,4 +47,8 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
   int deleteOldConfirmedNotifications(Instant targetDate, int batchSize);
 
   void deleteAllByUserId(UUID userId);
+
+  @Modifying
+  @Query("DELETE FROM Notification n WHERE n.user.id IN :userIds")
+  void deleteByUserIds(List<UUID> userIds);
 }

--- a/src/main/java/com/team3/monew/repository/SubscriptionRepository.java
+++ b/src/main/java/com/team3/monew/repository/SubscriptionRepository.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -40,4 +41,8 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, UUID
   );
 
   void deleteAllByUserId(UUID userId);
+
+  @Modifying
+  @Query("DELETE FROM Subscription s WHERE s.user.id IN :userIds")
+  void deleteByUserIds(List<UUID> userIds);
 }

--- a/src/main/java/com/team3/monew/repository/SubscriptionRepository.java
+++ b/src/main/java/com/team3/monew/repository/SubscriptionRepository.java
@@ -38,4 +38,6 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, UUID
       @Param("userId") UUID userId,
       @Param("interestIds") List<UUID> interestIds
   );
+
+  void deleteAllByUserId(UUID userId);
 }

--- a/src/main/java/com/team3/monew/repository/SubscriptionRepository.java
+++ b/src/main/java/com/team3/monew/repository/SubscriptionRepository.java
@@ -40,9 +40,9 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, UUID
       @Param("interestIds") List<UUID> interestIds
   );
 
-  void deleteAllByUserId(UUID userId);
+  void deleteAllByUserId(@Param("userId") UUID userId);
 
   @Modifying
   @Query("DELETE FROM Subscription s WHERE s.user.id IN :userIds")
-  void deleteByUserIds(List<UUID> userIds);
+  void deleteByUserIds(@Param("userIds") List<UUID> userIds);
 }

--- a/src/main/java/com/team3/monew/repository/UserActivityRepository.java
+++ b/src/main/java/com/team3/monew/repository/UserActivityRepository.java
@@ -19,4 +19,7 @@ public interface UserActivityRepository extends MongoRepository<UserActivityDocu
 
   @Query("{ 'commentLikes.commentId': ?0 }")
   List<UserActivityDocument> findAllByCommentLikesCommentId(UUID commentId);
+
+  @Query("{ 'commentLikes.commentId':  { $in:  ?0}}")
+  List<UserActivityDocument> findAllByCommentLikesCommentIdIn(List<UUID> commentIds);
 }

--- a/src/main/java/com/team3/monew/repository/UserActivityRepository.java
+++ b/src/main/java/com/team3/monew/repository/UserActivityRepository.java
@@ -6,7 +6,7 @@ import java.util.UUID;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 
-public interface UserActivityRepository extends MongoRepository<UserActivityDocument, UUID> {
+public interface UserActivityRepository extends MongoRepository<UserActivityDocument, UUID>, UserActivityRepositoryCustom {
 
   @Query("{ 'articleViews.articleId': ?0 }")
   List<UserActivityDocument> findAllByArticleViewsArticleId(UUID articleId);
@@ -22,4 +22,6 @@ public interface UserActivityRepository extends MongoRepository<UserActivityDocu
 
   @Query("{ 'commentLikes.commentId':  { $in:  ?0}}")
   List<UserActivityDocument> findAllByCommentLikesCommentIdIn(List<UUID> commentIds);
+
+  void deleteByIdIn(List<UUID> ids);
 }

--- a/src/main/java/com/team3/monew/repository/UserActivityRepositoryCustom.java
+++ b/src/main/java/com/team3/monew/repository/UserActivityRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.team3.monew.repository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface UserActivityRepositoryCustom {
+
+  void removeEmbeddedCommentsByUserIds(List<UUID> userIds);
+}

--- a/src/main/java/com/team3/monew/repository/UserRepository.java
+++ b/src/main/java/com/team3/monew/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.team3.monew.repository;
 
 import com.team3.monew.entity.User;
+import com.team3.monew.entity.enums.DeleteStatus;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,5 +11,7 @@ public interface UserRepository extends JpaRepository<User, UUID> {
 
   boolean existsByEmail(String email);
 
-  boolean existsById(UUID userId);
+  boolean existsByIdAndDeleteStatus(UUID id, DeleteStatus deleteStatus);
+
+  Optional<User> findByIdAndDeleteStatus(UUID id, DeleteStatus deleteStatus);
 }

--- a/src/main/java/com/team3/monew/repository/UserRepository.java
+++ b/src/main/java/com/team3/monew/repository/UserRepository.java
@@ -21,23 +21,14 @@ public interface UserRepository extends JpaRepository<User, UUID> {
 
   Optional<User> findByIdAndDeleteStatus(UUID id, DeleteStatus deleteStatus);
 
-  @Modifying
-  @Query(value = """
-        DELETE FROM users
-        WHERE id IN (
-            SELECT id FROM users
-            WHERE delete_status = 'DELETED'
-              AND deleted_at < :targetDate
-            LIMIT :batchSize
-        )
-        """, nativeQuery = true)
-  int deleteSoftDeletedUsers(@Param("targetDate") Instant targetDate,
-      @Param("batchSize") int batchSize);
-
   @Query("""
     SELECT u.id FROM User u
     WHERE u.deleteStatus = 'DELETED'
       AND u.deletedAt < :targetDate
 """)
   List<UUID> findDeletableUserIds(Instant targetDate, Pageable pageable);
+
+  @Modifying
+  @Query("DELETE FROM User u WHERE u.id IN :userIds")
+  int deleteByIds(List<UUID> userIds);
 }

--- a/src/main/java/com/team3/monew/repository/UserRepository.java
+++ b/src/main/java/com/team3/monew/repository/UserRepository.java
@@ -2,9 +2,15 @@ package com.team3.monew.repository;
 
 import com.team3.monew.entity.User;
 import com.team3.monew.entity.enums.DeleteStatus;
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
   Optional<User> findByEmail(String email);
@@ -14,4 +20,24 @@ public interface UserRepository extends JpaRepository<User, UUID> {
   boolean existsByIdAndDeleteStatus(UUID id, DeleteStatus deleteStatus);
 
   Optional<User> findByIdAndDeleteStatus(UUID id, DeleteStatus deleteStatus);
+
+  @Modifying
+  @Query(value = """
+        DELETE FROM users
+        WHERE id IN (
+            SELECT id FROM users
+            WHERE delete_status = 'DELETED'
+              AND deleted_at < :targetDate
+            LIMIT :batchSize
+        )
+        """, nativeQuery = true)
+  int deleteSoftDeletedUsers(@Param("targetDate") Instant targetDate,
+      @Param("batchSize") int batchSize);
+
+  @Query("""
+    SELECT u.id FROM User u
+    WHERE u.deleteStatus = 'DELETED'
+      AND u.deletedAt < :targetDate
+""")
+  List<UUID> findDeletableUserIds(Instant targetDate, Pageable pageable);
 }

--- a/src/main/java/com/team3/monew/repository/UserRepository.java
+++ b/src/main/java/com/team3/monew/repository/UserRepository.java
@@ -23,12 +23,12 @@ public interface UserRepository extends JpaRepository<User, UUID> {
 
   @Query("""
     SELECT u.id FROM User u
-    WHERE u.deleteStatus = 'DELETED'
+    WHERE u.deleteStatus = com.team3.monew.entity.enums.DeleteStatus.DELETED
       AND u.deletedAt < :targetDate
 """)
-  List<UUID> findDeletableUserIds(Instant targetDate, Pageable pageable);
+  List<UUID> findDeletableUserIds(@Param("targetDate") Instant targetDate, Pageable pageable);
 
   @Modifying
   @Query("DELETE FROM User u WHERE u.id IN :userIds")
-  int deleteByIds(List<UUID> userIds);
+  int deleteByIds(@Param("userIds") List<UUID> userIds);
 }

--- a/src/main/java/com/team3/monew/repository/impl/UserActivityRepositoryImpl.java
+++ b/src/main/java/com/team3/monew/repository/impl/UserActivityRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.team3.monew.repository.impl;
+
+import com.team3.monew.repository.UserActivityRepositoryCustom;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserActivityRepositoryImpl implements UserActivityRepositoryCustom {
+
+  private final MongoTemplate mongoTemplate;
+
+  @Override
+  public void removeEmbeddedCommentsByUserIds(List<UUID> userIds) {
+    Query query = new Query(
+        Criteria.where("commentLikes.commentUserId").in(userIds)
+    );
+
+    Update update = new Update().pull(
+        "commentLikes",
+        Query.query(Criteria.where("commentUserId").in(userIds))
+    );
+
+    mongoTemplate.updateMulti(query, update, "user_activities");
+  }
+}

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -9,6 +9,7 @@ import com.team3.monew.dto.pagination.CursorPageResponseDto;
 import com.team3.monew.entity.Interest;
 import com.team3.monew.entity.Subscription;
 import com.team3.monew.entity.User;
+import com.team3.monew.entity.enums.DeleteStatus;
 import com.team3.monew.event.InterestDeletedEvent;
 import com.team3.monew.event.InterestKeywordUpdatedEvent;
 import com.team3.monew.event.SubscriptionCanceledEvent;
@@ -300,7 +301,7 @@ public class InterestService {
   }
 
   private User findUserOrElseThrow(UUID userId) {
-    return userRepository.findById(userId)
+    return userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)
         .orElseThrow(() -> new UserNotFoundException(userId));
   }
 

--- a/src/main/java/com/team3/monew/service/NotificationService.java
+++ b/src/main/java/com/team3/monew/service/NotificationService.java
@@ -7,6 +7,7 @@ import com.team3.monew.dto.pagination.CursorPageResponseDto;
 import com.team3.monew.entity.Comment;
 import com.team3.monew.entity.Notification;
 import com.team3.monew.entity.User;
+import com.team3.monew.entity.enums.DeleteStatus;
 import com.team3.monew.entity.enums.NotificationResourceType;
 import com.team3.monew.exception.comment.CommentNotFoundException;
 import com.team3.monew.exception.notification.NotificationConfirmForbiddenException;
@@ -150,7 +151,7 @@ public class NotificationService {
   }
 
   private void checkUserAvailable(UUID requestUserId) {
-    if (!userRepository.existsById(requestUserId)) {
+    if (!userRepository.existsByIdAndDeleteStatus(requestUserId, DeleteStatus.ACTIVE)) {
       throw new UserNotFoundException(requestUserId);
     }
     log.debug("유효한 사용자 검증 완료");

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -19,10 +19,12 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.dao.TransientDataAccessException;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -135,6 +137,14 @@ public class UserActivityService {
     log.debug("사용자 활동 내역 닉네임 업데이트 성공: userId={}", userId);
   }
 
+  @Retryable(
+      retryFor = {
+          TransientDataAccessException.class,
+          OptimisticLockingFailureException.class
+      },
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 100)
+  )
   public void deleteUserActivity(UUID userId) {
     log.debug("사용자 활동 내역 삭제 시작: userId={}", userId);
     UserActivityDocument document = userActivityRepository.findById(userId)
@@ -345,5 +355,11 @@ public class UserActivityService {
     log.error("댓글 수정 활동 내역 업데이트 최종 실패: interestId={}, keywords={}", interestId, keywords, e);
     throw new UserActivityException(ErrorCode.USER_ACTIVITY_CONFLICT,
         Map.of("interestId", interestId, "keywords", keywords));
+  }
+
+  @Recover
+  public void recoverDeleteUserActivity(Exception e, UUID userId) {
+    log.error("사용자 활동 내역 삭제 최종 실패: userId={}", userId, e);
+    throw new UserActivityConflictException(userId);
   }
 }

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -137,6 +137,21 @@ public class UserActivityService {
 
   public void deleteUserActivity(UUID userId) {
     log.debug("사용자 활동 내역 삭제 시작: userId={}", userId);
+    UserActivityDocument document = userActivityRepository.findById(userId)
+        .orElse(null);
+    if (document == null) {
+      return;
+    }
+    // 다른 사람의 활동 내역 중 좋아요 한 댓글 삭제 반영
+    List<UUID> commentIds = document.getComments().stream()
+        .map(CommentSummary::id)
+        .toList();
+
+    userActivityRepository.findAllByCommentLikesCommentIdIn(commentIds)
+        .forEach(otherDocument -> {
+          commentIds.forEach(otherDocument::removeCommentLikeSummaryByCommentId);
+          userActivityRepository.save(otherDocument);
+        });
     userActivityRepository.deleteById(userId);
     log.debug("사용자 활동 내역 삭제 성공: userId={}", userId);
   }

--- a/src/main/java/com/team3/monew/service/UserService.java
+++ b/src/main/java/com/team3/monew/service/UserService.java
@@ -70,8 +70,7 @@ public class UserService {
     log.debug("사용자 로그인 요청: email={},", userLoginRequest.email());
     User user = userRepository.findByEmail(userLoginRequest.email())
         .orElseThrow(AuthException::new);
-
-    if (!passwordEncoder.matches(userLoginRequest.password(), user.getPassword())) {
+    if (user.isDeleted() || !passwordEncoder.matches(userLoginRequest.password(), user.getPassword())) {
       throw new AuthException();
     }
     log.debug("사용자 로그인 성공: userId={}, email={}", user.getId(), user.getEmail());
@@ -87,6 +86,9 @@ public class UserService {
     User findUser = userRepository.findById(userId)
         .orElseThrow(() -> new UserNotFoundException(userId));
 
+    if (findUser.isDeleted()) {
+      throw new DeletedUserException(userId);
+    }
     Optional.ofNullable(userUpdateRequest.nickname())
         .ifPresent(findUser::updateNickname);
     User updatedUser = userRepository.save(findUser);

--- a/src/main/java/com/team3/monew/service/UserService.java
+++ b/src/main/java/com/team3/monew/service/UserService.java
@@ -5,12 +5,18 @@ import com.team3.monew.dto.user.UserRegisterRequest;
 import com.team3.monew.dto.user.UserDto;
 import com.team3.monew.dto.user.UserUpdateRequest;
 import com.team3.monew.entity.User;
+import com.team3.monew.event.UserDeletedEvent;
 import com.team3.monew.event.UserRegisteredEvent;
 import com.team3.monew.event.UserUpdatedEvent;
 import com.team3.monew.exception.user.AuthException;
+import com.team3.monew.exception.user.DeletedUserException;
 import com.team3.monew.exception.user.DuplicateEmailException;
 import com.team3.monew.exception.user.UserNotFoundException;
 import com.team3.monew.mapper.UserMapper;
+import com.team3.monew.repository.CommentLikeRepository;
+import com.team3.monew.repository.CommentRepository;
+import com.team3.monew.repository.NotificationRepository;
+import com.team3.monew.repository.SubscriptionRepository;
 import com.team3.monew.repository.UserRepository;
 import java.util.Optional;
 import java.util.UUID;
@@ -29,6 +35,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
   private final UserRepository userRepository;
+  private final NotificationRepository notificationRepository;
+  private final CommentLikeRepository commentLikeRepository;
+  private final CommentRepository commentRepository;
+  private final SubscriptionRepository subscriptionRepository;
   private final UserMapper userMapper;
   private final PasswordEncoder passwordEncoder;
   private final ApplicationEventPublisher applicationEventPublisher;
@@ -86,6 +96,34 @@ public class UserService {
         new UserUpdatedEvent(updatedUser.getId(), updatedUser.getNickname())
     );
     return userMapper.toDto(updatedUser);
+  }
+
+  public void deleteUser(UUID userId) {
+    log.debug("사용자 소프트 삭제 시작: userId={}", userId);
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new UserNotFoundException(userId));
+    if (user.isDeleted()) {
+      throw new DeletedUserException(userId);
+    }
+    user.markDeleted();
+    log.debug("사용자 소프트 삭제 성공: userId={}", userId);
+    applicationEventPublisher.publishEvent(new UserDeletedEvent(user.getId()));
+  }
+
+  public void hardDeleteUser(UUID userId) {
+    log.debug("사용자 물리 삭제 시작: userId={}", userId);
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new UserNotFoundException(userId));
+
+    // 연관 객체 삭제
+    notificationRepository.deleteAllByUserId(userId);
+    commentLikeRepository.deleteAllByUserId(userId);
+    commentRepository.deleteAllByUserId(userId);
+    subscriptionRepository.deleteAllByUserId(userId);
+
+    userRepository.delete(user);
+    log.debug("사용자 물리 삭제 성공: userId={}", userId);
+    applicationEventPublisher.publishEvent(new UserDeletedEvent(userId));
   }
 
   private void validateDuplicateEmail(String email) {

--- a/src/main/java/com/team3/monew/service/UserService.java
+++ b/src/main/java/com/team3/monew/service/UserService.java
@@ -110,7 +110,6 @@ public class UserService {
     }
     user.markDeleted();
     log.debug("사용자 소프트 삭제 성공: userId={}", userId);
-    applicationEventPublisher.publishEvent(new UserDeletedEvent(user.getId()));
   }
 
   @Transactional

--- a/src/main/java/com/team3/monew/service/UserService.java
+++ b/src/main/java/com/team3/monew/service/UserService.java
@@ -98,6 +98,7 @@ public class UserService {
     return userMapper.toDto(updatedUser);
   }
 
+  @Transactional
   public void deleteUser(UUID userId) {
     log.debug("사용자 소프트 삭제 시작: userId={}", userId);
     User user = userRepository.findById(userId)
@@ -110,6 +111,7 @@ public class UserService {
     applicationEventPublisher.publishEvent(new UserDeletedEvent(user.getId()));
   }
 
+  @Transactional
   public void hardDeleteUser(UUID userId) {
     log.debug("사용자 물리 삭제 시작: userId={}", userId);
     User user = userRepository.findById(userId)

--- a/src/main/java/com/team3/monew/service/UserService.java
+++ b/src/main/java/com/team3/monew/service/UserService.java
@@ -13,6 +13,7 @@ import com.team3.monew.exception.user.DeletedUserException;
 import com.team3.monew.exception.user.DuplicateEmailException;
 import com.team3.monew.exception.user.UserNotFoundException;
 import com.team3.monew.mapper.UserMapper;
+import com.team3.monew.repository.ArticleViewRepository;
 import com.team3.monew.repository.CommentLikeRepository;
 import com.team3.monew.repository.CommentRepository;
 import com.team3.monew.repository.NotificationRepository;
@@ -39,6 +40,7 @@ public class UserService {
   private final CommentLikeRepository commentLikeRepository;
   private final CommentRepository commentRepository;
   private final SubscriptionRepository subscriptionRepository;
+  private final ArticleViewRepository articleViewRepository;
   private final UserMapper userMapper;
   private final PasswordEncoder passwordEncoder;
   private final ApplicationEventPublisher applicationEventPublisher;
@@ -123,6 +125,7 @@ public class UserService {
     commentLikeRepository.deleteAllByUserId(userId);
     commentRepository.deleteAllByUserId(userId);
     subscriptionRepository.deleteAllByUserId(userId);
+    articleViewRepository.deleteAllByUserId(userId);
 
     userRepository.delete(user);
     log.debug("사용자 물리 삭제 성공: userId={}", userId);

--- a/src/test/java/com/team3/monew/batch/scheduler/UserDeleteSchedulerTest.java
+++ b/src/test/java/com/team3/monew/batch/scheduler/UserDeleteSchedulerTest.java
@@ -1,0 +1,83 @@
+package com.team3.monew.batch.scheduler;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.launch.JobLauncher;
+
+@ExtendWith(MockitoExtension.class)
+class UserDeleteSchedulerTest {
+
+  @Mock
+  private JobLauncher jobLauncher;
+
+  @Mock
+  private Job userDeleteJob;
+
+  @InjectMocks
+  private UserDeleteScheduler scheduler;
+
+  @Test
+  @DisplayName("배치 실행 중 예외가 발생해도 스케줄러는 예외를 잡고 종료한다")
+  void run_ShouldCatchException() throws Exception {
+    // given
+    given(jobLauncher.run(any(Job.class), any(JobParameters.class)))
+        .willThrow(new RuntimeException("배치 실패"));
+
+    // when & then
+    assertDoesNotThrow(() -> scheduler.run());
+
+    then(jobLauncher).should(times(1))
+        .run(eq(userDeleteJob), any(JobParameters.class));
+  }
+
+  @Test
+  @DisplayName("배치 상태가 FAILED여도 스케줄러는 정상 종료된다")
+  void run_WhenStatusFailed() throws Exception {
+    // given
+    JobExecution execution = new JobExecution(1L);
+    execution.setStatus(BatchStatus.FAILED);
+
+    given(jobLauncher.run(any(Job.class), any(JobParameters.class)))
+        .willReturn(execution);
+
+    // when
+    scheduler.run();
+
+    // then
+    then(jobLauncher).should(times(1))
+        .run(eq(userDeleteJob), any(JobParameters.class));
+  }
+
+  @Test
+  @DisplayName("배치 상태가 COMPLETED면 정상 완료 로그 흐름")
+  void run_WhenStatusCompleted() throws Exception {
+    // given
+    JobExecution execution = new JobExecution(1L);
+    execution.setStatus(BatchStatus.COMPLETED);
+
+    given(jobLauncher.run(any(Job.class), any(JobParameters.class)))
+        .willReturn(execution);
+
+    // when
+    scheduler.run();
+
+    // then
+    then(jobLauncher).should(times(1))
+        .run(eq(userDeleteJob), any(JobParameters.class));
+  }
+}

--- a/src/test/java/com/team3/monew/batch/tasklet/UserDeleteTaskletTest.java
+++ b/src/test/java/com/team3/monew/batch/tasklet/UserDeleteTaskletTest.java
@@ -1,0 +1,119 @@
+package com.team3.monew.batch.tasklet;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.team3.monew.repository.CommentLikeRepository;
+import com.team3.monew.repository.CommentRepository;
+import com.team3.monew.repository.NotificationRepository;
+import com.team3.monew.repository.SubscriptionRepository;
+import com.team3.monew.repository.UserActivityRepository;
+import com.team3.monew.repository.UserRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.data.domain.PageRequest;
+
+class UserDeleteTaskletTest {
+
+  @InjectMocks
+  private UserDeleteTasklet tasklet;
+
+  @Mock
+  private UserRepository userRepository;
+  @Mock
+  private NotificationRepository notificationRepository;
+  @Mock
+  private CommentLikeRepository commentLikeRepository;
+  @Mock
+  private CommentRepository commentRepository;
+  @Mock
+  private SubscriptionRepository subscriptionRepository;
+  @Mock
+  private UserActivityRepository userActivityRepository;
+
+  private final Instant targetDate = Instant.now();
+  private final int batchSize = 100;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  @DisplayName("삭제 대상 유저가 있으면 모든 연관 데이터 삭제 후 CONTINUABLE 반환")
+  void execute_WithUsers() {
+    // given
+    List<UUID> userIds = List.of(UUID.randomUUID(), UUID.randomUUID());
+
+    given(userRepository.findDeletableUserIds(any(), any(PageRequest.class)))
+        .willReturn(userIds);
+
+    given(userRepository.deleteSoftDeletedUsers(any(), anyInt()))
+        .willReturn(2);
+
+    // when
+    RepeatStatus status = tasklet.execute(targetDate, batchSize);
+
+    // then
+    then(notificationRepository).should().deleteByUserIds(userIds);
+    then(commentLikeRepository).should().deleteByUserIds(userIds);
+    then(commentRepository).should().deleteByUserIds(userIds);
+    then(subscriptionRepository).should().deleteByUserIds(userIds);
+
+    then(userActivityRepository).should().deleteByIdIn(userIds);
+    then(userActivityRepository).should().removeEmbeddedCommentsByUserIds(userIds);
+
+    then(userRepository).should().deleteSoftDeletedUsers(any(), anyInt());
+
+    assertThat(status).isEqualTo(RepeatStatus.CONTINUABLE);
+  }
+
+  @Test
+  @DisplayName("삭제 대상 유저가 없으면 FINISHED 반환")
+  void execute_NoUsers() {
+    // given
+    given(userRepository.findDeletableUserIds(any(), any()))
+        .willReturn(List.of());
+
+    // when
+    RepeatStatus status = tasklet.execute(targetDate, batchSize);
+
+    // then
+    then(notificationRepository).shouldHaveNoInteractions();
+    then(commentLikeRepository).shouldHaveNoInteractions();
+    then(commentRepository).shouldHaveNoInteractions();
+    then(subscriptionRepository).shouldHaveNoInteractions();
+    then(userActivityRepository).shouldHaveNoInteractions();
+
+    assertThat(status).isEqualTo(RepeatStatus.FINISHED);
+  }
+
+  @Test
+  @DisplayName("삭제 결과가 0이면 FINISHED 반환")
+  void execute_DeleteZero() {
+    // given
+    List<UUID> userIds = List.of(UUID.randomUUID());
+
+    given(userRepository.findDeletableUserIds(any(), any()))
+        .willReturn(userIds);
+
+    given(userRepository.deleteSoftDeletedUsers(any(), anyInt()))
+        .willReturn(0);
+
+    // when
+    RepeatStatus status = tasklet.execute(targetDate, batchSize);
+
+    // then
+    assertThat(status).isEqualTo(RepeatStatus.FINISHED);
+  }
+}

--- a/src/test/java/com/team3/monew/batch/tasklet/UserDeleteTaskletTest.java
+++ b/src/test/java/com/team3/monew/batch/tasklet/UserDeleteTaskletTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
+import com.team3.monew.repository.ArticleViewRepository;
 import com.team3.monew.repository.CommentLikeRepository;
 import com.team3.monew.repository.CommentRepository;
 import com.team3.monew.repository.NotificationRepository;
@@ -40,6 +41,8 @@ class UserDeleteTaskletTest {
   private SubscriptionRepository subscriptionRepository;
   @Mock
   private UserActivityRepository userActivityRepository;
+  @Mock
+  private ArticleViewRepository articleViewRepository;
 
   private final Instant targetDate = Instant.now();
   private final int batchSize = 100;
@@ -69,6 +72,7 @@ class UserDeleteTaskletTest {
     then(commentLikeRepository).should().deleteByUserIds(userIds);
     then(commentRepository).should().deleteByUserIds(userIds);
     then(subscriptionRepository).should().deleteByUserIds(userIds);
+    then(articleViewRepository).should().deleteByUserIds(userIds);
 
     then(userActivityRepository).should().deleteByIdIn(userIds);
     then(userActivityRepository).should().removeEmbeddedCommentsByUserIds(userIds);
@@ -94,6 +98,7 @@ class UserDeleteTaskletTest {
     then(commentRepository).shouldHaveNoInteractions();
     then(subscriptionRepository).shouldHaveNoInteractions();
     then(userActivityRepository).shouldHaveNoInteractions();
+    then(articleViewRepository).shouldHaveNoInteractions();
 
     assertThat(status).isEqualTo(RepeatStatus.FINISHED);
   }

--- a/src/test/java/com/team3/monew/batch/tasklet/UserDeleteTaskletTest.java
+++ b/src/test/java/com/team3/monew/batch/tasklet/UserDeleteTaskletTest.java
@@ -61,7 +61,7 @@ class UserDeleteTaskletTest {
     given(userRepository.findDeletableUserIds(any(), any(PageRequest.class)))
         .willReturn(userIds);
 
-    given(userRepository.deleteSoftDeletedUsers(any(), anyInt()))
+    given(userRepository.deleteByIds(userIds))
         .willReturn(2);
 
     // when
@@ -77,7 +77,7 @@ class UserDeleteTaskletTest {
     then(userActivityRepository).should().deleteByIdIn(userIds);
     then(userActivityRepository).should().removeEmbeddedCommentsByUserIds(userIds);
 
-    then(userRepository).should().deleteSoftDeletedUsers(any(), anyInt());
+    then(userRepository).should().deleteByIds(userIds);
 
     assertThat(status).isEqualTo(RepeatStatus.CONTINUABLE);
   }
@@ -112,7 +112,7 @@ class UserDeleteTaskletTest {
     given(userRepository.findDeletableUserIds(any(), any()))
         .willReturn(userIds);
 
-    given(userRepository.deleteSoftDeletedUsers(any(), anyInt()))
+    given(userRepository.deleteByIds(userIds))
         .willReturn(0);
 
     // when

--- a/src/test/java/com/team3/monew/controller/UserControllerTest.java
+++ b/src/test/java/com/team3/monew/controller/UserControllerTest.java
@@ -314,7 +314,7 @@ class UserControllerTest {
 
     // when & then
     mockMvc.perform(delete("/api/users/{userId}", userId))
-        .andExpect(status().isOk());
+        .andExpect(status().isNoContent());
 
     verify(userService).deleteUser(userId);
   }
@@ -357,7 +357,7 @@ class UserControllerTest {
 
     // when & then
     mockMvc.perform(delete("/api/users/{userId}/hard", userId))
-        .andExpect(status().isOk());
+        .andExpect(status().isNoContent());
 
     verify(userService).hardDeleteUser(userId);
   }

--- a/src/test/java/com/team3/monew/controller/UserControllerTest.java
+++ b/src/test/java/com/team3/monew/controller/UserControllerTest.java
@@ -2,7 +2,11 @@ package com.team3.monew.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -14,7 +18,9 @@ import com.team3.monew.dto.user.UserLoginRequest;
 import com.team3.monew.dto.user.UserRegisterRequest;
 import com.team3.monew.dto.user.UserUpdateRequest;
 import com.team3.monew.exception.user.AuthException;
+import com.team3.monew.exception.user.DeletedUserException;
 import com.team3.monew.exception.user.DuplicateEmailException;
+import com.team3.monew.exception.user.UserNotFoundException;
 import com.team3.monew.global.exception.GlobalExceptionHandler;
 import com.team3.monew.service.UserService;
 import java.time.Instant;
@@ -296,5 +302,77 @@ class UserControllerTest {
             .contentType(APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("논리 삭제 요청이 유효하면 200을 반환한다.")
+  void shouldDeleteUser_whenRequestIsValid() throws Exception {
+    // given
+    UUID userId = UUID.randomUUID();
+
+    willDoNothing().given(userService).deleteUser(userId);
+
+    // when & then
+    mockMvc.perform(delete("/api/users/{userId}", userId))
+        .andExpect(status().isOk());
+
+    verify(userService).deleteUser(userId);
+  }
+
+  @Test
+  @DisplayName("논리 삭제 시 사용자가 없으면 예외가 발생한다.")
+  void shouldThrowException_whenUserNotFoundOnSoftDelete() throws Exception {
+    // given
+    UUID userId = UUID.randomUUID();
+
+    willThrow(new UserNotFoundException(userId))
+        .given(userService).deleteUser(userId);
+
+    // when & then
+    mockMvc.perform(delete("/api/users/{userId}", userId))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("논리 삭제 시 이미 삭제된 사용자면 예외가 발생한다.")
+  void shouldThrowException_whenUserAlreadyDeletedOnSoftDelete() throws Exception {
+    // given
+    UUID userId = UUID.randomUUID();
+
+    willThrow(new DeletedUserException(userId))
+        .given(userService).deleteUser(userId);
+
+    // when & then
+    mockMvc.perform(delete("/api/users/{userId}", userId))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("물리 삭제 요청이 유효하면 200을 반환한다.")
+  void shouldHardDeleteUser_whenRequestIsValid() throws Exception {
+    // given
+    UUID userId = UUID.randomUUID();
+
+    willDoNothing().given(userService).hardDeleteUser(userId);
+
+    // when & then
+    mockMvc.perform(delete("/api/users/{userId}/hard", userId))
+        .andExpect(status().isOk());
+
+    verify(userService).hardDeleteUser(userId);
+  }
+
+  @Test
+  @DisplayName("물리 삭제 시 사용자가 없으면 예외가 발생한다.")
+  void shouldThrowException_whenUserNotFoundOnHardDelete() throws Exception {
+    // given
+    UUID userId = UUID.randomUUID();
+
+    willThrow(new UserNotFoundException(userId))
+        .given(userService).hardDeleteUser(userId);
+
+    // when & then
+    mockMvc.perform(delete("/api/users/{userId}/hard", userId))
+        .andExpect(status().isNotFound());
   }
 }

--- a/src/test/java/com/team3/monew/integration/UserIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/UserIntegrationTest.java
@@ -235,7 +235,7 @@ class UserIntegrationTest extends IntegrationTestSupport {
 
     // when & then
     mockMvc.perform(delete("/api/users/{userId}", savedUser.getId()))
-        .andExpect(status().isOk());
+        .andExpect(status().isNoContent());
 
     User deletedUser = userRepository.findById(savedUser.getId()).orElseThrow();
     assertThat(deletedUser.isDeleted()).isTrue();
@@ -251,7 +251,7 @@ class UserIntegrationTest extends IntegrationTestSupport {
 
     // when & then
     mockMvc.perform(delete("/api/users/{userId}/hard", savedUser.getId()))
-        .andExpect(status().isOk());
+        .andExpect(status().isNoContent());
 
     assertThat(userRepository.findById(savedUser.getId())).isEmpty();
   }

--- a/src/test/java/com/team3/monew/integration/UserIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/UserIntegrationTest.java
@@ -1,6 +1,8 @@
 package com.team3.monew.integration;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -221,5 +223,36 @@ class UserIntegrationTest extends IntegrationTestSupport {
             .contentType(APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("유효한 요청이면 논리 삭제에 성공한다.")
+  void shouldSoftDeleteUser_whenRequestIsValid() throws Exception {
+    // given
+    User savedUser = userRepository.save(
+        User.create("soft-delete@example.com", "nickname", "password123!")
+    );
+
+    // when & then
+    mockMvc.perform(delete("/api/users/{userId}", savedUser.getId()))
+        .andExpect(status().isOk());
+
+    User deletedUser = userRepository.findById(savedUser.getId()).orElseThrow();
+    assertThat(deletedUser.isDeleted()).isTrue();
+  }
+
+  @Test
+  @DisplayName("유효한 요청이면 물리 삭제에 성공한다.")
+  void shouldHardDeleteUser_whenRequestIsValid() throws Exception {
+    // given
+    User savedUser = userRepository.save(
+        User.create("hard-delete@example.com", "nickname", "password123!")
+    );
+
+    // when & then
+    mockMvc.perform(delete("/api/users/{userId}/hard", savedUser.getId()))
+        .andExpect(status().isOk());
+
+    assertThat(userRepository.findById(savedUser.getId())).isEmpty();
   }
 }

--- a/src/test/java/com/team3/monew/service/InterestServiceTest.java
+++ b/src/test/java/com/team3/monew/service/InterestServiceTest.java
@@ -11,6 +11,7 @@ import com.team3.monew.entity.Interest;
 import com.team3.monew.entity.InterestKeyword;
 import com.team3.monew.entity.Subscription;
 import com.team3.monew.entity.User;
+import com.team3.monew.entity.enums.DeleteStatus;
 import com.team3.monew.exception.interest.InterestDuplicateNameException;
 import com.team3.monew.exception.interest.InterestException;
 import com.team3.monew.exception.interest.InterestNotFoundException;
@@ -635,7 +636,7 @@ class InterestServiceTest {
         savedSubscription.getCreatedAt()
     );
 
-    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(Optional.of(user));
     given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
     given(interestRepository.findByIdWithKeywords(interestId)).willReturn(Optional.of(interest));
     given(subscriptionRepository.existsByUserIdAndInterestId(userId, interestId)).willReturn(false);
@@ -650,7 +651,7 @@ class InterestServiceTest {
     assertThat(result.interestName()).isEqualTo("주식");
     assertThat(result.interestSubscriberCount()).isEqualTo(1);
 
-    then(userRepository).should().findById(userId);
+    then(userRepository).should().findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE);
     then(interestRepository).should(times(1)).findById(interestId);
     then(interestRepository).should(times(1)).findByIdWithKeywords(interestId);
     then(subscriptionRepository).should().existsByUserIdAndInterestId(userId, interestId);
@@ -665,7 +666,7 @@ class InterestServiceTest {
     UUID userId = UUID.randomUUID();
     UUID interestId = UUID.randomUUID();
 
-    given(userRepository.findById(userId)).willReturn(Optional.empty());
+    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(Optional.empty());
 
     // when & then
     assertThatThrownBy(() -> interestService.subscribe(userId, interestId))
@@ -686,7 +687,7 @@ class InterestServiceTest {
 
     User user = User.create("test@example.com", "password", "tester");
 
-    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(Optional.of(user));
     given(interestRepository.findById(interestId)).willReturn(Optional.empty());
 
     // when & then
@@ -708,7 +709,7 @@ class InterestServiceTest {
     User user = User.create("test@example.com", "password", "tester");
     Interest interest = Interest.create("주식");
 
-    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(Optional.of(user));
     given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
     given(subscriptionRepository.existsByUserIdAndInterestId(userId, interestId)).willReturn(true);
 
@@ -731,7 +732,7 @@ class InterestServiceTest {
     User user = User.create("test@example.com", "password", "tester");
     Interest interest = Interest.create("주식");
 
-    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(Optional.of(user));
     given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
     given(subscriptionRepository.existsByUserIdAndInterestId(userId, interestId)).willReturn(false);
 
@@ -752,7 +753,7 @@ class InterestServiceTest {
           assertThat(e.getMessage()).isEqualTo(ErrorCode.INTEREST_ALREADY_SUBSCRIBING.getMessage());
         });
 
-    then(userRepository).should().findById(userId);
+    then(userRepository).should().findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE);
     then(interestRepository).should().findById(interestId);
     then(subscriptionRepository).should().existsByUserIdAndInterestId(userId, interestId);
     then(subscriptionRepository).should().save(any(Subscription.class));
@@ -771,7 +772,7 @@ class InterestServiceTest {
     Interest interest = mock(Interest.class);
     Subscription subscription = mock(Subscription.class);
 
-    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(Optional.of(user));
     given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
     given(subscriptionRepository.findByUserIdAndInterestId(userId, interestId))
         .willReturn(Optional.of(subscription));
@@ -791,7 +792,7 @@ class InterestServiceTest {
     UUID userId = UUID.randomUUID();
     UUID interestId = UUID.randomUUID();
 
-    given(userRepository.findById(userId)).willReturn(Optional.empty());
+    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(Optional.empty());
 
     // when & then
     assertThatThrownBy(() -> interestService.cancelSubscribe(userId, interestId))
@@ -812,7 +813,7 @@ class InterestServiceTest {
 
     User user = mock(User.class);
 
-    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(Optional.of(user));
     given(interestRepository.findById(interestId)).willReturn(Optional.empty());
 
     // when & then
@@ -834,7 +835,7 @@ class InterestServiceTest {
     User user = mock(User.class);
     Interest interest = mock(Interest.class);
 
-    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(Optional.of(user));
     given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
     given(subscriptionRepository.findByUserIdAndInterestId(userId, interestId))
         .willReturn(Optional.empty());

--- a/src/test/java/com/team3/monew/service/NotificationServiceTest.java
+++ b/src/test/java/com/team3/monew/service/NotificationServiceTest.java
@@ -19,6 +19,7 @@ import com.team3.monew.entity.Comment;
 import com.team3.monew.entity.NewsArticle;
 import com.team3.monew.entity.Notification;
 import com.team3.monew.entity.User;
+import com.team3.monew.entity.enums.DeleteStatus;
 import com.team3.monew.entity.enums.NotificationResourceType;
 import com.team3.monew.exception.comment.CommentNotFoundException;
 import com.team3.monew.exception.notification.NotificationConfirmForbiddenException;
@@ -418,7 +419,7 @@ class NotificationServiceTest {
   @DisplayName("사용자 아이디가 존재하지 않을 때 알림 확인 상태 변경에 실패한다.")
   void shouldFailToConfirmNotification_whenUserNotFound() {
     // given
-    given(userRepository.existsById(userId1))
+    given(userRepository.existsByIdAndDeleteStatus(userId1, DeleteStatus.ACTIVE))
         .willReturn(false);
 
     // when & then
@@ -431,7 +432,7 @@ class NotificationServiceTest {
   @DisplayName("알림이 존재하지 않을 때 알림 확인 상태 변경에 실패한다.")
   void shouldFailToConfirmNotification_whenNotificationNotFound() {
     // given
-    given(userRepository.existsById(userId1)).willReturn(true);
+    given(userRepository.existsByIdAndDeleteStatus(userId1, DeleteStatus.ACTIVE)).willReturn(true);
     given(notificationRepository.findById(likeNotification1.getId()))
         .willReturn(Optional.empty());
 
@@ -445,7 +446,7 @@ class NotificationServiceTest {
   @DisplayName("알림이 존재하지만 권한이 없는 사용자 일때, 알림 확인 상태 변경에 실패한다.")
   void shouldFailToConfirmNotification_whenUnAuthorized() {
     // given
-    given(userRepository.existsById(userId2)).willReturn(true);
+    given(userRepository.existsByIdAndDeleteStatus(userId2, DeleteStatus.ACTIVE)).willReturn(true);
     given(notificationRepository.findById(likeNotification1.getId()))
         .willReturn(Optional.of(likeNotification1));
 
@@ -459,7 +460,7 @@ class NotificationServiceTest {
   @DisplayName("사용자 아이디와 알림 아이디로 미확인 알림의 확인 상태 변경에 성공한다.")
   void shouldConfirmNotification() {
     // given
-    given(userRepository.existsById(userId1)).willReturn(true);
+    given(userRepository.existsByIdAndDeleteStatus(userId1, DeleteStatus.ACTIVE)).willReturn(true);
     given(notificationRepository.findById(likeNotification1.getId()))
         .willReturn(Optional.of(likeNotification1));
 
@@ -477,7 +478,7 @@ class NotificationServiceTest {
     ReflectionTestUtils.setField(likeNotification1, "confirmedAt",
         Instant.parse("2026-03-01T12:00:00Z"));
 
-    given(userRepository.existsById(userId1)).willReturn(true);
+    given(userRepository.existsByIdAndDeleteStatus(userId1, DeleteStatus.ACTIVE)).willReturn(true);
     given(notificationRepository.findById(likeNotification1.getId()))
         .willReturn(Optional.of(likeNotification1));
 
@@ -493,7 +494,7 @@ class NotificationServiceTest {
   @DisplayName("사용자 아이디가 존재하지 않을 때 전체 알림 확인 상태 변경에 실패한다.")
   void shouldFailToConfirmAllNotifications_whenUserNotFound() {
     // given
-    given(userRepository.existsById(userId1))
+    given(userRepository.existsByIdAndDeleteStatus(userId1, DeleteStatus.ACTIVE))
         .willReturn(false);
 
     // when & then
@@ -508,7 +509,7 @@ class NotificationServiceTest {
   @DisplayName("유효한 사용자 아이디로 전체 미확인 알림의 확인 상태 변경에 성공한다.")
   void shouldConfirmAllNotifications() {
     // given
-    given(userRepository.existsById(userId1)).willReturn(true);
+    given(userRepository.existsByIdAndDeleteStatus(userId1, DeleteStatus.ACTIVE)).willReturn(true);
     given(notificationRepository.confirmAllByUserId(eq(userId1), any(Instant.class)))
         .willReturn(4);//4개 알림 확인 상태로 변경
 
@@ -516,7 +517,7 @@ class NotificationServiceTest {
     notificationService.confirmAll(userId1);
 
     //then
-    then(userRepository).should(times(1)).existsById(userId1);
+    then(userRepository).should(times(1)).existsByIdAndDeleteStatus(userId1, DeleteStatus.ACTIVE);
     then(notificationRepository).should(times(1))
         .confirmAllByUserId(eq(userId1), any(Instant.class));
   }

--- a/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
+++ b/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
@@ -468,17 +468,6 @@ class UserActivityServiceTest {
   }
 
   @Test
-  @DisplayName("사용자 삭제 이벤트 처리 시 활동 내역 문서 삭제에 성공합니다.")
-  void shouldDeleteUserActivity() {
-    // given
-    // when
-    userActivityService.deleteUserActivity(userId);
-
-    // then
-    then(userActivityRepository).should().deleteById(userId);
-  }
-
-  @Test
   @DisplayName("사용자 닉네임 수정 시 활동 내역 문서 닉네임 업데이트에 성공합니다.")
   void shouldUpdateUserNickname() {
     // given

--- a/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
+++ b/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
@@ -1085,4 +1085,71 @@ class UserActivityServiceTest {
         assertEquals(keywords, savedDocument.getSubscriptions().get(0).interestKeywords())
     );
   }
+
+  @Test
+  @DisplayName("사용자 삭제 시 해당 사용자의 댓글에 다른 사람이 좋아요한 활동 내역도 함께 삭제됩니다.")
+  void shouldRemoveOtherUserCommentLikeSummary_whenUserActivityDeleted() {
+    // given
+    UUID otherUserId = UUID.randomUUID();
+    UUID commentId = UUID.randomUUID();
+
+    UserActivityDocument userActivityDocument = UserActivityDocument.create(
+        userId,
+        "test@test.com",
+        "tester",
+        createdAt
+    );
+
+    CommentSummary commentSummary = new CommentSummary(
+        commentId,
+        UUID.randomUUID(),
+        "기사 제목",
+        userId,
+        "tester",
+        "댓글 내용",
+        0,
+        createdAt
+    );
+
+    UserActivityDocument otherUserActivityDocument = UserActivityDocument.create(
+        otherUserId,
+        "other@test.com",
+        "otherTester",
+        createdAt
+    );
+
+    CommentLikeSummary commentLikeSummary = new CommentLikeSummary(
+        UUID.randomUUID(),
+        createdAt,
+        commentId,
+        UUID.randomUUID(),
+        "기사 제목",
+        userId,
+        "tester",
+        "댓글 내용",
+        1,
+        createdAt
+    );
+
+    userActivityDocument.addCommentSummary(commentSummary);
+    otherUserActivityDocument.addCommentLikeSummary(commentLikeSummary);
+
+    given(userActivityRepository.findById(userId))
+        .willReturn(Optional.of(userActivityDocument));
+    given(userActivityRepository.findAllByCommentLikesCommentIdIn(List.of(commentId)))
+        .willReturn(List.of(otherUserActivityDocument));
+
+    // when
+    userActivityService.deleteUserActivity(userId);
+
+    // then
+    ArgumentCaptor<UserActivityDocument> documentCaptor =
+        ArgumentCaptor.forClass(UserActivityDocument.class);
+
+    then(userActivityRepository).should().save(documentCaptor.capture());
+    then(userActivityRepository).should().deleteById(userId);
+
+    UserActivityDocument savedDocument = documentCaptor.getValue();
+    assertEquals(0, savedDocument.getCommentLikes().size());
+  }
 }

--- a/src/test/java/com/team3/monew/service/UserServiceTest.java
+++ b/src/test/java/com/team3/monew/service/UserServiceTest.java
@@ -22,6 +22,7 @@ import com.team3.monew.exception.user.InvalidNicknameException;
 import com.team3.monew.exception.user.UserNotFoundException;
 import com.team3.monew.global.enums.ErrorCode;
 import com.team3.monew.mapper.UserMapper;
+import com.team3.monew.repository.ArticleViewRepository;
 import com.team3.monew.repository.CommentLikeRepository;
 import com.team3.monew.repository.CommentRepository;
 import com.team3.monew.repository.NotificationRepository;
@@ -55,6 +56,8 @@ class UserServiceTest {
   private CommentRepository commentRepository;
   @Mock
   private SubscriptionRepository subscriptionRepository;
+  @Mock
+  private ArticleViewRepository articleViewRepository;
   @Mock
   private UserMapper userMapper;
   @Mock
@@ -258,7 +261,6 @@ class UserServiceTest {
 
     // given
     User user = mock(User.class);
-    given(user.getId()).willReturn(userId);
     given(user.isDeleted()).willReturn(false);
     given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
@@ -267,7 +269,6 @@ class UserServiceTest {
 
     // then
     verify(user).markDeleted();
-    verify(eventPublisher).publishEvent(any(UserDeletedEvent.class));
   }
 
   @Test
@@ -285,7 +286,6 @@ class UserServiceTest {
         .isInstanceOf(DeletedUserException.class);
 
     verify(user, never()).markDeleted();
-    verify(eventPublisher, never()).publishEvent(any(UserDeletedEvent.class));
   }
 
   @Test
@@ -299,8 +299,6 @@ class UserServiceTest {
     // when & then
     assertThatThrownBy(() -> userService.deleteUser(userId))
         .isInstanceOf(UserNotFoundException.class);
-
-    verify(eventPublisher, never()).publishEvent(any(UserDeletedEvent.class));
   }
 
   @Test
@@ -320,6 +318,7 @@ class UserServiceTest {
     verify(commentLikeRepository).deleteAllByUserId(userId);
     verify(commentRepository).deleteAllByUserId(userId);
     verify(subscriptionRepository).deleteAllByUserId(userId);
+    verify(articleViewRepository).deleteAllByUserId(userId);
     verify(userRepository).delete(user);
     verify(eventPublisher).publishEvent(any(UserDeletedEvent.class));
   }
@@ -340,6 +339,7 @@ class UserServiceTest {
     verify(commentLikeRepository, never()).deleteAllByUserId(any());
     verify(commentRepository, never()).deleteAllByUserId(any());
     verify(subscriptionRepository, never()).deleteAllByUserId(any());
+    verify(articleViewRepository, never()).deleteAllByUserId(any());
     verify(userRepository, never()).delete(any());
     verify(eventPublisher, never()).publishEvent(any(UserDeletedEvent.class));
   }

--- a/src/test/java/com/team3/monew/service/UserServiceTest.java
+++ b/src/test/java/com/team3/monew/service/UserServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -12,13 +13,19 @@ import com.team3.monew.dto.user.UserLoginRequest;
 import com.team3.monew.dto.user.UserRegisterRequest;
 import com.team3.monew.dto.user.UserUpdateRequest;
 import com.team3.monew.entity.User;
+import com.team3.monew.event.UserDeletedEvent;
 import com.team3.monew.event.UserRegisteredEvent;
 import com.team3.monew.exception.user.AuthException;
+import com.team3.monew.exception.user.DeletedUserException;
 import com.team3.monew.exception.user.DuplicateEmailException;
 import com.team3.monew.exception.user.InvalidNicknameException;
 import com.team3.monew.exception.user.UserNotFoundException;
 import com.team3.monew.global.enums.ErrorCode;
 import com.team3.monew.mapper.UserMapper;
+import com.team3.monew.repository.CommentLikeRepository;
+import com.team3.monew.repository.CommentRepository;
+import com.team3.monew.repository.NotificationRepository;
+import com.team3.monew.repository.SubscriptionRepository;
 import com.team3.monew.repository.UserRepository;
 import java.time.Instant;
 import java.util.Optional;
@@ -40,6 +47,14 @@ class UserServiceTest {
 
   @Mock
   private UserRepository userRepository;
+  @Mock
+  private NotificationRepository notificationRepository;
+  @Mock
+  private CommentLikeRepository commentLikeRepository;
+  @Mock
+  private CommentRepository commentRepository;
+  @Mock
+  private SubscriptionRepository subscriptionRepository;
   @Mock
   private UserMapper userMapper;
   @Mock
@@ -234,5 +249,139 @@ class UserServiceTest {
     verify(userRepository).findById(userId);
     verify(userRepository).save(user);
     verify(userMapper).toDto(user);
+  }
+
+  @Test
+  @DisplayName("사용자 논리 삭제에 성공합니다.")
+  void shouldSoftDeleteUser() {
+    UUID userId = UUID.randomUUID();
+
+    // given
+    User user = mock(User.class);
+    given(user.getId()).willReturn(userId);
+    given(user.isDeleted()).willReturn(false);
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+    // when
+    userService.deleteUser(userId);
+
+    // then
+    verify(user).markDeleted();
+    verify(eventPublisher).publishEvent(any(UserDeletedEvent.class));
+  }
+
+  @Test
+  @DisplayName("사용자 논리 삭제 시 이미 삭제된 사용자면 예외가 발생합니다.")
+  void shouldThrowExceptionWhenUserAlreadyDeleted() {
+    UUID userId = UUID.randomUUID();
+
+    // given
+    User user = mock(User.class);
+    given(user.isDeleted()).willReturn(true);
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+    // when & then
+    assertThatThrownBy(() -> userService.deleteUser(userId))
+        .isInstanceOf(DeletedUserException.class);
+
+    verify(user, never()).markDeleted();
+    verify(eventPublisher, never()).publishEvent(any(UserDeletedEvent.class));
+  }
+
+  @Test
+  @DisplayName("사용자 논리 삭제 시 사용자가 없으면 예외가 발생합니다.")
+  void shouldThrowExceptionWhenUserNotFoundOnSoftDelete() {
+    UUID userId = UUID.randomUUID();
+
+    // given
+    given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> userService.deleteUser(userId))
+        .isInstanceOf(UserNotFoundException.class);
+
+    verify(eventPublisher, never()).publishEvent(any(UserDeletedEvent.class));
+  }
+
+  @Test
+  @DisplayName("사용자 물리 삭제에 성공합니다.")
+  void shouldHardDeleteUser() {
+    UUID userId = UUID.randomUUID();
+
+    // given
+    User user = mock(User.class);
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+    // when
+    userService.hardDeleteUser(userId);
+
+    // then
+    verify(notificationRepository).deleteAllByUserId(userId);
+    verify(commentLikeRepository).deleteAllByUserId(userId);
+    verify(commentRepository).deleteAllByUserId(userId);
+    verify(subscriptionRepository).deleteAllByUserId(userId);
+    verify(userRepository).delete(user);
+    verify(eventPublisher).publishEvent(any(UserDeletedEvent.class));
+  }
+
+  @Test
+  @DisplayName("사용자 물리 삭제 시 사용자가 없으면 예외가 발생합니다.")
+  void shouldThrowExceptionWhenUserNotFoundOnHardDelete() {
+    UUID userId = UUID.randomUUID();
+
+    // given
+    given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> userService.hardDeleteUser(userId))
+        .isInstanceOf(UserNotFoundException.class);
+
+    verify(notificationRepository, never()).deleteAllByUserId(any());
+    verify(commentLikeRepository, never()).deleteAllByUserId(any());
+    verify(commentRepository, never()).deleteAllByUserId(any());
+    verify(subscriptionRepository, never()).deleteAllByUserId(any());
+    verify(userRepository, never()).delete(any());
+    verify(eventPublisher, never()).publishEvent(any(UserDeletedEvent.class));
+  }
+
+  @Test
+  @DisplayName("논리 삭제된 사용자는 로그인 시 예외가 발생합니다.")
+  void shouldThrowExceptionWhenDeletedUserLogin() {
+    // given
+    String email = "email1@naver.com";
+    String rawPassword = "rawPassword";
+    String encodedPassword = "encoded-password";
+
+    User user = mock(User.class);
+    given(user.isDeleted()).willReturn(true);
+    given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+
+    UserLoginRequest request = new UserLoginRequest(email, rawPassword);
+
+    // when & then
+    assertThatThrownBy(() -> userService.loginUser(request))
+        .isInstanceOf(AuthException.class);
+
+    verify(passwordEncoder, never()).matches(any(), any());
+    verify(userMapper, never()).toDto(any());
+  }
+
+  @Test
+  @DisplayName("논리 삭제된 사용자는 수정 시 예외가 발생합니다.")
+  void shouldThrowExceptionWhenDeletedUserUpdate() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UserUpdateRequest request = new UserUpdateRequest("newname");
+
+    User user = mock(User.class);
+    given(user.isDeleted()).willReturn(true);
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+    // when & then
+    assertThatThrownBy(() -> userService.updateUser(userId, request))
+        .isInstanceOf(DeletedUserException.class);
+
+    verify(userRepository, never()).save(any());
+    verify(userMapper, never()).toDto(any());
   }
 }


### PR DESCRIPTION
<<제목은 커밋과 동일하게>>>

## 관련 이슈
- closes #42 

## 작업 내용
- 도메인 상태 및 레포지토리 메서드 추가 #142 
- 서비스 로직 구현 #143 
- 컨트롤러 구현 #144 
- 관련 로직 추가(조회, 수정 등 논리 삭제 상태 검증) #145 
- 배치 삭제 기능 추가
- 테스트 #146 , #147 

## 변경 사항
- 연관 삭제를 위해 관심사, 댓글, 좋아요, 알림, 기사 뷰에 deleteAllByUserId 추가
- 배치 삭제 시 연관 삭제를 위한 deleteByIdIn(List<UUID> userIds) 각각 추가
- 기존 관심사, 알림에 사용자 조회시 논리 삭제 여부 체크 추가
- 기존 활동 내역에서 사용자 삭제 시 연관 객체 삭제 안되던 문제 수정
- 기존 사용자 로그인, 수정, 가입에 논리 삭제 여부 체크 추가

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- MongoTemplate는 사용자 삭제 시 해당 사용자가 쓴 댓글에 다른 사람이 좋아요를 누른 기록을 지우기 위해 사용했습니다.
- 현재 같은 기사를 여러 사람이 볼때 다른 사람의 활동 내역에 증가한 조회수가 반영안되는 문제가 있는데 이거는 따로 fix로 처리하겠습니다.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

## 새로운 기능
* 사용자 계정 삭제 기능 추가 (논리적 삭제 및 물리적 삭제)
* 삭제된 사용자의 관련 데이터 자동 정리 (알림, 댓글, 구독 정보 등)
* 비활성 사용자에 대한 자동 배치 삭제 작업 추가 (일일 스케줄)

## 테스트
* 사용자 삭제 기능에 대한 단위 및 통합 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->