### PR TITLE
fix: 관심사 목록 조회 커서 오류

### DIFF
--- a/src/main/java/com/team3/monew/controller/InterestController.java
+++ b/src/main/java/com/team3/monew/controller/InterestController.java
@@ -61,16 +61,11 @@ public class InterestController implements InterestApi {
       Instant after,
       int limit
   ) {
-    InterestCursor interestCursor =
-        (cursor == null || after == null)
-            ? new InterestCursor(null, null)
-            : new InterestCursor(cursor, after);
-
     InterestSearchCondition condition = new InterestSearchCondition(
         keyword,
         orderBy,
         direction,
-        interestCursor,
+        new InterestCursor(cursor, after),
         limit
     );
 

--- a/src/main/java/com/team3/monew/global/enums/ErrorCode.java
+++ b/src/main/java/com/team3/monew/global/enums/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
   INTEREST_KEYWORD_DUPLICATED(HttpStatus.BAD_REQUEST, "중복된 관심사 키워드가 존재합니다."),
   INTEREST_ALREADY_SUBSCRIBING(HttpStatus.CONFLICT, "이미 구독중인 관심사입니다."),
   INTEREST_NOT_SUBSCRIBING(HttpStatus.BAD_REQUEST, "구독하지 않은 관심사입니다."),
+  INVALID_CURSOR_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 cursor 형식입니다."),
 
   // NOTIFICATION
   NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 알림입니다."),

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -324,20 +324,26 @@ public class InterestService {
     String cursor = condition.cursor().cursor();
     Instant after = condition.cursor().after();
 
-    if (cursor == null || cursor.isBlank() || after != null) {
+    if (cursor == null || cursor.isBlank()) {
       return condition;
     }
 
-    String[] parts = cursor.split(CURSOR_DELIMITER, 2);
-    if (parts.length != 2) {
+    // after가 없이도 cursor 파싱 가능하게 수정
+    int delimiterIndex = cursor.lastIndexOf(CURSOR_DELIMITER);
+    if (delimiterIndex < 0) {
       return condition;
     }
+
+    String cursorValue = cursor.substring(0, delimiterIndex);
+    Instant parsedAfter = Instant.parse(
+        cursor.substring(delimiterIndex + CURSOR_DELIMITER.length())
+    );
 
     return new InterestSearchCondition(
         condition.keyword(),
         condition.orderBy(),
         condition.direction(),
-        new InterestCursor(parts[0], Instant.parse(parts[1])),
+        new InterestCursor(cursorValue, after != null ? after : parsedAfter),
         condition.limit()
     );
   }

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -4,6 +4,7 @@ import com.team3.monew.dto.interest.InterestDto;
 import com.team3.monew.dto.interest.InterestRegisterRequest;
 import com.team3.monew.dto.interest.InterestUpdateRequest;
 import com.team3.monew.dto.interest.SubscriptionDto;
+import com.team3.monew.dto.interest.internal.InterestCursor;
 import com.team3.monew.dto.interest.internal.InterestSearchCondition;
 import com.team3.monew.dto.pagination.CursorPageResponseDto;
 import com.team3.monew.entity.Interest;
@@ -66,6 +67,8 @@ public class InterestService {
       'ㅄ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'
   };
 
+  private static final String CURSOR_DELIMITER = ", ";
+
   public InterestDto createInterest(InterestRegisterRequest dto) {
     log.debug("관심사 등록 요청 - name={}, keywordCount={}",
         dto.name(), dto.keywords().size());
@@ -105,35 +108,40 @@ public class InterestService {
   }
 
   @Transactional(readOnly = true)
-  public CursorPageResponseDto<InterestDto> findAll(InterestSearchCondition condition,
-      UUID userId) {
+  public CursorPageResponseDto<InterestDto> findAll(
+      InterestSearchCondition condition,
+      UUID userId
+  ) {
+    InterestSearchCondition normalizedCondition = normalizeCursor(condition);
+
     log.debug(
         "관심사 목록 조회 요청 - userId={}, keyword={}, orderBy={}, direction={}, cursor={}, after={}, limit={}",
         userId,
-        condition.keyword(),
-        condition.orderBy(),
-        condition.direction(),
-        condition.cursor() == null ? null : condition.cursor().cursor(),
-        condition.cursor() == null ? null : condition.cursor().after(),
-        condition.limit());
+        normalizedCondition.keyword(),
+        normalizedCondition.orderBy(),
+        normalizedCondition.direction(),
+        normalizedCondition.cursor() == null ? null : normalizedCondition.cursor().cursor(),
+        normalizedCondition.cursor() == null ? null : normalizedCondition.cursor().after(),
+        normalizedCondition.limit()
+    );
 
-    List<Interest> result = interestRepository.searchByCondition(condition);
-    boolean hasNext = result.size() > condition.limit();
+    List<Interest> result = interestRepository.searchByCondition(normalizedCondition);
+    boolean hasNext = result.size() > normalizedCondition.limit();
     List<Interest> content = hasNext
-        ? result.subList(0, condition.limit())
+        ? result.subList(0, normalizedCondition.limit())
         : result;
 
-    long totalElements = interestRepository.countByCondition(condition);
+    long totalElements = interestRepository.countByCondition(normalizedCondition);
 
     if (content.isEmpty()) {
       log.debug("관심사 목록 조회 결과 없음 - userId={}, keyword={}, totalElements=0",
-          userId, condition.keyword());
+          userId, normalizedCondition.keyword());
 
-      return new CursorPageResponseDto<InterestDto>(
+      return new CursorPageResponseDto<>(
           List.of(),
           null,
           null,
-          condition.limit(),
+          normalizedCondition.limit(),
           totalElements,
           false
       );
@@ -145,13 +153,12 @@ public class InterestService {
     if (hasNext) {
       Interest last = content.get(content.size() - 1);
 
-      if ("subscriberCount".equals(condition.orderBy())) {
-        nextCursor = String.valueOf(last.getSubscriberCount());
-      } else {
-        nextCursor = last.getName();
-      }
+      String cursorValue = "subscriberCount".equals(normalizedCondition.orderBy())
+          ? String.valueOf(last.getSubscriberCount())
+          : last.getName();
 
       nextAfter = last.getCreatedAt();
+      nextCursor = cursorValue + CURSOR_DELIMITER + nextAfter;
     }
 
     List<UUID> interestIds = content.stream()
@@ -172,11 +179,11 @@ public class InterestService {
         "관심사 목록 조회 성공 - userId={}, contentSize={}, totalElements={}, hasNext={}, nextCursor={}, nextAfter={}",
         userId, dtoList.size(), totalElements, hasNext, nextCursor, nextAfter);
 
-    return new CursorPageResponseDto<InterestDto>(
+    return new CursorPageResponseDto<>(
         dtoList,
         nextCursor,
         nextAfter,
-        condition.limit(),
+        normalizedCondition.limit(),
         totalElements,
         hasNext
     );
@@ -307,6 +314,32 @@ public class InterestService {
 
   private record SimilarityResult(boolean similar, double similarity) {
 
+  }
+
+  private InterestSearchCondition normalizeCursor(InterestSearchCondition condition) {
+    if (condition.cursor() == null) {
+      return condition;
+    }
+
+    String cursor = condition.cursor().cursor();
+    Instant after = condition.cursor().after();
+
+    if (cursor == null || cursor.isBlank() || after != null) {
+      return condition;
+    }
+
+    String[] parts = cursor.split(CURSOR_DELIMITER, 2);
+    if (parts.length != 2) {
+      return condition;
+    }
+
+    return new InterestSearchCondition(
+        condition.keyword(),
+        condition.orderBy(),
+        condition.direction(),
+        new InterestCursor(parts[0], Instant.parse(parts[1])),
+        condition.limit()
+    );
   }
 
   // 유니크 제약 위반 검증

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -25,6 +25,7 @@ import com.team3.monew.repository.InterestRepository;
 import com.team3.monew.repository.SubscriptionRepository;
 import com.team3.monew.repository.UserRepository;
 import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.Objects;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -328,16 +329,32 @@ public class InterestService {
       return condition;
     }
 
-    // after가 없이도 cursor 파싱 가능하게 수정
     int delimiterIndex = cursor.lastIndexOf(CURSOR_DELIMITER);
     if (delimiterIndex < 0) {
       return condition;
     }
 
     String cursorValue = cursor.substring(0, delimiterIndex);
-    Instant parsedAfter = Instant.parse(
-        cursor.substring(delimiterIndex + CURSOR_DELIMITER.length())
-    );
+
+    Instant parsedAfter;
+    try {
+      parsedAfter = Instant.parse(
+          cursor.substring(delimiterIndex + CURSOR_DELIMITER.length())
+      );
+    } catch (DateTimeParseException e) {
+      // after가 있는 경우 → cursor는 name 그대로 사용
+      if (after != null) {
+        return new InterestSearchCondition(
+            condition.keyword(),
+            condition.orderBy(),
+            condition.direction(),
+            new InterestCursor(cursor, after),
+            condition.limit()
+        );
+      }
+      // after도 없으면 → 잘못된 요청 → 400
+      throw new InterestException(ErrorCode.INVALID_CURSOR_FORMAT);
+    }
 
     return new InterestSearchCondition(
         condition.keyword(),

--- a/src/main/java/com/team3/monew/service/InterestService.java
+++ b/src/main/java/com/team3/monew/service/InterestService.java
@@ -335,6 +335,11 @@ public class InterestService {
     }
 
     String cursorValue = cursor.substring(0, delimiterIndex);
+    if (cursorValue.isBlank()
+        || ("subscriberCount".equals(condition.orderBy())
+        && !cursorValue.matches("-?\\d+"))) {
+      throw new InterestException(ErrorCode.INVALID_CURSOR_FORMAT);
+    }
 
     Instant parsedAfter;
     try {

--- a/src/test/java/com/team3/monew/controller/InterestControllerTest.java
+++ b/src/test/java/com/team3/monew/controller/InterestControllerTest.java
@@ -252,7 +252,7 @@ class InterestControllerTest {
 
     CursorPageResponseDto<InterestDto> response = new CursorPageResponseDto<InterestDto>(
         List.of(first, second),
-        "나무",
+        "나무, " + after,
         after,
         2,
         5L,
@@ -282,10 +282,52 @@ class InterestControllerTest {
         .andExpect(jsonPath("$.content[0].subscribedByMe").value(true))
         .andExpect(jsonPath("$.content[1].name").value("나무"))
         .andExpect(jsonPath("$.content[1].subscribedByMe").value(false))
-        .andExpect(jsonPath("$.nextCursor").value("나무"))
+        .andExpect(jsonPath("$.nextCursor").value("나무, " + after))
         .andExpect(jsonPath("$.nextAfter").value(after.toString()))
         .andExpect(jsonPath("$.size").value(2))
         .andExpect(jsonPath("$.totalElements").value(5))
+        .andExpect(jsonPath("$.hasNext").value(true));
+
+    then(interestService).should().findAll(condition, userId);
+  }
+
+  @Test
+  @DisplayName("after 없이 cursor 값만으로 관심사 다음 페이지 조회 요청을 보낼 수 있다")
+  void shouldFindNextPage_whenOnlyCursorIsGiven() throws Exception {
+    // given
+    UUID userId = UUID.randomUUID();
+    Instant after = Instant.parse("2026-04-22T10:00:00Z");
+    String combinedCursor = "나무, " + after;
+
+    CursorPageResponseDto<InterestDto> response = new CursorPageResponseDto<>(
+        List.of(),
+        "다리, " + after,
+        after,
+        2,
+        5L,
+        true
+    );
+
+    InterestSearchCondition condition = new InterestSearchCondition(
+        null,
+        "name",
+        "ASC",
+        new InterestCursor(combinedCursor, null),
+        2
+    );
+
+    given(interestService.findAll(condition, userId)).willReturn(response);
+
+    // when & then
+    mockMvc.perform(get("/api/interests")
+            .header(REQUEST_USER_HEADER, userId.toString())
+            .param("orderBy", "name")
+            .param("direction", "ASC")
+            .param("cursor", combinedCursor)
+            .param("limit", "2"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.nextCursor").value("다리, " + after))
+        .andExpect(jsonPath("$.nextAfter").value(after.toString()))
         .andExpect(jsonPath("$.hasNext").value(true));
 
     then(interestService).should().findAll(condition, userId);
@@ -342,7 +384,7 @@ class InterestControllerTest {
 
     CursorPageResponseDto<InterestDto> response = new CursorPageResponseDto<InterestDto>(
         List.of(),
-        "다리",
+        "다리, " + after,
         after,
         2,
         5L,
@@ -368,7 +410,7 @@ class InterestControllerTest {
             .param("after", after.toString())
             .param("limit", "2"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.nextCursor").value("다리"))
+        .andExpect(jsonPath("$.nextCursor").value("다리, " + after))
         .andExpect(jsonPath("$.hasNext").value(true));
 
     then(interestService).should().findAll(condition, userId);

--- a/src/test/java/com/team3/monew/integration/InterestServiceIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/InterestServiceIntegrationTest.java
@@ -512,7 +512,7 @@ public class InterestServiceIntegrationTest extends IntegrationTestSupport {
         .extracting(InterestDto::name)
         .containsExactly("가구", "나무");
     assertThat(response.hasNext()).isTrue();
-    assertThat(response.nextCursor()).isEqualTo("나무");
+    assertThat(response.nextCursor()).isEqualTo("나무, " + response.nextAfter());
     assertThat(response.nextAfter()).isNotNull();
     assertThat(response.totalElements()).isEqualTo(5);
 
@@ -572,7 +572,7 @@ public class InterestServiceIntegrationTest extends IntegrationTestSupport {
         .extracting(InterestDto::name)
         .containsExactly("C", "D");
     assertThat(secondPage.hasNext()).isTrue();
-    assertThat(secondPage.nextCursor()).isEqualTo("D");
+    assertThat(secondPage.nextCursor()).isEqualTo("D, " + secondPage.nextAfter());
     assertThat(secondPage.nextAfter()).isNotNull();
     assertThat(secondPage.totalElements()).isEqualTo(5);
   }
@@ -636,6 +636,60 @@ public class InterestServiceIntegrationTest extends IntegrationTestSupport {
     assertThat(thirdPage.nextCursor()).isNull();
     assertThat(thirdPage.nextAfter()).isNull();
     assertThat(thirdPage.totalElements()).isEqualTo(5);
+  }
+
+  @Test
+  @DisplayName("after 없이 nextCursor 값만으로 다음 페이지를 조회할 수 있다")
+  void shouldReturnNextPage_whenOnlyCombinedCursorIsGiven() {
+    // given
+    User user = userRepository.save(
+        User.create("cursor-test@example.com", "tester", "test1234!")
+    );
+    UUID userId = user.getId();
+
+    interestRepository.save(Interest.create("A"));
+    interestRepository.save(Interest.create("B"));
+    interestRepository.save(Interest.create("C"));
+    interestRepository.save(Interest.create("D"));
+    interestRepository.save(Interest.create("E"));
+
+    entityManager.flush();
+    entityManager.clear();
+
+    InterestSearchCondition firstCondition = new InterestSearchCondition(
+        null,
+        "name",
+        "ASC",
+        new InterestCursor(null, null),
+        2
+    );
+
+    CursorPageResponseDto<InterestDto> firstPage =
+        interestService.findAll(firstCondition, userId);
+
+    InterestSearchCondition secondCondition = new InterestSearchCondition(
+        null,
+        "name",
+        "ASC",
+        new InterestCursor(firstPage.nextCursor(), null),
+        2
+    );
+
+    // when
+    CursorPageResponseDto<InterestDto> secondPage =
+        interestService.findAll(secondCondition, userId);
+
+    // then
+    assertThat(firstPage.nextCursor()).isEqualTo("B, " + firstPage.nextAfter());
+
+    assertThat(secondPage.content())
+        .extracting(InterestDto::name)
+        .containsExactly("C", "D");
+
+    assertThat(secondPage.hasNext()).isTrue();
+    assertThat(secondPage.nextCursor()).isEqualTo("D, " + secondPage.nextAfter());
+    assertThat(secondPage.nextAfter()).isNotNull();
+    assertThat(secondPage.totalElements()).isEqualTo(5);
   }
 
   @Test

--- a/src/test/java/com/team3/monew/service/InterestServiceTest.java
+++ b/src/test/java/com/team3/monew/service/InterestServiceTest.java
@@ -518,8 +518,9 @@ class InterestServiceTest {
     // then
     assertThat(response.content()).hasSize(2);
     assertThat(response.hasNext()).isTrue();
-    assertThat(response.nextCursor()).isEqualTo("나무");
     assertThat(response.nextAfter()).isNotNull();
+    assertThat(response.nextCursor())
+        .isEqualTo("나무, " + response.nextAfter());
   }
 
   private Interest createInterest(String name) {
@@ -611,6 +612,41 @@ class InterestServiceTest {
 
     // then
     assertThat(response.content().get(0).subscribedByMe()).isTrue();
+  }
+
+  @Test
+  @DisplayName("after 없이 cursor에 포함된 값으로 다음 페이지 조회 조건을 복원한다")
+  void shouldNormalizeCursor_whenAfterIsMissing() {
+    // given
+    UUID userId = UUID.randomUUID();
+    Instant after = Instant.now();
+
+    InterestCursor cursor = new InterestCursor("나무, " + after, null);
+
+    InterestSearchCondition requestCondition = new InterestSearchCondition(
+        null, "name", "ASC", cursor, 2
+    );
+
+    InterestSearchCondition normalizedCondition = new InterestSearchCondition(
+        null, "name", "ASC", new InterestCursor("나무", after), 2
+    );
+
+    given(interestRepository.searchByCondition(normalizedCondition))
+        .willReturn(List.of());
+
+    given(interestRepository.countByCondition(normalizedCondition))
+        .willReturn(0L);
+
+    // when
+    CursorPageResponseDto<InterestDto> response =
+        interestService.findAll(requestCondition, userId);
+
+    // then
+    assertThat(response.content()).isEmpty();
+    assertThat(response.hasNext()).isFalse();
+
+    then(interestRepository).should().searchByCondition(normalizedCondition);
+    then(interestRepository).should().countByCondition(normalizedCondition);
   }
 
   @Test

--- a/src/test/java/com/team3/monew/service/InterestServiceTest.java
+++ b/src/test/java/com/team3/monew/service/InterestServiceTest.java
@@ -682,6 +682,65 @@ class InterestServiceTest {
   }
 
   @Test
+  @DisplayName("after가 있고 cursor에 콤마가 포함되어도 timestamp가 아니면 원본 cursor와 after를 사용한다")
+  void shouldUseOriginalCursorAndAfter_whenCursorContainsCommaButSuffixIsNotTimestamp() {
+    // given
+    UUID userId = UUID.randomUUID();
+    Instant after = Instant.parse("2026-04-22T10:00:00Z");
+
+    InterestSearchCondition requestCondition = new InterestSearchCondition(
+        null,
+        "name",
+        "ASC",
+        new InterestCursor("경제, 금융", after),
+        2
+    );
+
+    InterestSearchCondition expectedCondition = new InterestSearchCondition(
+        null,
+        "name",
+        "ASC",
+        new InterestCursor("경제, 금융", after),
+        2
+    );
+
+    given(interestRepository.searchByCondition(expectedCondition)).willReturn(List.of());
+    given(interestRepository.countByCondition(expectedCondition)).willReturn(0L);
+
+    // when
+    CursorPageResponseDto<InterestDto> response =
+        interestService.findAll(requestCondition, userId);
+
+    // then
+    assertThat(response.content()).isEmpty();
+
+    then(interestRepository).should().searchByCondition(expectedCondition);
+    then(interestRepository).should().countByCondition(expectedCondition);
+  }
+
+  @Test
+  @DisplayName("after 없이 잘못된 combined cursor 형식이면 예외가 발생한다")
+  void shouldThrowException_whenCombinedCursorFormatIsInvalidAndAfterIsMissing() {
+    // given
+    UUID userId = UUID.randomUUID();
+
+    InterestSearchCondition condition = new InterestSearchCondition(
+        null,
+        "name",
+        "ASC",
+        new InterestCursor("경제, 금융", null),
+        2
+    );
+
+    // when & then
+    assertThatThrownBy(() -> interestService.findAll(condition, userId))
+        .isInstanceOf(InterestException.class);
+
+    then(interestRepository).should(never()).searchByCondition(any());
+    then(interestRepository).should(never()).countByCondition(any());
+  }
+
+  @Test
   @DisplayName("관심사를 구독할 수 있다")
   void shouldSubscribeInterest_whenSubscribeRequest() {
     // given

--- a/src/test/java/com/team3/monew/service/InterestServiceTest.java
+++ b/src/test/java/com/team3/monew/service/InterestServiceTest.java
@@ -650,6 +650,38 @@ class InterestServiceTest {
   }
 
   @Test
+  @DisplayName("cursor와 after가 모두 있으면 after 값을 우선 사용한다")
+  void shouldUseAfter_whenCursorAndAfterBothExist() {
+    // given
+    UUID userId = UUID.randomUUID();
+
+    Instant cursorAfter = Instant.parse("2026-04-22T10:00:00Z");
+    Instant requestAfter = Instant.parse("2026-04-23T10:00:00Z");
+
+    InterestCursor cursor = new InterestCursor("나무, " + cursorAfter, requestAfter);
+
+    InterestSearchCondition requestCondition = new InterestSearchCondition(
+        null, "name", "ASC", cursor, 2
+    );
+
+    InterestSearchCondition expectedCondition = new InterestSearchCondition(
+        null, "name", "ASC", new InterestCursor("나무", requestAfter), 2
+    );
+
+    given(interestRepository.searchByCondition(expectedCondition))
+        .willReturn(List.of());
+
+    given(interestRepository.countByCondition(expectedCondition))
+        .willReturn(0L);
+
+    // when
+    interestService.findAll(requestCondition, userId);
+
+    // then
+    then(interestRepository).should().searchByCondition(expectedCondition);
+  }
+
+  @Test
   @DisplayName("관심사를 구독할 수 있다")
   void shouldSubscribeInterest_whenSubscribeRequest() {
     // given
@@ -672,7 +704,8 @@ class InterestServiceTest {
         savedSubscription.getCreatedAt()
     );
 
-    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(Optional.of(user));
+    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(
+        Optional.of(user));
     given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
     given(interestRepository.findByIdWithKeywords(interestId)).willReturn(Optional.of(interest));
     given(subscriptionRepository.existsByUserIdAndInterestId(userId, interestId)).willReturn(false);
@@ -702,7 +735,8 @@ class InterestServiceTest {
     UUID userId = UUID.randomUUID();
     UUID interestId = UUID.randomUUID();
 
-    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(Optional.empty());
+    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(
+        Optional.empty());
 
     // when & then
     assertThatThrownBy(() -> interestService.subscribe(userId, interestId))
@@ -723,7 +757,8 @@ class InterestServiceTest {
 
     User user = User.create("test@example.com", "password", "tester");
 
-    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(Optional.of(user));
+    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(
+        Optional.of(user));
     given(interestRepository.findById(interestId)).willReturn(Optional.empty());
 
     // when & then
@@ -745,7 +780,8 @@ class InterestServiceTest {
     User user = User.create("test@example.com", "password", "tester");
     Interest interest = Interest.create("주식");
 
-    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(Optional.of(user));
+    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(
+        Optional.of(user));
     given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
     given(subscriptionRepository.existsByUserIdAndInterestId(userId, interestId)).willReturn(true);
 
@@ -768,7 +804,8 @@ class InterestServiceTest {
     User user = User.create("test@example.com", "password", "tester");
     Interest interest = Interest.create("주식");
 
-    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(Optional.of(user));
+    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(
+        Optional.of(user));
     given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
     given(subscriptionRepository.existsByUserIdAndInterestId(userId, interestId)).willReturn(false);
 
@@ -808,7 +845,8 @@ class InterestServiceTest {
     Interest interest = mock(Interest.class);
     Subscription subscription = mock(Subscription.class);
 
-    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(Optional.of(user));
+    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(
+        Optional.of(user));
     given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
     given(subscriptionRepository.findByUserIdAndInterestId(userId, interestId))
         .willReturn(Optional.of(subscription));
@@ -828,7 +866,8 @@ class InterestServiceTest {
     UUID userId = UUID.randomUUID();
     UUID interestId = UUID.randomUUID();
 
-    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(Optional.empty());
+    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(
+        Optional.empty());
 
     // when & then
     assertThatThrownBy(() -> interestService.cancelSubscribe(userId, interestId))
@@ -849,7 +888,8 @@ class InterestServiceTest {
 
     User user = mock(User.class);
 
-    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(Optional.of(user));
+    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(
+        Optional.of(user));
     given(interestRepository.findById(interestId)).willReturn(Optional.empty());
 
     // when & then
@@ -871,7 +911,8 @@ class InterestServiceTest {
     User user = mock(User.class);
     Interest interest = mock(Interest.class);
 
-    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(Optional.of(user));
+    given(userRepository.findByIdAndDeleteStatus(userId, DeleteStatus.ACTIVE)).willReturn(
+        Optional.of(user));
     given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
     given(subscriptionRepository.findByUserIdAndInterestId(userId, interestId))
         .willReturn(Optional.empty());


### PR DESCRIPTION
## 관련 이슈
- closes #242 

## 작업 내용
- 프론트에서 after 값을 보내주지 않아 무한 스크롤이 발생
- 프론트가 after를 안 보내니까, 백엔드가 cursor 안에 정렬값 + createdAt을 같이 넣어줌
- InterestService.findAll() 로직 수정
  - 뉴스기사 목록 조회와 동일하게 반영함

## 변경 사항
- 뉴스기사 목록 조회(ArticleService.getArticleList())와 마찬가지로 ", " 기준으로 작성

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 관심사 페이지네이션 커서 처리 정교화: 단일 커서 값에 타임스탬프가 포함된 경우도 정상 처리하도록 개선
  * 다음 페이지 응답의 nextCursor가 정렬 키와 타임스탬프로 결합되어 일관된 페이징 제공
  * 잘못된 커서 형식에 대해 400 응답 처리(유효성 검증 추가)

* **테스트**
  * 커서 결합 형태와 우선순위 동작을 검증하는 단위·통합 테스트 추가/업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->