### PR TITLE
fix: 활동 내역 미동기화 요소 수정

### DIFF
--- a/src/main/java/com/team3/monew/document/UserActivityDocument.java
+++ b/src/main/java/com/team3/monew/document/UserActivityDocument.java
@@ -176,6 +176,24 @@ public class UserActivityDocument {
         ).collect(Collectors.toCollection(ArrayList::new));
   }
 
+  public void updateCommentLikeNickname(UUID commentUserId, String newNickname) {
+    commentLikes = commentLikes.stream()
+        .map(commentLike -> Objects.equals(commentLike.commentUserId(), commentUserId)
+            ? new CommentLikeSummary(
+            commentLike.id(),
+            commentLike.createdAt(),
+            commentLike.commentId(),
+            commentLike.articleId(),
+            commentLike.articleTitle(),
+            commentLike.commentUserId(),
+            newNickname,
+            commentLike.commentContent(),
+            commentLike.commentLikeCount(),
+            commentLike.commentCreatedAt()
+            ) : commentLike
+        ).collect(Collectors.toCollection(ArrayList::new));
+  }
+
   private <T, ID> void addToRecentList(List<T> items, T newItem, Function<T, ID> idExtractor) {
     // 중복 제거
     items.removeIf(item -> Objects.equals(idExtractor.apply(item), idExtractor.apply(newItem)));

--- a/src/main/java/com/team3/monew/event/ArticleViewEvent.java
+++ b/src/main/java/com/team3/monew/event/ArticleViewEvent.java
@@ -15,9 +15,10 @@ public record ArticleViewEvent(
     Instant articlePublishedDate,
     String articleSummary,
     Integer articleCommentCount,
-    Integer articleViewCount
+    Integer articleViewCount,
+    Boolean isFirstView
 ) {
-  public static ArticleViewEvent from(ArticleView articleView) {
+  public static ArticleViewEvent from(ArticleView articleView, Boolean isFirstView) {
     return new ArticleViewEvent(
         articleView.getId(),
         articleView.getUser().getId(),
@@ -29,7 +30,8 @@ public record ArticleViewEvent(
         articleView.getArticle().getPublishedAt(),
         articleView.getArticle().getSummary(),
         articleView.getArticle().getCommentCount(),
-        articleView.getArticle().getViewCount()
+        articleView.getArticle().getViewCount(),
+        isFirstView
     );
   }
 }

--- a/src/main/java/com/team3/monew/event/CommentDeletedEvent.java
+++ b/src/main/java/com/team3/monew/event/CommentDeletedEvent.java
@@ -4,7 +4,8 @@ import java.util.UUID;
 
 public record CommentDeletedEvent(
     UUID commentId,
-    UUID userId
+    UUID userId,
+    UUID articleId
 ) {
 
 }

--- a/src/main/java/com/team3/monew/event/CommentDeletedEvent.java
+++ b/src/main/java/com/team3/monew/event/CommentDeletedEvent.java
@@ -5,7 +5,9 @@ import java.util.UUID;
 public record CommentDeletedEvent(
     UUID commentId,
     UUID userId,
-    UUID articleId
+    UUID articleId,
+    boolean isHardDelete,
+    boolean isFirstDelete
 ) {
 
 }

--- a/src/main/java/com/team3/monew/event/CommentLikedActivityEvent.java
+++ b/src/main/java/com/team3/monew/event/CommentLikedActivityEvent.java
@@ -1,0 +1,37 @@
+package com.team3.monew.event;
+
+import com.team3.monew.entity.Comment;
+import com.team3.monew.entity.CommentLike;
+import java.time.Instant;
+import java.util.UUID;
+
+public record CommentLikedActivityEvent(
+    UUID actorUserId, //좋아요를 누른 사용자
+    UUID commentId,
+    UUID id,
+    UUID articleId,
+    String articleTitle,
+    UUID commentUserId,
+    String commentUserNickname,
+    String commentContent,
+    Integer commentLikeCount,
+    Instant commentCreatedAt
+) {
+
+  public static CommentLikedActivityEvent from(CommentLike commentLike) {
+    Comment comment = commentLike.getComment();
+
+    return new CommentLikedActivityEvent(
+        commentLike.getUser().getId(),
+        comment.getId(),
+        commentLike.getId(),
+        comment.getArticle().getId(),
+        comment.getArticle().getTitle(),
+        comment.getUser().getId(),
+        comment.getUser().getNickname(),
+        comment.getContent(),
+        comment.getLikeCount(),
+        comment.getCreatedAt()
+    );
+  }
+}

--- a/src/main/java/com/team3/monew/event/CommentLikedEvent.java
+++ b/src/main/java/com/team3/monew/event/CommentLikedEvent.java
@@ -1,51 +1,15 @@
 package com.team3.monew.event;
 
-import com.team3.monew.entity.Comment;
-import com.team3.monew.entity.CommentLike;
-import java.time.Instant;
 import java.util.UUID;
 
 public record CommentLikedEvent(
     UUID actorUserId, //좋아요를 누른 사용자
-    UUID commentId,
-    UUID id,
-    UUID articleId,
-    String articleTitle,
-    UUID commentUserId,
-    String commentUserNickname,
-    String commentContent,
-    Integer commentLikeCount,
-    Instant commentCreatedAt
+    UUID commentId
 ) {
   public static CommentLikedEvent of(UUID actorUserId, UUID commentId) {
     return new CommentLikedEvent(
         actorUserId,
-        commentId,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-    );
-  }
-
-  public static CommentLikedEvent from(CommentLike commentLike) {
-    Comment comment = commentLike.getComment();
-
-    return new CommentLikedEvent(
-        commentLike.getUser().getId(),
-        comment.getId(),
-        commentLike.getId(),
-        comment.getArticle().getId(),
-        comment.getArticle().getTitle(),
-        comment.getUser().getId(),
-        comment.getUser().getNickname(),
-        comment.getContent(),
-        comment.getLikeCount(),
-        comment.getCreatedAt()
+        commentId
     );
   }
 }

--- a/src/main/java/com/team3/monew/event/CommentUnlikedEvent.java
+++ b/src/main/java/com/team3/monew/event/CommentUnlikedEvent.java
@@ -4,7 +4,8 @@ import java.util.UUID;
 
 public record CommentUnlikedEvent(
     UUID actorUserId,
-    UUID commentLikeId
+    UUID commentLikeId,
+    UUID commentId
 ) {
 
 }

--- a/src/main/java/com/team3/monew/listener/UserActivityEventListener.java
+++ b/src/main/java/com/team3/monew/listener/UserActivityEventListener.java
@@ -3,6 +3,7 @@ package com.team3.monew.listener;
 import com.team3.monew.event.ArticleDeletedEvent;
 import com.team3.monew.event.ArticleViewEvent;
 import com.team3.monew.event.CommentDeletedEvent;
+import com.team3.monew.event.CommentLikedActivityEvent;
 import com.team3.monew.event.CommentLikedEvent;
 import com.team3.monew.event.CommentRegisteredEvent;
 import com.team3.monew.event.CommentUnlikedEvent;
@@ -88,7 +89,7 @@ public class UserActivityEventListener {
       maxAttempts = 3,
       backoff = @Backoff(delay = 1000)
   )
-  public void handleCommentLikedEvent(CommentLikedEvent event) {
+  public void handleCommentLikedEvent(CommentLikedActivityEvent event) {
     userActivityService.updateCommentLikeSummary(event.actorUserId(), userActivityMapper.toCommentLikeSummary(event));
   }
 
@@ -167,7 +168,7 @@ public class UserActivityEventListener {
       backoff = @Backoff(delay = 1000)
   )
   public void handleCommentUnlikedEvent(CommentUnlikedEvent event) {
-    userActivityService.removeCommentLikeSummary(event.actorUserId(), event.commentLikeId());
+    userActivityService.removeCommentLikeSummary(event.actorUserId(), event.commentLikeId(), event.commentId());
   }
 
   @Async("userActivityTaskExecutor")

--- a/src/main/java/com/team3/monew/listener/UserActivityEventListener.java
+++ b/src/main/java/com/team3/monew/listener/UserActivityEventListener.java
@@ -103,7 +103,10 @@ public class UserActivityEventListener {
       backoff = @Backoff(delay = 1000)
   )
   public void handleArticleViewEvent(ArticleViewEvent event) {
-    userActivityService.updateArticleViewSummary(event.userId(), userActivityMapper.toArticleViewSummary(event));
+    userActivityService.updateArticleViewSummary(
+        event.userId(),
+        userActivityMapper.toArticleViewSummary(event),
+        event.isFirstView());
   }
 
   @Async("userActivityTaskExecutor")

--- a/src/main/java/com/team3/monew/listener/UserActivityEventListener.java
+++ b/src/main/java/com/team3/monew/listener/UserActivityEventListener.java
@@ -145,7 +145,7 @@ public class UserActivityEventListener {
       backoff = @Backoff(delay = 1000)
   )
   public void handleCommentDeletedEvent(CommentDeletedEvent event) {
-    userActivityService.removeCommentSummary(event.userId(), event.commentId());
+    userActivityService.removeCommentSummary(event.userId(), event.commentId(), event.articleId());
   }
 
   @Async("userActivityTaskExecutor")

--- a/src/main/java/com/team3/monew/listener/UserActivityEventListener.java
+++ b/src/main/java/com/team3/monew/listener/UserActivityEventListener.java
@@ -4,7 +4,6 @@ import com.team3.monew.event.ArticleDeletedEvent;
 import com.team3.monew.event.ArticleViewEvent;
 import com.team3.monew.event.CommentDeletedEvent;
 import com.team3.monew.event.CommentLikedActivityEvent;
-import com.team3.monew.event.CommentLikedEvent;
 import com.team3.monew.event.CommentRegisteredEvent;
 import com.team3.monew.event.CommentUnlikedEvent;
 import com.team3.monew.event.CommentUpdatedEvent;
@@ -231,8 +230,8 @@ public class UserActivityEventListener {
   }
 
   @Recover
-  public void recover(Exception e, CommentLikedEvent event) {
-    log.error("사용자 활동 내역 CommentLiked Event 처리 실패: userId={} commentId={}", event.actorUserId(), event.commentId(), e);
+  public void recover(Exception e, CommentLikedActivityEvent event) {
+    log.error("사용자 활동 내역 CommentLikedActivity Event 처리 실패: userId={} commentId={}", event.actorUserId(), event.commentId(), e);
   }
 
   @Recover

--- a/src/main/java/com/team3/monew/listener/UserActivityEventListener.java
+++ b/src/main/java/com/team3/monew/listener/UserActivityEventListener.java
@@ -145,7 +145,13 @@ public class UserActivityEventListener {
       backoff = @Backoff(delay = 1000)
   )
   public void handleCommentDeletedEvent(CommentDeletedEvent event) {
-    userActivityService.removeCommentSummary(event.userId(), event.commentId(), event.articleId());
+    userActivityService.removeCommentSummary(
+        event.userId(),
+        event.commentId(),
+        event.articleId(),
+        event.isHardDelete(),
+        event.isFirstDelete()
+    );
   }
 
   @Async("userActivityTaskExecutor")

--- a/src/main/java/com/team3/monew/mapper/UserActivityMapper.java
+++ b/src/main/java/com/team3/monew/mapper/UserActivityMapper.java
@@ -8,7 +8,7 @@ import com.team3.monew.document.UserActivityDocument;
 import com.team3.monew.document.UserActivityRequest;
 import com.team3.monew.dto.useractivity.UserActivityDto;
 import com.team3.monew.event.ArticleViewEvent;
-import com.team3.monew.event.CommentLikedEvent;
+import com.team3.monew.event.CommentLikedActivityEvent;
 import com.team3.monew.event.CommentRegisteredEvent;
 import com.team3.monew.event.SubscriptionEvent;
 import com.team3.monew.event.UserRegisteredEvent;
@@ -40,7 +40,7 @@ public interface UserActivityMapper {
   SubscriptionSummary toSubscriptionSummary(SubscriptionEvent event);
 
   @Mapping(target = "createdAt", source = "commentCreatedAt")
-  CommentLikeSummary toCommentLikeSummary(CommentLikedEvent event);
+  CommentLikeSummary toCommentLikeSummary(CommentLikedActivityEvent event);
 
   @Mapping(target = "viewedBy", source = "userId")
   ArticleViewSummary toArticleViewSummary(ArticleViewEvent event);

--- a/src/main/java/com/team3/monew/repository/UserActivityRepository.java
+++ b/src/main/java/com/team3/monew/repository/UserActivityRepository.java
@@ -37,4 +37,12 @@ public interface UserActivityRepository extends MongoRepository<UserActivityDocu
   @Query("{ 'commentLikes.commentId': ?0 }")
   @Update("{ '$inc': { 'commentLikes.$.commentLikeCount': ?1 } }")
   void incrementCommentLikeCountInLikes(UUID commentId, int delta);
+
+  @Query("{ 'articleViews.articleId': ?0 }")
+  @Update("{ '$inc': { 'articleViews.$.articleCommentCount': ?1 } }")
+  void incrementArticleCommentCount(UUID articleId, int delta);
+
+  @Query("{ 'articleViews.articleId': ?0 }")
+  @Update("{ '$inc': { 'articleViews.$.articleViewCount': ?1 } }")
+  void incrementArticleViewCount(UUID articleId, int delta);
 }

--- a/src/main/java/com/team3/monew/repository/UserActivityRepository.java
+++ b/src/main/java/com/team3/monew/repository/UserActivityRepository.java
@@ -29,4 +29,12 @@ public interface UserActivityRepository extends MongoRepository<UserActivityDocu
   @Query("{ 'subscriptions.interestId': ?0 }")
   @Update("{ '$inc': { 'subscriptions.$.interestSubscriberCount': ?1 } }")
   void incrementSubscriberCount(UUID interestId, int delta);
+
+  @Query("{ 'comments.id': ?0 }")
+  @Update("{ '$inc': { 'comments.$.likeCount': ?1 } }")
+  void incrementCommentLikeCount(UUID commentId, int delta);
+
+  @Query("{ 'commentLikes.commentId': ?0 }")
+  @Update("{ '$inc': { 'commentLikes.$.commentLikeCount': ?1 } }")
+  void incrementCommentLikeCountInLikes(UUID commentId, int delta);
 }

--- a/src/main/java/com/team3/monew/repository/UserActivityRepository.java
+++ b/src/main/java/com/team3/monew/repository/UserActivityRepository.java
@@ -45,4 +45,7 @@ public interface UserActivityRepository extends MongoRepository<UserActivityDocu
   @Query("{ 'articleViews.articleId': ?0 }")
   @Update("{ '$inc': { 'articleViews.$.articleViewCount': ?1 } }")
   void incrementArticleViewCount(UUID articleId, int delta);
+
+  @Query("{ 'commentLikes.commentUserId': ?0 }")
+  List<UserActivityDocument> findAllByCommentLikesCommentUserId(UUID commentUserId);
 }

--- a/src/main/java/com/team3/monew/repository/UserActivityRepository.java
+++ b/src/main/java/com/team3/monew/repository/UserActivityRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
+import org.springframework.data.mongodb.repository.Update;
 
 public interface UserActivityRepository extends MongoRepository<UserActivityDocument, UUID>, UserActivityRepositoryCustom {
 
@@ -24,4 +25,8 @@ public interface UserActivityRepository extends MongoRepository<UserActivityDocu
   List<UserActivityDocument> findAllByCommentLikesCommentIdIn(List<UUID> commentIds);
 
   void deleteByIdIn(List<UUID> ids);
+
+  @Query("{ 'subscriptions.interestId': ?0 }")
+  @Update("{ '$inc': { 'subscriptions.$.interestSubscriberCount': ?1 } }")
+  void incrementSubscriberCount(UUID interestId, int delta);
 }

--- a/src/main/java/com/team3/monew/repository/UserActivityRepository.java
+++ b/src/main/java/com/team3/monew/repository/UserActivityRepository.java
@@ -48,4 +48,12 @@ public interface UserActivityRepository extends MongoRepository<UserActivityDocu
 
   @Query("{ 'commentLikes.commentUserId': ?0 }")
   List<UserActivityDocument> findAllByCommentLikesCommentUserId(UUID commentUserId);
+
+  @Query("{ 'commentLikes.commentId': ?0 }")
+  @Update("{ '$pull': { 'commentLikes': { 'commentId': ?0 } } }")
+  void removeCommentLikeSummaryByCommentId(UUID commentId);
+
+  @Query("{ 'commentLikes.commentId': { $in: ?0 } }")
+  @Update("{ '$pull': { 'commentLikes': { 'commentId': { $in: ?0 } } } }")
+  void removeCommentLikeSummariesByCommentIds(List<UUID> commentIds);
 }

--- a/src/main/java/com/team3/monew/service/ArticleViewService.java
+++ b/src/main/java/com/team3/monew/service/ArticleViewService.java
@@ -15,6 +15,7 @@ import com.team3.monew.repository.NewsArticleRepository;
 import com.team3.monew.repository.UserRepository;
 import jakarta.persistence.EntityManager;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -41,15 +42,23 @@ public class ArticleViewService {
     NewsArticle article = findActiveArticle(articleId);
     User user = findActiveUser(requestUserId);
 
+    // 재조회 시 이벤트 미발행 하기 위한 boolean
+    AtomicBoolean isFirstView = new AtomicBoolean(false);
+
     // 같은 사용자의 재조회는 기존 이력을 갱신하고, 첫 조회만 기사 조회 수를 증가시킨다.
     ArticleView articleView = articleViewRepository.findByArticleIdAndUserId(articleId, requestUserId)
         .map(existingArticleView -> {
           existingArticleView.touch();
           return existingArticleView;
         })
-        .orElseGet(() -> createFirstViewSafely(article, user));
+        .orElseGet(() -> {
+          isFirstView.set(true);
+          return createFirstViewSafely(article, user);
+        });
 
-    eventPublisher.publishEvent(ArticleViewEvent.from(articleView));
+    if (isFirstView.get()){
+      eventPublisher.publishEvent(ArticleViewEvent.from(articleView));
+    }
     log.debug("기사 뷰 등록 성공 - articleId={}, requestUserId={}, articleViewId={}",
         articleId, requestUserId, articleView.getId());
 

--- a/src/main/java/com/team3/monew/service/ArticleViewService.java
+++ b/src/main/java/com/team3/monew/service/ArticleViewService.java
@@ -56,9 +56,8 @@ public class ArticleViewService {
           return createFirstViewSafely(article, user);
         });
 
-    if (isFirstView.get()){
-      eventPublisher.publishEvent(ArticleViewEvent.from(articleView));
-    }
+
+    eventPublisher.publishEvent(ArticleViewEvent.from(articleView, isFirstView.get()));
     log.debug("기사 뷰 등록 성공 - articleId={}, requestUserId={}, articleViewId={}",
         articleId, requestUserId, articleView.getId());
 

--- a/src/main/java/com/team3/monew/service/CommentService.java
+++ b/src/main/java/com/team3/monew/service/CommentService.java
@@ -11,6 +11,7 @@ import com.team3.monew.entity.NewsArticle;
 import com.team3.monew.entity.User;
 import com.team3.monew.entity.enums.NotificationResourceType;
 import com.team3.monew.event.CommentDeletedEvent;
+import com.team3.monew.event.CommentLikedActivityEvent;
 import com.team3.monew.event.CommentRegisteredEvent;
 import com.team3.monew.event.CommentLikedEvent;
 import com.team3.monew.event.CommentUnlikedEvent;
@@ -214,10 +215,11 @@ public class CommentService {
     comment.increaseLikeCount();
 
     if (!comment.getUser().getId().equals(requestUserId)) {
-      eventPublisher.publishEvent(CommentLikedEvent.from(savedCommentLike));
+      eventPublisher.publishEvent(CommentLikedEvent.of(requestUserId, commentId));
       log.debug("댓글 좋아요 이벤트 발행 완료 - commentId={}, requestUserId={}",
           commentId, requestUserId);
     }
+    eventPublisher.publishEvent(CommentLikedActivityEvent.from(savedCommentLike));
 
     log.info("댓글 좋아요 성공 - commentId={}, requestUserId={}", commentId, requestUserId);
     return toCommentLikeDto(savedCommentLike);
@@ -241,7 +243,8 @@ public class CommentService {
     eventPublisher.publishEvent(
         new CommentUnlikedEvent(
           requestUserId,
-          commentLike.getId()
+          commentLike.getId(),
+          commentId
         )
     );
   }

--- a/src/main/java/com/team3/monew/service/CommentService.java
+++ b/src/main/java/com/team3/monew/service/CommentService.java
@@ -134,7 +134,11 @@ public class CommentService {
     comment.markDeleted();
     newsArticleRepository.decrementCommentCountById(comment.getArticle().getId());
     log.info("댓글 삭제 성공 - commentId={}", commentId);
-    eventPublisher.publishEvent(new CommentDeletedEvent(comment.getId(), comment.getUser().getId()));
+    eventPublisher.publishEvent(new CommentDeletedEvent(
+        comment.getId(),
+        comment.getUser().getId(),
+        comment.getArticle().getId())
+    );
   }
 
   @Transactional
@@ -154,7 +158,11 @@ public class CommentService {
     );
     commentRepository.delete(comment);
     log.info("댓글 물리 삭제 성공 - commentId={}", commentId);
-    eventPublisher.publishEvent(new CommentDeletedEvent(comment.getId(), comment.getUser().getId()));
+    eventPublisher.publishEvent(new CommentDeletedEvent(
+        comment.getId(),
+        comment.getUser().getId(),
+        comment.getArticle().getId())
+    );
   }
 
   public CursorPageResponseCommentDto findComments(

--- a/src/main/java/com/team3/monew/service/CommentService.java
+++ b/src/main/java/com/team3/monew/service/CommentService.java
@@ -137,7 +137,9 @@ public class CommentService {
     eventPublisher.publishEvent(new CommentDeletedEvent(
         comment.getId(),
         comment.getUser().getId(),
-        comment.getArticle().getId())
+        comment.getArticle().getId(),
+        false,
+        comment.isDeleted())
     );
   }
 
@@ -161,7 +163,9 @@ public class CommentService {
     eventPublisher.publishEvent(new CommentDeletedEvent(
         comment.getId(),
         comment.getUser().getId(),
-        comment.getArticle().getId())
+        comment.getArticle().getId(),
+        true,
+        comment.isDeleted())
     );
   }
 

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -100,8 +100,10 @@ public class UserActivityService {
 
     userActivityRepository.incrementCommentLikeCount(commentLikeSummary.commentId(), 1);
     userActivityRepository.incrementCommentLikeCountInLikes(commentLikeSummary.commentId(), 1);
-    userActivityDocument.addCommentLikeSummary(commentLikeSummary);
-    userActivityRepository.save(userActivityDocument);
+    if (!Objects.equals(commentLikeSummary.commentUserId(), userId)) {
+      userActivityDocument.addCommentLikeSummary(commentLikeSummary);
+      userActivityRepository.save(userActivityDocument);
+    }
     log.debug("사용자 활동 내역 좋아요 업데이트 성공: userId={} commentLikeId={}", userId, commentLikeSummary.id());
   }
 
@@ -234,28 +236,22 @@ public class UserActivityService {
     log.debug("사용자 활동 내역 댓글 수정 성공: userId={} commentId={}", userId, commentId);
   }
 
-  public void removeCommentLikeSummary(UUID userId, UUID commentLikeId) {
+  public void removeCommentLikeSummary(UUID userId, UUID commentLikeId, UUID commentId) {
     log.debug("사용자 활동 내역 댓글 좋아요 삭제 시작: userId={} commentLikeId={}", userId, commentLikeId);
+
+    userActivityRepository.incrementCommentLikeCount(commentId, -1);
+    userActivityRepository.incrementCommentLikeCountInLikes(commentId, -1);
+
     UserActivityDocument userActivityDocument = userActivityRepository.findById(userId)
         .orElse(null);
     if (userActivityDocument == null) {
       log.debug("사용자 활동 내역 문서가 이미 없어 좋아요 삭제를 건너뜁니다: userId={} commentLikeId={}", userId, commentLikeId);
       return;
     }
-    userActivityDocument.getCommentLikes().stream()
-        .filter(cl -> Objects.equals(cl.id(), commentLikeId))
-        .findFirst()
-        .ifPresent(commentLikeSummary -> {
-          UUID commentId = commentLikeSummary.commentId();
 
-          userActivityDocument.removeCommentLikeSummary(commentLikeId);
-          userActivityRepository.save(userActivityDocument);
+    userActivityDocument.removeCommentLikeSummary(commentLikeId);
+    userActivityRepository.save(userActivityDocument);
 
-          // 댓글 작성자 문서의 likeCount 감소
-          userActivityRepository.incrementCommentLikeCount(commentId, -1);
-          // 다른 유저 문서의 commentLikeCount 감소
-          userActivityRepository.incrementCommentLikeCountInLikes(commentId, -1);
-        });
     log.debug("사용자 활동 내역 댓글 좋아요 삭제 성공: userId={} commentLikeId={}", userId, commentLikeId);
   }
 

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -187,16 +187,23 @@ public class UserActivityService {
       log.debug("사용자 활동 내역 문서가 이미 없어 댓글 삭제를 건너뜁니다: userId={} commentId={}", userId, commentId);
       return;
     }
-    userActivityRepository.incrementArticleCommentCount(commentId, -1);
-    userActivityDocument.removeCommentSummary(commentId);
-    userActivityRepository.save(userActivityDocument);
+    userActivityDocument.getComments().stream()
+        .filter(c -> Objects.equals(c.id(), commentId))
+        .findFirst()
+        .ifPresent(commentSummary -> {
+          UUID articleId = commentSummary.articleId();
 
-    // 삭제 처리하는 사용자가 쓴 댓글이 다른 사람의 좋아요 댓글에 있는 경우
-    List<UserActivityDocument> documents = userActivityRepository.findAllByCommentLikesCommentId(commentId);
-    documents.forEach(document -> {
-      document.removeCommentLikeSummaryByCommentId(commentId);
-      userActivityRepository.save(document);
-    });
+          userActivityDocument.removeCommentSummary(commentId);
+          userActivityRepository.save(userActivityDocument);
+          userActivityRepository.incrementArticleCommentCount(articleId, -1);
+
+          // 삭제 처리하는 사용자가 쓴 댓글이 다른 사람의 좋아요 댓글에 있는 경우
+          List<UserActivityDocument> documents = userActivityRepository.findAllByCommentLikesCommentId(commentId);
+          documents.forEach(document -> {
+            document.removeCommentLikeSummaryByCommentId(commentId);
+            userActivityRepository.save(document);
+          });
+        });
     log.debug("사용자 활동 내역 댓글 삭제 성공: userId={} commentId={}", userId, commentId);
   }
 

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -85,6 +85,7 @@ public class UserActivityService {
 
     userActivityDocument.addCommentSummary(commentSummary);
     userActivityRepository.save(userActivityDocument);
+    userActivityRepository.incrementArticleCommentCount(commentSummary.articleId(), 1);
     log.debug("사용자 활동 내역 댓글 업데이트 성공: userId={} commentId={}", commentSummary.userId(), commentSummary.id());
   }
 
@@ -115,6 +116,7 @@ public class UserActivityService {
 
     userActivityDocument.addArticleViewSummary(articleViewSummary);
     userActivityRepository.save(userActivityDocument);
+    userActivityRepository.incrementArticleViewCount(articleViewSummary.articleId(), 1);
     log.debug("사용자 활동 내역 기사 뷰 업데이트 성공: userId={} articleViewId={}", userId, articleViewSummary.id());
   }
 
@@ -178,6 +180,7 @@ public class UserActivityService {
       log.debug("사용자 활동 내역 문서가 이미 없어 댓글 삭제를 건너뜁니다: userId={} commentId={}", userId, commentId);
       return;
     }
+    userActivityRepository.incrementArticleCommentCount(commentId, -1);
     userActivityDocument.removeCommentSummary(commentId);
     userActivityRepository.save(userActivityDocument);
 
@@ -245,6 +248,7 @@ public class UserActivityService {
     List<UserActivityDocument> userActivityDocuments =
         userActivityRepository.findAllByArticleViewsArticleId(articleId);
 
+    userActivityRepository.incrementArticleViewCount(articleId, -1);
     userActivityDocuments.forEach(userActivityDocument -> {
       userActivityDocument.removeArticleViewSummary(articleId);
       userActivityRepository.save(userActivityDocument);

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -110,13 +110,15 @@ public class UserActivityService {
       maxAttempts = 3,                                    // 최초 1회 + 재시도 2회
       backoff = @Backoff(delay = 100)                     // 재시도 전 100ms 대기
   )
-  public void updateArticleViewSummary(UUID userId, ArticleViewSummary articleViewSummary) {
+  public void updateArticleViewSummary(UUID userId, ArticleViewSummary articleViewSummary, Boolean isFirstView) {
     log.debug("사용자 활동 내역 기사 뷰 업데이트 시작: userId={} articleViewId={}", userId, articleViewSummary.id());
     UserActivityDocument userActivityDocument = getOrCreate(userId);
 
     userActivityDocument.addArticleViewSummary(articleViewSummary);
     userActivityRepository.save(userActivityDocument);
-    userActivityRepository.incrementArticleViewCount(articleViewSummary.articleId(), 1);
+    if (isFirstView) {
+      userActivityRepository.incrementArticleViewCount(articleViewSummary.articleId(), 1);
+    }
     log.debug("사용자 활동 내역 기사 뷰 업데이트 성공: userId={} articleViewId={}", userId, articleViewSummary.id());
   }
 

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -140,6 +140,13 @@ public class UserActivityService {
       userActivityRepository.save(document);
     });
 
+    List<UserActivityDocument> commentLikeDocuments = userActivityRepository.findAllByCommentLikesCommentUserId(userId);
+
+    commentLikeDocuments.forEach(document -> {
+      document.updateCommentLikeNickname(userId, newNickname);
+      userActivityRepository.save(document);
+    });
+
     log.debug("사용자 활동 내역 닉네임 업데이트 성공: userId={}", userId);
   }
 

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -99,6 +99,8 @@ public class UserActivityService {
 
     userActivityDocument.addCommentLikeSummary(commentLikeSummary);
     userActivityRepository.save(userActivityDocument);
+    userActivityRepository.incrementCommentLikeCount(commentLikeSummary.commentId(), 1);
+    userActivityRepository.incrementCommentLikeCountInLikes(commentLikeSummary.commentId(), 1);
     log.debug("사용자 활동 내역 좋아요 업데이트 성공: userId={} commentLikeId={}", userId, commentLikeSummary.id());
   }
 
@@ -221,8 +223,20 @@ public class UserActivityService {
       log.debug("사용자 활동 내역 문서가 이미 없어 좋아요 삭제를 건너뜁니다: userId={} commentLikeId={}", userId, commentLikeId);
       return;
     }
-    userActivityDocument.removeCommentLikeSummary(commentLikeId);
-    userActivityRepository.save(userActivityDocument);
+    userActivityDocument.getCommentLikes().stream()
+        .filter(cl -> Objects.equals(cl.id(), commentLikeId))
+        .findFirst()
+        .ifPresent(commentLikeSummary -> {
+          UUID commentId = commentLikeSummary.commentId();
+
+          userActivityDocument.removeCommentLikeSummary(commentLikeId);
+          userActivityRepository.save(userActivityDocument);
+
+          // 댓글 작성자 문서의 likeCount 감소
+          userActivityRepository.incrementCommentLikeCount(commentId, -1);
+          // 다른 유저 문서의 commentLikeCount 감소
+          userActivityRepository.incrementCommentLikeCountInLikes(commentId, -1);
+        });
     log.debug("사용자 활동 내역 댓글 좋아요 삭제 성공: userId={} commentLikeId={}", userId, commentLikeId);
   }
 

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -15,6 +15,7 @@ import com.team3.monew.mapper.UserActivityMapper;
 import com.team3.monew.repository.UserActivityRepository;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -69,6 +70,7 @@ public class UserActivityService {
 
     userActivityDocument.addSubscriptionSummary(subscriptionSummary);
     userActivityRepository.save(userActivityDocument);
+    userActivityRepository.incrementSubscriberCount(subscriptionSummary.interestId(), 1);
     log.debug("사용자 활동 내역 구독 업데이트 성공: userId={} interestId={}", userId, subscriptionSummary.interestId());
   }
 
@@ -244,8 +246,16 @@ public class UserActivityService {
       log.debug("사용자 활동 내역 문서가 이미 없어 구독 삭제를 건너뜁니다: userId={} subscriptionId={}", userId, subscriptionId);
       return;
     }
-    userActivityDocument.removeSubscriptionSummary(subscriptionId);
-    userActivityRepository.save(userActivityDocument);
+    userActivityDocument.getSubscriptions().stream()
+        .filter(s -> Objects.equals(s.id(), subscriptionId))
+        .map(SubscriptionSummary::interestId)
+        .findFirst()
+        .ifPresent(interestId -> {
+          userActivityDocument.removeSubscriptionSummary(subscriptionId);
+          userActivityRepository.save(userActivityDocument);
+          // 다른 유저 문서의 구독자 수 감소
+          userActivityRepository.incrementSubscriberCount(interestId, -1);
+        });
     log.debug("사용자 활동 내역 구독 삭제 성공: userId={} subscriptionId={}", userId, subscriptionId);
   }
 

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -98,10 +98,10 @@ public class UserActivityService {
     log.debug("사용자 활동 내역 좋아요 업데이트 시작: userId={} commentLikeId={}", userId, commentLikeSummary.id());
     UserActivityDocument userActivityDocument = getOrCreate(userId);
 
-    userActivityDocument.addCommentLikeSummary(commentLikeSummary);
-    userActivityRepository.save(userActivityDocument);
     userActivityRepository.incrementCommentLikeCount(commentLikeSummary.commentId(), 1);
     userActivityRepository.incrementCommentLikeCountInLikes(commentLikeSummary.commentId(), 1);
+    userActivityDocument.addCommentLikeSummary(commentLikeSummary);
+    userActivityRepository.save(userActivityDocument);
     log.debug("사용자 활동 내역 좋아요 업데이트 성공: userId={} commentLikeId={}", userId, commentLikeSummary.id());
   }
 

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -98,12 +98,12 @@ public class UserActivityService {
     log.debug("사용자 활동 내역 좋아요 업데이트 시작: userId={} commentLikeId={}", userId, commentLikeSummary.id());
     UserActivityDocument userActivityDocument = getOrCreate(userId);
 
-    userActivityRepository.incrementCommentLikeCount(commentLikeSummary.commentId(), 1);
-    userActivityRepository.incrementCommentLikeCountInLikes(commentLikeSummary.commentId(), 1);
     if (!Objects.equals(commentLikeSummary.commentUserId(), userId)) {
       userActivityDocument.addCommentLikeSummary(commentLikeSummary);
       userActivityRepository.save(userActivityDocument);
     }
+    userActivityRepository.incrementCommentLikeCount(commentLikeSummary.commentId(), 1);
+    userActivityRepository.incrementCommentLikeCountInLikes(commentLikeSummary.commentId(), 1);
     log.debug("사용자 활동 내역 좋아요 업데이트 성공: userId={} commentLikeId={}", userId, commentLikeSummary.id());
   }
 
@@ -239,8 +239,6 @@ public class UserActivityService {
   public void removeCommentLikeSummary(UUID userId, UUID commentLikeId, UUID commentId) {
     log.debug("사용자 활동 내역 댓글 좋아요 삭제 시작: userId={} commentLikeId={}", userId, commentLikeId);
 
-    userActivityRepository.incrementCommentLikeCount(commentId, -1);
-    userActivityRepository.incrementCommentLikeCountInLikes(commentId, -1);
 
     UserActivityDocument userActivityDocument = userActivityRepository.findById(userId)
         .orElse(null);
@@ -252,6 +250,8 @@ public class UserActivityService {
     userActivityDocument.removeCommentLikeSummary(commentLikeId);
     userActivityRepository.save(userActivityDocument);
 
+    userActivityRepository.incrementCommentLikeCount(commentId, -1);
+    userActivityRepository.incrementCommentLikeCountInLikes(commentId, -1);
     log.debug("사용자 활동 내역 댓글 좋아요 삭제 성공: userId={} commentLikeId={}", userId, commentLikeId);
   }
 

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -179,22 +179,29 @@ public class UserActivityService {
     log.debug("사용자 활동 내역 삭제 성공: userId={}", userId);
   }
 
-  public void removeCommentSummary(UUID userId, UUID commentId, UUID articleId) {
+  public void removeCommentSummary(UUID userId, UUID commentId, UUID articleId, boolean isHardDelete, boolean isFirstDelete) {
     log.debug("사용자 활동 내역 댓글 삭제 시작: userId={} commentId={}", userId, commentId);
-    UserActivityDocument userActivityDocument = userActivityRepository.findById(userId)
-        .orElse(null);
-    if (userActivityDocument == null) {
-      log.debug("사용자 활동 내역 문서가 이미 없어 댓글 삭제를 건너뜁니다: userId={} commentId={}", userId, commentId);
-      return;
-    }
-    userActivityDocument.removeCommentSummary(commentId);
-    userActivityRepository.save(userActivityDocument);
+    // 하드 삭제 시 최근 댓글, 다른 사람이 좋아요 한 댓글에서 삭제
+    if (isHardDelete) {
+      UserActivityDocument userActivityDocument = userActivityRepository.findById(userId)
+          .orElse(null);
+      if (userActivityDocument == null) {
+        log.debug("사용자 활동 내역 문서가 이미 없어 댓글 삭제를 건너뜁니다: userId={} commentId={}", userId, commentId);
+        return;
+      }
+      userActivityDocument.removeCommentSummary(commentId);
+      userActivityRepository.save(userActivityDocument);
 
-    // 해당 댓글이 달린 기사의 댓글 수 감소
-    userActivityRepository.incrementArticleCommentCount(articleId, -1);
-    // 삭제 처리하는 사용자가 쓴 댓글이 다른 사람의 좋아요 댓글에 있는 경우
-    userActivityRepository.removeCommentLikeSummaryByCommentId(commentId);
+      // 삭제 처리하는 사용자가 쓴 댓글이 다른 사람의 좋아요 댓글에 있는 경우
+      userActivityRepository.removeCommentLikeSummaryByCommentId(commentId);
+    }
+
+    // 첫 소프트 or 하드 삭제 시 해당 댓글이 달린 기사의 댓글 수 감소
+    if (isFirstDelete){
+      userActivityRepository.incrementArticleCommentCount(articleId, -1);
+    }
     log.debug("사용자 활동 내역 댓글 삭제 성공: userId={} commentId={}", userId, commentId);
+
   }
 
   @Retryable(
@@ -246,7 +253,6 @@ public class UserActivityService {
     List<UserActivityDocument> userActivityDocuments =
         userActivityRepository.findAllByArticleViewsArticleId(articleId);
 
-    userActivityRepository.incrementArticleViewCount(articleId, -1);
     userActivityDocuments.forEach(userActivityDocument -> {
       userActivityDocument.removeArticleViewSummary(articleId);
       userActivityRepository.save(userActivityDocument);

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -187,10 +187,10 @@ public class UserActivityService {
           .orElse(null);
       if (userActivityDocument == null) {
         log.debug("사용자 활동 내역 문서가 이미 없어 댓글 삭제를 건너뜁니다: userId={} commentId={}", userId, commentId);
-        return;
+      } else {
+        userActivityDocument.removeCommentSummary(commentId);
+        userActivityRepository.save(userActivityDocument);
       }
-      userActivityDocument.removeCommentSummary(commentId);
-      userActivityRepository.save(userActivityDocument);
 
       // 삭제 처리하는 사용자가 쓴 댓글이 다른 사람의 좋아요 댓글에 있는 경우
       userActivityRepository.removeCommentLikeSummaryByCommentId(commentId);
@@ -345,7 +345,8 @@ public class UserActivityService {
   public void recoverUpdateArticleViewSummary(
       OptimisticLockingFailureException e,
       UUID userId,
-      ArticleViewSummary summary
+      ArticleViewSummary summary,
+      Boolean isFirstView
   ) {
     log.error("기사 뷰 요약 업데이트 최종 실패: userId={}, articleViewId={}",
         userId, summary.id(), e);

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -173,17 +173,13 @@ public class UserActivityService {
     List<UUID> commentIds = document.getComments().stream()
         .map(CommentSummary::id)
         .toList();
+    userActivityRepository.removeCommentLikeSummariesByCommentIds(commentIds);
 
-    userActivityRepository.findAllByCommentLikesCommentIdIn(commentIds)
-        .forEach(otherDocument -> {
-          commentIds.forEach(otherDocument::removeCommentLikeSummaryByCommentId);
-          userActivityRepository.save(otherDocument);
-        });
     userActivityRepository.deleteById(userId);
     log.debug("사용자 활동 내역 삭제 성공: userId={}", userId);
   }
 
-  public void removeCommentSummary(UUID userId, UUID commentId) {
+  public void removeCommentSummary(UUID userId, UUID commentId, UUID articleId) {
     log.debug("사용자 활동 내역 댓글 삭제 시작: userId={} commentId={}", userId, commentId);
     UserActivityDocument userActivityDocument = userActivityRepository.findById(userId)
         .orElse(null);
@@ -191,23 +187,13 @@ public class UserActivityService {
       log.debug("사용자 활동 내역 문서가 이미 없어 댓글 삭제를 건너뜁니다: userId={} commentId={}", userId, commentId);
       return;
     }
-    userActivityDocument.getComments().stream()
-        .filter(c -> Objects.equals(c.id(), commentId))
-        .findFirst()
-        .ifPresent(commentSummary -> {
-          UUID articleId = commentSummary.articleId();
+    userActivityDocument.removeCommentSummary(commentId);
+    userActivityRepository.save(userActivityDocument);
 
-          userActivityDocument.removeCommentSummary(commentId);
-          userActivityRepository.save(userActivityDocument);
-          userActivityRepository.incrementArticleCommentCount(articleId, -1);
-
-          // 삭제 처리하는 사용자가 쓴 댓글이 다른 사람의 좋아요 댓글에 있는 경우
-          List<UserActivityDocument> documents = userActivityRepository.findAllByCommentLikesCommentId(commentId);
-          documents.forEach(document -> {
-            document.removeCommentLikeSummaryByCommentId(commentId);
-            userActivityRepository.save(document);
-          });
-        });
+    // 해당 댓글이 달린 기사의 댓글 수 감소
+    userActivityRepository.incrementArticleCommentCount(articleId, -1);
+    // 삭제 처리하는 사용자가 쓴 댓글이 다른 사람의 좋아요 댓글에 있는 경우
+    userActivityRepository.removeCommentLikeSummaryByCommentId(commentId);
     log.debug("사용자 활동 내역 댓글 삭제 성공: userId={} commentId={}", userId, commentId);
   }
 

--- a/src/test/java/com/team3/monew/listener/UserActivityEventListenerTest.java
+++ b/src/test/java/com/team3/monew/listener/UserActivityEventListenerTest.java
@@ -229,7 +229,8 @@ class UserActivityEventListenerTest {
         publishedAt,
         "기사 요약",
         3,
-        100
+        100,
+        true
     );
 
     ArticleViewSummary summary = new ArticleViewSummary(
@@ -254,7 +255,7 @@ class UserActivityEventListenerTest {
     // then
     then(userActivityMapper).should(times(1)).toArticleViewSummary(event);
     then(userActivityService).should(times(1))
-        .updateArticleViewSummary(userId, summary);
+        .updateArticleViewSummary(userId, summary, true);
   }
 
   @Test

--- a/src/test/java/com/team3/monew/listener/UserActivityEventListenerTest.java
+++ b/src/test/java/com/team3/monew/listener/UserActivityEventListenerTest.java
@@ -12,7 +12,7 @@ import com.team3.monew.document.UserActivityRequest;
 import com.team3.monew.event.ArticleDeletedEvent;
 import com.team3.monew.event.ArticleViewEvent;
 import com.team3.monew.event.CommentDeletedEvent;
-import com.team3.monew.event.CommentLikedEvent;
+import com.team3.monew.event.CommentLikedActivityEvent;
 import com.team3.monew.event.CommentRegisteredEvent;
 import com.team3.monew.event.CommentUnlikedEvent;
 import com.team3.monew.event.CommentUpdatedEvent;
@@ -171,7 +171,7 @@ class UserActivityEventListenerTest {
     UUID commentUserId = UUID.randomUUID();
     Instant createdAt = Instant.now();
 
-    CommentLikedEvent event = new CommentLikedEvent(
+    CommentLikedActivityEvent event = new CommentLikedActivityEvent(
         actorUserId,
         commentId,
         commentLikeId,
@@ -330,15 +330,16 @@ class UserActivityEventListenerTest {
     // given
     UUID commentLikeId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();
+    UUID commentId = UUID.randomUUID();
 
-    CommentUnlikedEvent event = new CommentUnlikedEvent(userId, commentLikeId);
+    CommentUnlikedEvent event = new CommentUnlikedEvent(userId, commentLikeId, commentId);
 
     // when
     userActivityEventListener.handleCommentUnlikedEvent(event);
 
     // then
     then(userActivityService).should(times(1))
-        .removeCommentLikeSummary(userId, commentLikeId);
+        .removeCommentLikeSummary(userId, commentLikeId, commentId);
   }
 
   @Test

--- a/src/test/java/com/team3/monew/listener/UserActivityEventListenerTest.java
+++ b/src/test/java/com/team3/monew/listener/UserActivityEventListenerTest.java
@@ -295,15 +295,16 @@ class UserActivityEventListenerTest {
     // given
     UUID commentId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();
+    UUID articleId = UUID.randomUUID();
 
-    CommentDeletedEvent event = new CommentDeletedEvent(commentId, userId);
+    CommentDeletedEvent event = new CommentDeletedEvent(commentId, userId, articleId);
 
     // when
     userActivityEventListener.handleCommentDeletedEvent(event);
 
     // then
     then(userActivityService).should(times(1))
-        .removeCommentSummary(userId, commentId);
+        .removeCommentSummary(userId, commentId, articleId);
   }
 
   @Test

--- a/src/test/java/com/team3/monew/listener/UserActivityEventListenerTest.java
+++ b/src/test/java/com/team3/monew/listener/UserActivityEventListenerTest.java
@@ -297,14 +297,14 @@ class UserActivityEventListenerTest {
     UUID userId = UUID.randomUUID();
     UUID articleId = UUID.randomUUID();
 
-    CommentDeletedEvent event = new CommentDeletedEvent(commentId, userId, articleId);
+    CommentDeletedEvent event = new CommentDeletedEvent(commentId, userId, articleId, true, true);
 
     // when
     userActivityEventListener.handleCommentDeletedEvent(event);
 
     // then
     then(userActivityService).should(times(1))
-        .removeCommentSummary(userId, commentId, articleId);
+        .removeCommentSummary(userId, commentId, articleId, true, true);
   }
 
   @Test

--- a/src/test/java/com/team3/monew/service/CommentServiceTest.java
+++ b/src/test/java/com/team3/monew/service/CommentServiceTest.java
@@ -11,6 +11,7 @@ import com.team3.monew.entity.NewsSource;
 import com.team3.monew.entity.User;
 import com.team3.monew.entity.enums.DeleteStatus;
 import com.team3.monew.entity.enums.NotificationResourceType;
+import com.team3.monew.event.CommentLikedActivityEvent;
 import com.team3.monew.event.CommentLikedEvent;
 import com.team3.monew.event.CommentUnlikedEvent;
 import com.team3.monew.exception.article.ArticleNotFoundException;
@@ -54,6 +55,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 class CommentServiceTest {
@@ -686,7 +688,8 @@ class CommentServiceTest {
             then(commentLikeRepository).should().save(argThat(commentLike ->
                     commentLike.getComment() == comment && commentLike.getUser() == liker
             ));
-            then(eventPublisher).should().publishEvent(CommentLikedEvent.from(savedLike));
+            then(eventPublisher).should().publishEvent(CommentLikedEvent.of(requestUserId, commentId));
+            then(eventPublisher).should().publishEvent(CommentLikedActivityEvent.from(savedLike));
         }
 
         @Test
@@ -711,7 +714,8 @@ class CommentServiceTest {
             assertThat(actual).isEqualTo(expected);
             assertThat(comment.getLikeCount()).isEqualTo(1);
             then(commentLikeRepository).should().save(any(CommentLike.class));
-            then(eventPublisher).shouldHaveNoInteractions();
+            then(eventPublisher).should(never()).publishEvent(any(CommentLikedEvent.class));
+            then(eventPublisher).should().publishEvent(CommentLikedActivityEvent.from(savedLike));
         }
 
         @Test

--- a/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
+++ b/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
@@ -1208,4 +1208,81 @@ class UserActivityServiceTest {
     then(userActivityRepository).should().save(any(UserActivityDocument.class));
     then(userActivityRepository).should().incrementSubscriberCount(interestId, -1);
   }
+
+  @Test
+  @DisplayName("댓글 좋아요 추가 시 댓글 작성자 문서의 likeCount와 다른 유저 문서의 commentLikeCount가 증가합니다.")
+  void shouldIncrementCommentLikeCount_whenCommentLikeAdded() {
+    // given
+    UUID commentId = UUID.randomUUID();
+
+    UserActivityDocument userActivityDocument = UserActivityDocument.create(
+        userId,
+        "test@test.com",
+        "tester",
+        createdAt
+    );
+
+    CommentLikeSummary summary = new CommentLikeSummary(
+        UUID.randomUUID(),
+        createdAt,
+        commentId,
+        UUID.randomUUID(),
+        "기사 제목",
+        UUID.randomUUID(),
+        "commentWriter",
+        "댓글 내용",
+        1,
+        createdAt
+    );
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(userActivityDocument));
+
+    // when
+    userActivityService.updateCommentLikeSummary(userId, summary);
+
+    // then
+    then(userActivityRepository).should().save(any(UserActivityDocument.class));
+    then(userActivityRepository).should().incrementCommentLikeCount(commentId, 1);
+    then(userActivityRepository).should().incrementCommentLikeCountInLikes(commentId, 1);
+  }
+
+  @Test
+  @DisplayName("댓글 좋아요 취소 시 댓글 작성자 문서의 likeCount와 다른 유저 문서의 commentLikeCount가 감소합니다.")
+  void shouldDecrementCommentLikeCount_whenCommentLikeRemoved() {
+    // given
+    UUID commentLikeId = UUID.randomUUID();
+    UUID commentId = UUID.randomUUID();
+
+    UserActivityDocument userActivityDocument = UserActivityDocument.create(
+        userId,
+        "test@test.com",
+        "tester",
+        createdAt
+    );
+
+    CommentLikeSummary summary = new CommentLikeSummary(
+        commentLikeId,
+        createdAt,
+        commentId,
+        UUID.randomUUID(),
+        "기사 제목",
+        userId,
+        "commentWriter",
+        "댓글 내용",
+        1,
+        createdAt
+    );
+
+    userActivityDocument.addCommentLikeSummary(summary);
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(userActivityDocument));
+
+    // when
+    userActivityService.removeCommentLikeSummary(userId, commentLikeId);
+
+    // then
+    then(userActivityRepository).should().save(any(UserActivityDocument.class));
+    then(userActivityRepository).should().incrementCommentLikeCount(commentId, -1);
+    then(userActivityRepository).should().incrementCommentLikeCountInLikes(commentId, -1);
+  }
 }

--- a/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
+++ b/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
@@ -1285,4 +1285,154 @@ class UserActivityServiceTest {
     then(userActivityRepository).should().incrementCommentLikeCount(commentId, -1);
     then(userActivityRepository).should().incrementCommentLikeCountInLikes(commentId, -1);
   }
+
+  @Test
+  @DisplayName("댓글 추가 시 기사 댓글 수가 증가합니다.")
+  void shouldIncrementArticleCommentCount_whenCommentAdded() {
+    // given
+    UUID articleId = UUID.randomUUID();
+
+    UserActivityDocument userActivityDocument = UserActivityDocument.create(
+        userId,
+        "test@test.com",
+        "tester",
+        createdAt
+    );
+
+    CommentSummary summary = new CommentSummary(
+        UUID.randomUUID(),
+        articleId,
+        "기사 제목",
+        userId,
+        "tester",
+        "댓글 내용",
+        0,
+        createdAt
+    );
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(userActivityDocument));
+
+    // when
+    userActivityService.updateCommentSummary(summary);
+
+    // then
+    then(userActivityRepository).should().save(any(UserActivityDocument.class));
+    then(userActivityRepository).should().incrementArticleCommentCount(articleId, 1);
+  }
+
+  @Test
+  @DisplayName("댓글 삭제 시 기사 댓글 수가 감소합니다.")
+  void shouldDecrementArticleCommentCount_whenCommentRemoved() {
+    // given
+    UUID commentId = UUID.randomUUID();
+    UUID articleId = UUID.randomUUID();
+
+    UserActivityDocument userActivityDocument = UserActivityDocument.create(
+        userId,
+        "test@test.com",
+        "tester",
+        createdAt
+    );
+
+    CommentSummary summary = new CommentSummary(
+        commentId,
+        articleId,
+        "기사 제목",
+        userId,
+        "tester",
+        "댓글 내용",
+        0,
+        createdAt
+    );
+
+    userActivityDocument.addCommentSummary(summary);
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(userActivityDocument));
+    given(userActivityRepository.findAllByCommentLikesCommentId(commentId))
+        .willReturn(List.of());
+
+    // when
+    userActivityService.removeCommentSummary(userId, commentId);
+
+    // then
+    then(userActivityRepository).should().save(any(UserActivityDocument.class));
+    then(userActivityRepository).should().incrementArticleCommentCount(commentId, -1);
+  }
+
+  @Test
+  @DisplayName("기사 조회 시 기사 뷰 조회수가 증가합니다.")
+  void shouldIncrementArticleViewCount_whenArticleViewed() {
+    // given
+    UUID articleId = UUID.randomUUID();
+
+    UserActivityDocument userActivityDocument = UserActivityDocument.create(
+        userId,
+        "test@test.com",
+        "tester",
+        createdAt
+    );
+
+    ArticleViewSummary summary = new ArticleViewSummary(
+        UUID.randomUUID(),
+        userId,
+        createdAt,
+        articleId,
+        "NAVER",
+        "https://example.com",
+        "기사 제목",
+        createdAt,
+        "기사 요약",
+        3,
+        100
+    );
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(userActivityDocument));
+
+    // when
+    userActivityService.updateArticleViewSummary(userId, summary);
+
+    // then
+    then(userActivityRepository).should().save(any(UserActivityDocument.class));
+    then(userActivityRepository).should().incrementArticleViewCount(articleId, 1);
+  }
+
+  @Test
+  @DisplayName("기사 삭제 시 기사 뷰 조회수가 감소합니다.")
+  void shouldDecrementArticleViewCount_whenArticleDeleted() {
+    // given
+    UUID articleId = UUID.randomUUID();
+
+    UserActivityDocument userActivityDocument = UserActivityDocument.create(
+        userId,
+        "test@test.com",
+        "tester",
+        createdAt
+    );
+
+    ArticleViewSummary summary = new ArticleViewSummary(
+        UUID.randomUUID(),
+        userId,
+        createdAt,
+        articleId,
+        "NAVER",
+        "https://example.com",
+        "기사 제목",
+        createdAt,
+        "기사 요약",
+        3,
+        100
+    );
+
+    userActivityDocument.addArticleViewSummary(summary);
+
+    given(userActivityRepository.findAllByArticleViewsArticleId(articleId))
+        .willReturn(List.of(userActivityDocument));
+
+    // when
+    userActivityService.removeArticleViewSummary(articleId);
+
+    // then
+    then(userActivityRepository).should().save(any(UserActivityDocument.class));
+    then(userActivityRepository).should().incrementArticleViewCount(articleId, -1);
+  }
 }

--- a/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
+++ b/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
@@ -526,6 +526,7 @@ class UserActivityServiceTest {
 
     given(userActivityRepository.findById(userId)).willReturn(Optional.of(document));
     given(userActivityRepository.findAllByCommentsUserId(userId)).willReturn(List.of());
+    given(userActivityRepository.findAllByCommentLikesCommentUserId(userId)).willReturn(List.of());
 
     // when
     userActivityService.updateUserNickname(userId, newNickname);
@@ -543,6 +544,61 @@ class UserActivityServiceTest {
     assertEquals(newNickname, savedDocument.getNickname());
     assertEquals(1, savedDocument.getComments().size());
     assertEquals(newNickname, savedDocument.getComments().get(0).userNickname());
+  }
+
+  @Test
+  @DisplayName("사용자 닉네임 수정 시 다른 유저의 댓글 좋아요 목록의 닉네임도 함께 업데이트됩니다.")
+  void shouldUpdateNicknameInCommentLikeSummaries() {
+    // given
+    String newNickname = "newTester";
+    UUID otherUserId = UUID.randomUUID();
+
+    UserActivityDocument document = UserActivityDocument.create(
+        userId,
+        "test@test.com",
+        "tester",
+        createdAt
+    );
+
+    UserActivityDocument otherDocument = UserActivityDocument.create(
+        otherUserId,
+        "other@test.com",
+        "otherTester",
+        createdAt
+    );
+
+    CommentLikeSummary commentLikeSummary = new CommentLikeSummary(
+        UUID.randomUUID(),
+        createdAt,
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        "기사 제목",
+        userId,          // 댓글 작성자 = 닉네임 변경하는 유저
+        "tester",        // 기존 닉네임
+        "댓글 내용",
+        1,
+        createdAt
+    );
+
+    otherDocument.addCommentLikeSummary(commentLikeSummary);
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(document));
+    given(userActivityRepository.findAllByCommentsUserId(userId)).willReturn(List.of());
+    given(userActivityRepository.findAllByCommentLikesCommentUserId(userId))
+        .willReturn(List.of(otherDocument));
+
+    // when
+    userActivityService.updateUserNickname(userId, newNickname);
+
+    // then
+    ArgumentCaptor<UserActivityDocument> documentCaptor =
+        ArgumentCaptor.forClass(UserActivityDocument.class);
+
+    then(userActivityRepository).should(times(2)).save(documentCaptor.capture());
+
+    List<UserActivityDocument> savedDocuments = documentCaptor.getAllValues();
+
+    assertEquals(newNickname, savedDocuments.get(1).getCommentLikes().get(0).commentUserNickname());
   }
 
   @Test

--- a/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
+++ b/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
@@ -1141,4 +1141,71 @@ class UserActivityServiceTest {
     UserActivityDocument savedDocument = documentCaptor.getValue();
     assertEquals(0, savedDocument.getCommentLikes().size());
   }
+
+  @Test
+  @DisplayName("구독 추가 시 다른 유저 문서의 구독자 수가 증가합니다.")
+  void shouldIncrementSubscriberCount_whenSubscriptionAdded() {
+    // given
+    UUID interestId = UUID.randomUUID();
+
+    UserActivityDocument userActivityDocument = UserActivityDocument.create(
+        userId,
+        "test@test.com",
+        "tester",
+        createdAt
+    );
+
+    SubscriptionSummary summary = new SubscriptionSummary(
+        UUID.randomUUID(),
+        interestId,
+        "경제",
+        List.of("금리", "주식"),
+        10,
+        createdAt
+    );
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(userActivityDocument));
+
+    // when
+    userActivityService.updateSubscriptionSummary(userId, summary);
+
+    // then
+    then(userActivityRepository).should().save(any(UserActivityDocument.class));
+    then(userActivityRepository).should().incrementSubscriberCount(interestId, 1);
+  }
+
+  @Test
+  @DisplayName("구독 취소 시 다른 유저 문서의 구독자 수가 감소합니다.")
+  void shouldDecrementSubscriberCount_whenSubscriptionRemoved() {
+    // given
+    UUID subscriptionId = UUID.randomUUID();
+    UUID interestId = UUID.randomUUID();
+
+    UserActivityDocument userActivityDocument = UserActivityDocument.create(
+        userId,
+        "test@test.com",
+        "tester",
+        createdAt
+    );
+
+    SubscriptionSummary summary = new SubscriptionSummary(
+        subscriptionId,
+        interestId,
+        "경제",
+        List.of("금리", "주식"),
+        10,
+        createdAt
+    );
+
+    userActivityDocument.addSubscriptionSummary(summary);
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(userActivityDocument));
+
+    // when
+    userActivityService.removeSubscriptionSummary(userId, subscriptionId);
+
+    // then
+    then(userActivityRepository).should().save(any(UserActivityDocument.class));
+    then(userActivityRepository).should().incrementSubscriberCount(interestId, -1);
+  }
 }

--- a/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
+++ b/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
@@ -415,7 +415,7 @@ class UserActivityServiceTest {
     given(userActivityRepository.findById(userId)).willReturn(Optional.of(document));
 
     // when
-    userActivityService.updateArticleViewSummary(userId, summary);
+    userActivityService.updateArticleViewSummary(userId, summary, true);
 
     // then
     ArgumentCaptor<UserActivityDocument> documentCaptor =
@@ -450,7 +450,7 @@ class UserActivityServiceTest {
     given(userActivityRepository.findById(userId)).willReturn(Optional.empty());
 
     // when
-    userActivityService.updateArticleViewSummary(userId, summary);
+    userActivityService.updateArticleViewSummary(userId, summary, true);
 
     // then
     ArgumentCaptor<UserActivityDocument> documentCaptor =
@@ -1412,7 +1412,7 @@ class UserActivityServiceTest {
 
     // then
     then(userActivityRepository).should().save(any(UserActivityDocument.class));
-    then(userActivityRepository).should().incrementArticleCommentCount(commentId, -1);
+    then(userActivityRepository).should().incrementArticleCommentCount(articleId, -1);
   }
 
   @Test
@@ -1445,7 +1445,7 @@ class UserActivityServiceTest {
     given(userActivityRepository.findById(userId)).willReturn(Optional.of(userActivityDocument));
 
     // when
-    userActivityService.updateArticleViewSummary(userId, summary);
+    userActivityService.updateArticleViewSummary(userId, summary, true);
 
     // then
     then(userActivityRepository).should().save(any(UserActivityDocument.class));

--- a/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
+++ b/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
@@ -879,6 +879,7 @@ class UserActivityServiceTest {
   void shouldRemoveCommentLikeSummary() {
     // given
     UUID commentLikeId = UUID.randomUUID();
+    UUID commentId = UUID.randomUUID();
 
     UserActivityDocument document = UserActivityDocument.create(
         userId,
@@ -905,7 +906,7 @@ class UserActivityServiceTest {
     given(userActivityRepository.findById(userId)).willReturn(Optional.of(document));
 
     // when
-    userActivityService.removeCommentLikeSummary(userId, commentLikeId);
+    userActivityService.removeCommentLikeSummary(userId, commentLikeId, commentId);
 
     // then
     ArgumentCaptor<UserActivityDocument> documentCaptor =
@@ -925,11 +926,12 @@ class UserActivityServiceTest {
   void shouldDoNothingWhenUserActivityNotFoundOnRemoveCommentLikeSummary() {
     // given
     UUID commentLikeId = UUID.randomUUID();
+    UUID commentId = UUID.randomUUID();
 
     given(userActivityRepository.findById(userId)).willReturn(Optional.empty());
 
     // when
-    userActivityService.removeCommentLikeSummary(userId, commentLikeId);
+    userActivityService.removeCommentLikeSummary(userId, commentLikeId, commentId);
 
     // then
     then(userActivityRepository).should(never()).save(any());
@@ -1334,7 +1336,7 @@ class UserActivityServiceTest {
     given(userActivityRepository.findById(userId)).willReturn(Optional.of(userActivityDocument));
 
     // when
-    userActivityService.removeCommentLikeSummary(userId, commentLikeId);
+    userActivityService.removeCommentLikeSummary(userId, commentLikeId, commentId);
 
     // then
     then(userActivityRepository).should().save(any(UserActivityDocument.class));

--- a/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
+++ b/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
@@ -2,6 +2,7 @@ package com.team3.monew.service;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
@@ -615,134 +616,6 @@ class UserActivityServiceTest {
         () -> userActivityService.updateUserNickname(userId, newNickname)
     );
 
-    then(userActivityRepository).should(never()).save(any());
-  }
-
-  @Test
-  @DisplayName("댓글 삭제 시 활동 내역 댓글 목록에서 해당 댓글을 제거합니다.")
-  void shouldRemoveCommentSummary() {
-    // given
-    UUID commentId = UUID.randomUUID();
-    UUID articleId = UUID.randomUUID();
-
-    UserActivityDocument document = UserActivityDocument.create(
-        userId,
-        "test@test.com",
-        "tester",
-        createdAt
-    );
-
-    CommentSummary summary = new CommentSummary(
-        commentId,
-        articleId,
-        "기사 제목",
-        userId,
-        "tester",
-        "댓글 내용",
-        0,
-        createdAt
-    );
-
-    document.addCommentSummary(summary);
-
-    given(userActivityRepository.findById(userId)).willReturn(Optional.of(document));
-
-    // when
-    userActivityService.removeCommentSummary(userId, commentId, articleId);
-
-    // then
-    ArgumentCaptor<UserActivityDocument> documentCaptor =
-        ArgumentCaptor.forClass(UserActivityDocument.class);
-
-    then(userActivityRepository).should().save(documentCaptor.capture());
-
-    UserActivityDocument savedDocument = documentCaptor.getValue();
-
-    assertNotNull(savedDocument);
-    assertEquals(userId, savedDocument.getId());
-    assertEquals(0, savedDocument.getComments().size());
-  }
-
-  @Test
-  @DisplayName("댓글 삭제 시 다른 유저의 활동 내역 좋아요 목록에서도 해당 댓글의 좋아요를 제거합니다.")
-  void shouldRemoveCommentLikeSummaryFromOtherUserActivity_whenCommentDeleted() {
-    // given
-    UUID commentId = UUID.randomUUID();
-    UUID otherUserId = UUID.randomUUID();
-    UUID articleId = UUID.randomUUID();
-
-    UserActivityDocument userActivityDocument = UserActivityDocument.create(
-        userId,
-        "test@test.com",
-        "tester",
-        createdAt
-    );
-
-    CommentSummary commentSummary = new CommentSummary(
-        commentId,
-        articleId,
-        "기사 제목",
-        userId,
-        "tester",
-        "댓글 내용",
-        0,
-        createdAt
-    );
-
-    UserActivityDocument otherUserActivityDocument = UserActivityDocument.create(
-        otherUserId,
-        "other@test.com",
-        "otherTester",
-        createdAt
-    );
-
-    CommentLikeSummary commentLikeSummary = new CommentLikeSummary(
-        UUID.randomUUID(),
-        createdAt,
-        commentId,         // 삭제될 댓글 ID
-        articleId,
-        "기사 제목",
-        userId,
-        "tester",
-        "댓글 내용",
-        1,
-        createdAt
-    );
-
-    userActivityDocument.addCommentSummary(commentSummary);
-    otherUserActivityDocument.addCommentLikeSummary(commentLikeSummary);
-
-    given(userActivityRepository.findById(userId)).willReturn(Optional.of(userActivityDocument));
-
-    // when
-    userActivityService.removeCommentSummary(userId, commentId, articleId);
-
-    // then
-    ArgumentCaptor<UserActivityDocument> documentCaptor =
-        ArgumentCaptor.forClass(UserActivityDocument.class);
-
-    then(userActivityRepository).should(times(1)).save(documentCaptor.capture());
-
-    List<UserActivityDocument> savedDocuments = documentCaptor.getAllValues();
-
-    assertEquals(0, savedDocuments.get(0).getComments().size());
-    then(userActivityRepository).should().removeCommentLikeSummaryByCommentId(commentId);
-    then(userActivityRepository).should().incrementArticleCommentCount(articleId, -1);
-  }
-
-  @Test
-  @DisplayName("댓글 삭제 시 문서가 문서가 없으면 정상 종료합니다.")
-  void shouldDoNothingWhenUserActivityNotFoundOnRemoveCommentSummary() {
-    // given
-    UUID commentId = UUID.randomUUID();
-    UUID articleId = UUID.randomUUID();
-
-    given(userActivityRepository.findById(userId)).willReturn(Optional.empty());
-
-    // when
-    userActivityService.removeCommentSummary(userId, commentId, articleId);
-
-    // then
     then(userActivityRepository).should(never()).save(any());
   }
 
@@ -1372,44 +1245,6 @@ class UserActivityServiceTest {
   }
 
   @Test
-  @DisplayName("댓글 삭제 시 기사 댓글 수가 감소합니다.")
-  void shouldDecrementArticleCommentCount_whenCommentRemoved() {
-    // given
-    UUID commentId = UUID.randomUUID();
-    UUID articleId = UUID.randomUUID();
-
-    UserActivityDocument userActivityDocument = UserActivityDocument.create(
-        userId,
-        "test@test.com",
-        "tester",
-        createdAt
-    );
-
-    CommentSummary summary = new CommentSummary(
-        commentId,
-        articleId,
-        "기사 제목",
-        userId,
-        "tester",
-        "댓글 내용",
-        0,
-        createdAt
-    );
-
-    userActivityDocument.addCommentSummary(summary);
-
-    given(userActivityRepository.findById(userId)).willReturn(Optional.of(userActivityDocument));
-
-    // when
-    userActivityService.removeCommentSummary(userId, commentId, articleId);
-
-    // then
-    then(userActivityRepository).should().save(any(UserActivityDocument.class));
-    then(userActivityRepository).should().incrementArticleCommentCount(articleId, -1);
-    then(userActivityRepository).should().removeCommentLikeSummaryByCommentId(commentId);
-  }
-
-  @Test
   @DisplayName("기사 조회 시 기사 뷰 조회수가 증가합니다.")
   void shouldIncrementArticleViewCount_whenArticleViewed() {
     // given
@@ -1484,5 +1319,126 @@ class UserActivityServiceTest {
     // then
     then(userActivityRepository).should().save(any(UserActivityDocument.class));
     then(userActivityRepository).should().incrementArticleViewCount(articleId, -1);
+  }
+
+  @Test
+  @DisplayName("소프트 삭제 시 기사 댓글 수가 감소하고 활동 내역 댓글은 유지됩니다.")
+  void shouldDecrementArticleCommentCount_whenCommentSoftDeleted() {
+    // given
+    UUID commentId = UUID.randomUUID();
+    UUID articleId = UUID.randomUUID();
+
+    // when
+    userActivityService.removeCommentSummary(userId, commentId, articleId, false, true);
+
+    // then
+    then(userActivityRepository).should(never()).findById(any());
+    then(userActivityRepository).should(never()).save(any());
+    then(userActivityRepository).should(never()).removeCommentLikeSummaryByCommentId(any());
+    then(userActivityRepository).should().incrementArticleCommentCount(articleId, -1);
+  }
+
+  @Test
+  @DisplayName("소프트 삭제 후 하드 삭제 시 댓글 수 감소 없이 활동 내역 댓글만 제거됩니다.")
+  void shouldRemoveCommentSummaryWithoutDecrement_whenCommentHardDeletedAfterSoftDelete() {
+    // given
+    UUID commentId = UUID.randomUUID();
+    UUID articleId = UUID.randomUUID();
+
+    UserActivityDocument userActivityDocument = UserActivityDocument.create(
+        userId,
+        "test@test.com",
+        "tester",
+        createdAt
+    );
+
+    CommentSummary summary = new CommentSummary(
+        commentId,
+        articleId,
+        "기사 제목",
+        userId,
+        "tester",
+        "댓글 내용",
+        0,
+        createdAt
+    );
+
+    userActivityDocument.addCommentSummary(summary);
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(userActivityDocument));
+
+    // when
+    userActivityService.removeCommentSummary(userId, commentId, articleId, true, false);
+
+    // then
+    ArgumentCaptor<UserActivityDocument> documentCaptor =
+        ArgumentCaptor.forClass(UserActivityDocument.class);
+
+    then(userActivityRepository).should().save(documentCaptor.capture());
+    then(userActivityRepository).should().removeCommentLikeSummaryByCommentId(commentId);
+    then(userActivityRepository).should(never()).incrementArticleCommentCount(any(), anyInt());
+
+    assertEquals(0, documentCaptor.getValue().getComments().size());
+  }
+
+  @Test
+  @DisplayName("바로 하드 삭제 시 기사 댓글 수 감소와 활동 내역 댓글이 제거됩니다.")
+  void shouldDecrementArticleCommentCountAndRemoveCommentSummary_whenCommentHardDeletedDirectly() {
+    // given
+    UUID commentId = UUID.randomUUID();
+    UUID articleId = UUID.randomUUID();
+
+    UserActivityDocument userActivityDocument = UserActivityDocument.create(
+        userId,
+        "test@test.com",
+        "tester",
+        createdAt
+    );
+
+    CommentSummary summary = new CommentSummary(
+        commentId,
+        articleId,
+        "기사 제목",
+        userId,
+        "tester",
+        "댓글 내용",
+        0,
+        createdAt
+    );
+
+    userActivityDocument.addCommentSummary(summary);
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.of(userActivityDocument));
+
+    // when
+    userActivityService.removeCommentSummary(userId, commentId, articleId, true, true);
+
+    // then
+    ArgumentCaptor<UserActivityDocument> documentCaptor =
+        ArgumentCaptor.forClass(UserActivityDocument.class);
+
+    then(userActivityRepository).should().save(documentCaptor.capture());
+    then(userActivityRepository).should().removeCommentLikeSummaryByCommentId(commentId);
+    then(userActivityRepository).should().incrementArticleCommentCount(articleId, -1);
+
+    assertEquals(0, documentCaptor.getValue().getComments().size());
+  }
+
+  @Test
+  @DisplayName("하드 삭제 시 문서가 없으면 아무 작업도 하지 않습니다.")
+  void shouldDoNothing_whenUserActivityNotFoundOnHardDelete() {
+    // given
+    UUID commentId = UUID.randomUUID();
+    UUID articleId = UUID.randomUUID();
+
+    given(userActivityRepository.findById(userId)).willReturn(Optional.empty());
+
+    // when
+    userActivityService.removeCommentSummary(userId, commentId, articleId, true, true);
+
+    // then
+    then(userActivityRepository).should(never()).save(any());
+    then(userActivityRepository).should(never()).removeCommentLikeSummaryByCommentId(any());
+    then(userActivityRepository).should(never()).incrementArticleCommentCount(any(), anyInt());
   }
 }

--- a/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
+++ b/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
@@ -1424,8 +1424,8 @@ class UserActivityServiceTest {
   }
 
   @Test
-  @DisplayName("하드 삭제 시 문서가 없으면 아무 작업도 하지 않습니다.")
-  void shouldDoNothing_whenUserActivityNotFoundOnHardDelete() {
+  @DisplayName("하드 삭제 시 문서가 없으면 save는 하지 않고 좋아요 삭제와 댓글 수 감소는 수행합니다.")
+  void shouldSkipSaveButStillRemoveLikeAndDecrementCount_whenUserActivityNotFoundOnHardDelete() {
     // given
     UUID commentId = UUID.randomUUID();
     UUID articleId = UUID.randomUUID();
@@ -1437,7 +1437,7 @@ class UserActivityServiceTest {
 
     // then
     then(userActivityRepository).should(never()).save(any());
-    then(userActivityRepository).should(never()).removeCommentLikeSummaryByCommentId(any());
-    then(userActivityRepository).should(never()).incrementArticleCommentCount(any(), anyInt());
+    then(userActivityRepository).should().removeCommentLikeSummaryByCommentId(commentId);
+    then(userActivityRepository).should().incrementArticleCommentCount(articleId, -1);
   }
 }

--- a/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
+++ b/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
@@ -623,6 +623,7 @@ class UserActivityServiceTest {
   void shouldRemoveCommentSummary() {
     // given
     UUID commentId = UUID.randomUUID();
+    UUID articleId = UUID.randomUUID();
 
     UserActivityDocument document = UserActivityDocument.create(
         userId,
@@ -633,7 +634,7 @@ class UserActivityServiceTest {
 
     CommentSummary summary = new CommentSummary(
         commentId,
-        UUID.randomUUID(),
+        articleId,
         "기사 제목",
         userId,
         "tester",
@@ -647,7 +648,7 @@ class UserActivityServiceTest {
     given(userActivityRepository.findById(userId)).willReturn(Optional.of(document));
 
     // when
-    userActivityService.removeCommentSummary(userId, commentId);
+    userActivityService.removeCommentSummary(userId, commentId, articleId);
 
     // then
     ArgumentCaptor<UserActivityDocument> documentCaptor =
@@ -668,6 +669,7 @@ class UserActivityServiceTest {
     // given
     UUID commentId = UUID.randomUUID();
     UUID otherUserId = UUID.randomUUID();
+    UUID articleId = UUID.randomUUID();
 
     UserActivityDocument userActivityDocument = UserActivityDocument.create(
         userId,
@@ -678,7 +680,7 @@ class UserActivityServiceTest {
 
     CommentSummary commentSummary = new CommentSummary(
         commentId,
-        UUID.randomUUID(),
+        articleId,
         "기사 제목",
         userId,
         "tester",
@@ -698,7 +700,7 @@ class UserActivityServiceTest {
         UUID.randomUUID(),
         createdAt,
         commentId,         // 삭제될 댓글 ID
-        UUID.randomUUID(),
+        articleId,
         "기사 제목",
         userId,
         "tester",
@@ -711,22 +713,21 @@ class UserActivityServiceTest {
     otherUserActivityDocument.addCommentLikeSummary(commentLikeSummary);
 
     given(userActivityRepository.findById(userId)).willReturn(Optional.of(userActivityDocument));
-    given(userActivityRepository.findAllByCommentLikesCommentId(commentId))
-        .willReturn(List.of(otherUserActivityDocument));
 
     // when
-    userActivityService.removeCommentSummary(userId, commentId);
+    userActivityService.removeCommentSummary(userId, commentId, articleId);
 
     // then
     ArgumentCaptor<UserActivityDocument> documentCaptor =
         ArgumentCaptor.forClass(UserActivityDocument.class);
 
-    then(userActivityRepository).should(times(2)).save(documentCaptor.capture());
+    then(userActivityRepository).should(times(1)).save(documentCaptor.capture());
 
     List<UserActivityDocument> savedDocuments = documentCaptor.getAllValues();
 
     assertEquals(0, savedDocuments.get(0).getComments().size());
-    assertEquals(0, savedDocuments.get(1).getCommentLikes().size());
+    then(userActivityRepository).should().removeCommentLikeSummaryByCommentId(commentId);
+    then(userActivityRepository).should().incrementArticleCommentCount(articleId, -1);
   }
 
   @Test
@@ -734,11 +735,12 @@ class UserActivityServiceTest {
   void shouldDoNothingWhenUserActivityNotFoundOnRemoveCommentSummary() {
     // given
     UUID commentId = UUID.randomUUID();
+    UUID articleId = UUID.randomUUID();
 
     given(userActivityRepository.findById(userId)).willReturn(Optional.empty());
 
     // when
-    userActivityService.removeCommentSummary(userId, commentId);
+    userActivityService.removeCommentSummary(userId, commentId, articleId);
 
     // then
     then(userActivityRepository).should(never()).save(any());
@@ -1183,21 +1185,13 @@ class UserActivityServiceTest {
 
     given(userActivityRepository.findById(userId))
         .willReturn(Optional.of(userActivityDocument));
-    given(userActivityRepository.findAllByCommentLikesCommentIdIn(List.of(commentId)))
-        .willReturn(List.of(otherUserActivityDocument));
 
     // when
     userActivityService.deleteUserActivity(userId);
 
     // then
-    ArgumentCaptor<UserActivityDocument> documentCaptor =
-        ArgumentCaptor.forClass(UserActivityDocument.class);
-
-    then(userActivityRepository).should().save(documentCaptor.capture());
     then(userActivityRepository).should().deleteById(userId);
-
-    UserActivityDocument savedDocument = documentCaptor.getValue();
-    assertEquals(0, savedDocument.getCommentLikes().size());
+    then(userActivityRepository).should().removeCommentLikeSummariesByCommentIds(List.of(commentId));
   }
 
   @Test
@@ -1369,7 +1363,6 @@ class UserActivityServiceTest {
     );
 
     given(userActivityRepository.findById(userId)).willReturn(Optional.of(userActivityDocument));
-
     // when
     userActivityService.updateCommentSummary(summary);
 
@@ -1406,15 +1399,14 @@ class UserActivityServiceTest {
     userActivityDocument.addCommentSummary(summary);
 
     given(userActivityRepository.findById(userId)).willReturn(Optional.of(userActivityDocument));
-    given(userActivityRepository.findAllByCommentLikesCommentId(commentId))
-        .willReturn(List.of());
 
     // when
-    userActivityService.removeCommentSummary(userId, commentId);
+    userActivityService.removeCommentSummary(userId, commentId, articleId);
 
     // then
     then(userActivityRepository).should().save(any(UserActivityDocument.class));
     then(userActivityRepository).should().incrementArticleCommentCount(articleId, -1);
+    then(userActivityRepository).should().removeCommentLikeSummaryByCommentId(commentId);
   }
 
   @Test

--- a/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
+++ b/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
@@ -1318,7 +1318,6 @@ class UserActivityServiceTest {
 
     // then
     then(userActivityRepository).should().save(any(UserActivityDocument.class));
-    then(userActivityRepository).should().incrementArticleViewCount(articleId, -1);
   }
 
   @Test


### PR DESCRIPTION
## 관련 이슈
- closes #252 

## 작업 내용
- 다른 사람이 구독 등록/해제 시 구독자수 증가/감소
- 내가 쓴 댓글에 다른 사람이 좋아요하면 likeCount 증가/감소
- 내가 좋아요한 댓글에 다른 사람이 좋아요하면 commentLikeCount 증가/감소 동기화
- 다른 사람이 기사에 댓글 작성/삭제 시 활동 내역의 댓글 수인 articleCommentCount 동기화
- 다른 사람이 기사 조회 시 활동 내역의 articleViewCount 동기화
- 다른 사람의 좋아요한 댓글의 닉네임 동기화
- 이미 본 기사를 조회할 경우 최근 본 기사의 상단으로 이동
- 자기 자신의 댓글에 좋아요 가능하게 수정

## 변경 사항
- 기존 좋아요 이벤트를 알림에서만 사용하고, 활동 내역 이벤트를 따로 작성
- 기사 뷰 이벤트 발행시 isFirstView 필드 추가
- 댓글 삭제 이벤트 발행시 commentId 추가

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 댓글 좋아요 활동을 더 상세히 전달하는 활동 이벤트 추가

* **개선 사항**
  * 기사 조회에 ‘첫 조회 여부(isFirstView)’ 정보 포함
  * 사용자 닉네임 변경 시 다른 사용자의 댓글 좋아요 요약에 닉네임 자동 반영
  * 구독자·댓글·댓글좋아요·조회수 등 중첩 카운터를 원자적으로 증감하도록 처리 강화
  * 좋아요·삭제·언라이크 관련 이벤트 처리와 전파 로직 정교화

* **테스트**
  * 이벤트 흐름 및 카운터/삭제 동작을 검증하는 단위 테스트 확장 및 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->