### PR TITLE
feat: 알림 더미 데이터 생성기 추가

### DIFF
--- a/performance-test/.gitignore
+++ b/performance-test/.gitignore
@@ -1,1 +1,2 @@
 venv/
+data/*

--- a/src/main/java/com/team3/monew/testdata/DataGenerationRunner.java
+++ b/src/main/java/com/team3/monew/testdata/DataGenerationRunner.java
@@ -1,6 +1,9 @@
 package com.team3.monew.testdata;
 
+import com.team3.monew.entity.User;
+import com.team3.monew.testdata.generator.NotificationGenerator;
 import com.team3.monew.testdata.generator.UserGenerator;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
@@ -19,6 +22,8 @@ public class DataGenerationRunner implements CommandLineRunner {
 
   private final ApplicationContext context;
   private final UserGenerator userGenerator;
+  private final NotificationGenerator notificationGenerator;
+
   // private final로 제너레이트 추가
 
   @Override
@@ -26,9 +31,12 @@ public class DataGenerationRunner implements CommandLineRunner {
     log.info("데이터 생성 시작");
 
     // 데이터 생성 순서 주의(의존 관계 고려)
-    userGenerator.generate(10000, 1000); // 1만 명 생성, 1천 건씩 배치
+    List<User> generatedUsers = userGenerator.generate(10000, 1000); // 1만 명 생성, 1천 건씩 배치
+    log.info("✅ 사용자 데이터 생성 완료");
 
-    log.info("✅ 데이터 생성 완료");
+    notificationGenerator.setUsers(generatedUsers);
+    notificationGenerator.generate(10000, 10000);
+    log.info("✅ 알림 데이터 생성 완료");
 
     // 생성 후 종료
     SpringApplication.exit(context, () -> 0);

--- a/src/main/java/com/team3/monew/testdata/DataGenerationRunner.java
+++ b/src/main/java/com/team3/monew/testdata/DataGenerationRunner.java
@@ -35,7 +35,7 @@ public class DataGenerationRunner implements CommandLineRunner {
     log.info("✅ 사용자 데이터 생성 완료");
 
     notificationGenerator.setUsers(generatedUsers);
-    notificationGenerator.generate(10000, 10000);
+    notificationGenerator.generate(10000, 1000);
     log.info("✅ 알림 데이터 생성 완료");
 
     // 생성 후 종료

--- a/src/main/java/com/team3/monew/testdata/generator/AbstractGenerator.java
+++ b/src/main/java/com/team3/monew/testdata/generator/AbstractGenerator.java
@@ -5,8 +5,10 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -32,6 +34,8 @@ import org.springframework.jdbc.core.JdbcTemplate;
  * - @Qualifier("dataGeneratorExecutor")를 생성자에 주입받아야 합니다.
  * <p>
  * - 성능을 위해 JDBC batchUpdate를 사용합니다.
+ * <p>
+ * - 날짜를 사용하는 경우, 데이터 특성을 고려하여 정규 분포랑 균등 분포 중 선택하여 사용해주세요.
  */
 @Slf4j
 @RequiredArgsConstructor
@@ -76,10 +80,11 @@ public abstract class AbstractGenerator<T extends BaseEntity> {
   protected abstract void setValues(PreparedStatement ps, T entity) throws SQLException;
 
   // 병렬로 데이터 생성 -> 배치로 저장
-  public void generate(int totalSize, int chunkSize) {
+  public List<T> generate(int totalSize, int chunkSize) {
     int numTasks = (int) Math.ceil((double) totalSize / chunkSize);
     AtomicInteger insertedCount = new AtomicInteger(0); // 삽입 성공 건수 추적
 
+    ConcurrentLinkedQueue<T> allGeneratedEntities = new ConcurrentLinkedQueue<>();
     List<CompletableFuture<Void>> futures = IntStream.range(0, numTasks)
         .mapToObj(i -> {
           int currentChunkSize = Math.min(chunkSize, totalSize - (i * chunkSize));
@@ -87,6 +92,7 @@ public abstract class AbstractGenerator<T extends BaseEntity> {
                 // 청크 사이즈만큼 생성
                 List<T> chunk = Instancio.ofList(getModel()).size(currentChunkSize).create();
                 executeBatch(chunk);
+                allGeneratedEntities.addAll(chunk);
                 insertedCount.addAndGet(chunk.size());
               }, dataGeneratorExecutor)
               .exceptionally(ex -> {
@@ -98,6 +104,7 @@ public abstract class AbstractGenerator<T extends BaseEntity> {
 
     CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
     log.info("데이터 생성 작업 완료: 총 {}건 삽입 (요청: {}건)", insertedCount.get(), totalSize);
+    return new ArrayList<>(allGeneratedEntities);
   }
 
   private void executeBatch(List<T> entities) {

--- a/src/main/java/com/team3/monew/testdata/generator/AbstractGenerator.java
+++ b/src/main/java/com/team3/monew/testdata/generator/AbstractGenerator.java
@@ -103,7 +103,13 @@ public abstract class AbstractGenerator<T extends BaseEntity> {
         .toList();
 
     CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
-    log.info("데이터 생성 작업 완료: 총 {}건 삽입 (요청: {}건)", insertedCount.get(), totalSize);
+    int inserted = insertedCount.get();
+    if (inserted < totalSize) {
+      log.warn("데이터 생성 부분 실패: {}건 삽입 성공, {}건 실패 (요청: {}건)",
+          inserted, totalSize - inserted, totalSize);
+    } else {
+      log.info("데이터 생성 작업 완료: 총 {}건 삽입 (요청: {}건)", inserted, totalSize);
+    }
     return new ArrayList<>(allGeneratedEntities);
   }
 

--- a/src/main/java/com/team3/monew/testdata/generator/NotificationGenerator.java
+++ b/src/main/java/com/team3/monew/testdata/generator/NotificationGenerator.java
@@ -1,0 +1,109 @@
+package com.team3.monew.testdata.generator;
+
+import com.team3.monew.entity.Notification;
+import com.team3.monew.entity.User;
+import com.team3.monew.entity.enums.NotificationResourceType;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Executor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.instancio.Model;
+import java.util.concurrent.ThreadLocalRandom;
+import org.instancio.Instancio;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import static org.instancio.Select.all;
+import static org.instancio.Select.field;
+
+@Component
+@Profile("data-gen")
+public class NotificationGenerator extends AbstractGenerator<Notification> {
+
+  private List<User> userPool = new ArrayList<>(); // 사용자 ID 풀
+
+  public NotificationGenerator(JdbcTemplate jdbcTemplate,
+      @Qualifier("dataGeneratorExecutor") Executor executor) {
+    super(jdbcTemplate, executor);
+  }
+
+  public void setUsers(List<User> users) {
+    this.userPool = users;
+  }
+
+  @Override
+  protected Model<Notification> getModel() {
+    return Instancio.of(Notification.class)
+        .supply(field(Notification::getContent), () -> "새로운 알림이 도착했습니다.")
+        .supply(field(Notification::getResourceType), () ->
+            ThreadLocalRandom.current().nextBoolean() ? NotificationResourceType.INTEREST
+                : NotificationResourceType.COMMENT
+        )
+        //리소스 아이디는 실제 참조 관계가 아니기 때문에 랜덤 생성
+        .supply(field(Notification::getResourceId), java.util.UUID::randomUUID)
+
+        // 2. User매핑 - 유저 더미 데이터 활용
+        .supply(field(Notification::getUser), () ->
+            userPool.get(ThreadLocalRandom.current().nextInt(userPool.size()))
+        )
+        .supply(field(Notification::getActorUser), () ->
+            userPool.get(ThreadLocalRandom.current().nextInt(userPool.size()))
+        )
+        .supply(field(Notification::isConfirmed), () ->
+            ThreadLocalRandom.current().nextBoolean())
+        .toModel();
+  }
+
+  @Override
+  protected String getSql() {
+    return
+        "INSERT INTO notifications (id, user_id, content, resource_type, resource_id, actor_user_id, is_confirmed, confirmed_at, created_at, updated_at) "
+            + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+  }
+
+  @Override
+  protected void setValues(PreparedStatement ps, Notification n) throws SQLException {
+    Timestamp createdAt = getUniformTimestamp(7);
+    Timestamp updatedAt;
+    //확인여부에 따라 수정시간 변경
+    if (n.isConfirmed()) {
+      // 확인된 알림 - 생성 시간 ~ 현재 시간 사이의 랜덤 시간
+      long diffMillis = Instant.now().toEpochMilli() - createdAt.getTime();
+      long randomOffset = ThreadLocalRandom.current().nextLong(0, diffMillis + 1);
+      updatedAt = new Timestamp(createdAt.getTime() + randomOffset);
+    } else {
+      // 미확인 알림 - 생성 시간과 수정 시간을 동일
+      updatedAt = createdAt;
+    }
+
+    ps.setObject(1, n.getId());
+    ps.setObject(2, n.getUser().getId());
+    ps.setString(3, n.getContent());
+    ps.setString(4, n.getResourceType().name());
+    ps.setObject(5, n.getResourceId());
+
+    // 리소스타입에 따라 액터유저 유무 변경
+    if (n.getResourceType().equals(NotificationResourceType.COMMENT)) {
+      ps.setObject(6, n.getActorUser().getId());
+    } else {
+      ps.setNull(6, java.sql.Types.OTHER);
+    }
+
+    ps.setBoolean(7, n.isConfirmed());
+
+    if (n.isConfirmed()) {
+      ps.setObject(8, updatedAt);
+    } else {
+      ps.setNull(8, java.sql.Types.OTHER);
+    }
+    ps.setTimestamp(9, createdAt);
+    ps.setTimestamp(10, updatedAt);
+  }
+
+}

--- a/src/main/java/com/team3/monew/testdata/generator/NotificationGenerator.java
+++ b/src/main/java/com/team3/monew/testdata/generator/NotificationGenerator.java
@@ -34,6 +34,9 @@ public class NotificationGenerator extends AbstractGenerator<Notification> {
   }
 
   public void setUsers(List<User> users) {
+    if (users == null || users.isEmpty()) {
+      throw new IllegalStateException("userPool이 비어 있습니다. setUsers()에 유효한 사용자 목록을 전달해야 합니다.");
+    }
     this.userPool = users;
   }
 


### PR DESCRIPTION
## 관련 이슈
- closes #257

## 작업 내용
- 사용자 생성 데이터를 사용하여 알림 더미 데이터를 생성
- 기본 데이터 생성자에서 생성 데이터를 반환하도록 수정
  - 실제 저장 데이터와 수가 다르면 경고 로그
- locust 테스트 데이터를 깃 추적에서 제외

## 변경 사항
- 기본 데이터 생성자에서 생성 데이터를 반환하도록 수정하여 연관관계가 있는경우 사용할 수 있도록 하였습니다.

## 테스트 내용
- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [ ] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 테스트 데이터 파이프라인에 알림(Notification) 테스트 데이터 생성 기능 추가
  * 데이터 생성 프로세스가 사용자 데이터 및 알림 데이터 생성에 대해 분리된 완료 메시지 제공
  * 생성된 엔티티 목록을 반환하는 기능으로 데이터 생성 프로세스 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->