### PR TITLE
feat: 뉴스기사 데이터 생성기 구현

### DIFF
--- a/src/main/java/com/team3/monew/testdata/DataGenerationRunner.java
+++ b/src/main/java/com/team3/monew/testdata/DataGenerationRunner.java
@@ -1,6 +1,8 @@
 package com.team3.monew.testdata;
 
+import com.team3.monew.entity.NewsArticle;
 import com.team3.monew.entity.User;
+import com.team3.monew.testdata.generator.NewsArticleGenerator;
 import com.team3.monew.testdata.generator.NotificationGenerator;
 import com.team3.monew.testdata.generator.UserGenerator;
 import java.util.List;
@@ -22,6 +24,7 @@ public class DataGenerationRunner implements CommandLineRunner {
 
   private final ApplicationContext context;
   private final UserGenerator userGenerator;
+  private final NewsArticleGenerator newsArticleGenerator;
   private final NotificationGenerator notificationGenerator;
 
   // private final로 제너레이트 추가
@@ -33,6 +36,9 @@ public class DataGenerationRunner implements CommandLineRunner {
     // 데이터 생성 순서 주의(의존 관계 고려)
     List<User> generatedUsers = userGenerator.generate(10000, 1000); // 1만 명 생성, 1천 건씩 배치
     log.info("✅ 사용자 데이터 생성 완료");
+
+    List<NewsArticle> generatedArticles = newsArticleGenerator.generate(10000, 1000);
+    log.info("✅ 뉴스 기사 데이터 생성 완료");
 
     notificationGenerator.setUsers(generatedUsers);
     notificationGenerator.generate(10000, 1000);

--- a/src/main/java/com/team3/monew/testdata/generator/NewsArticleGenerator.java
+++ b/src/main/java/com/team3/monew/testdata/generator/NewsArticleGenerator.java
@@ -52,11 +52,7 @@ public class NewsArticleGenerator extends AbstractGenerator<NewsArticle> {
         // NewsArticle은 NewsSource를 참조하므로 미리 준비된 sourcePool에서 매핑
         .supply(field(NewsArticle::getSource), () ->
             sourcePool.get(ThreadLocalRandom.current().nextInt(sourcePool.size())))
-        // original_link는 unique 제약이 있어 source baseUrl과 UUID를 조합해 생성
-        .supply(field(NewsArticle::getOriginalLink), () -> {
-          NewsSource source = sourcePool.get(ThreadLocalRandom.current().nextInt(sourcePool.size()));
-          return source.getBaseUrl() + "/news/" + UUID.randomUUID();
-        })
+        .ignore(field(NewsArticle::getOriginalLink)) // setValues()에서 source 기준으로 생성
         .supply(field(NewsArticle::getTitle), () -> {
           String title = faker().lorem().sentence(3, 6);
           return title.length() > 500 ? title.substring(0, 500) : title;
@@ -90,10 +86,11 @@ public class NewsArticleGenerator extends AbstractGenerator<NewsArticle> {
     long diffMillis = Instant.now().toEpochMilli() - createdAt.getTime();
     long randomOffset = ThreadLocalRandom.current().nextLong(0, diffMillis + 1);
     Timestamp updatedAt = new Timestamp(createdAt.getTime() + randomOffset);
+    String originalLink = article.getSource().getBaseUrl() + "/news/" + UUID.randomUUID();
 
     ps.setObject(1, article.getId());
     ps.setObject(2, article.getSource().getId());
-    ps.setString(3, article.getOriginalLink());
+    ps.setString(3, originalLink);
     ps.setString(4, article.getTitle());
     ps.setTimestamp(5, Timestamp.from(article.getPublishedAt()));
     ps.setString(6, article.getSummary());

--- a/src/main/java/com/team3/monew/testdata/generator/NewsArticleGenerator.java
+++ b/src/main/java/com/team3/monew/testdata/generator/NewsArticleGenerator.java
@@ -1,0 +1,119 @@
+package com.team3.monew.testdata.generator;
+
+import static org.instancio.Select.field;
+
+import com.team3.monew.entity.NewsArticle;
+import com.team3.monew.entity.NewsSource;
+import com.team3.monew.repository.NewsSourceRepository;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadLocalRandom;
+import lombok.extern.slf4j.Slf4j;
+import org.instancio.Instancio;
+import org.instancio.Model;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile("data-gen")
+public class NewsArticleGenerator extends AbstractGenerator<NewsArticle> {
+
+  private final NewsSourceRepository newsSourceRepository;
+  private List<NewsSource> sourcePool = new ArrayList<>();
+
+  public NewsArticleGenerator(
+      JdbcTemplate jdbcTemplate,
+      @Qualifier("dataGeneratorExecutor") Executor executor,
+      NewsSourceRepository newsSourceRepository
+  ) {
+    super(jdbcTemplate, executor);
+    this.newsSourceRepository = newsSourceRepository;
+  }
+
+  public void setSources(List<NewsSource> sources) {
+    if (sources == null || sources.isEmpty()) {
+      throw new IllegalStateException("sourcePool이 비어 있습니다. setSources()에 유효한 source 목록이 필요합니다.");
+    }
+    this.sourcePool = sources;
+  }
+
+  @Override
+  protected Model<NewsArticle> getModel() {
+    return Instancio.of(NewsArticle.class)
+        .supply(field(NewsArticle::getSource), () ->
+            sourcePool.get(ThreadLocalRandom.current().nextInt(sourcePool.size())))
+        .supply(field(NewsArticle::getOriginalLink), () -> {
+          NewsSource source = sourcePool.get(ThreadLocalRandom.current().nextInt(sourcePool.size()));
+          return source.getBaseUrl() + "/news/" + UUID.randomUUID();
+        })
+        .supply(field(NewsArticle::getTitle), () -> {
+          String title = faker().lorem().sentence(3, 6);
+          return title.length() > 500 ? title.substring(0, 500) : title;
+        })
+        .supply(field(NewsArticle::getSummary), () -> {
+          String summary = faker().lorem().paragraph();
+          return summary.length() > 1000 ? summary.substring(0, 1000) : summary;
+        })
+        .supply(field(NewsArticle::getPublishedAt), () ->
+            Instant.now().minusSeconds(ThreadLocalRandom.current().nextLong(30L * 24 * 60 * 60)))
+        .supply(field(NewsArticle::getCommentCount), () -> 0)
+        .supply(field(NewsArticle::getViewCount), () -> ThreadLocalRandom.current().nextInt(0, 5001))
+        .toModel();
+  }
+
+  @Override
+  protected String getSql() {
+    return """
+        INSERT INTO news_articles (
+          id, source_id, original_link, title, published_at, summary,
+          comment_count, view_count, delete_status, deleted_at, created_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT (original_link) DO NOTHING
+        """;
+  }
+
+  @Override
+  protected void setValues(PreparedStatement ps, NewsArticle article) throws SQLException {
+    Timestamp createdAt = getUniformTimestamp(30);
+    long diffMillis = Instant.now().toEpochMilli() - createdAt.getTime();
+    long randomOffset = ThreadLocalRandom.current().nextLong(0, diffMillis + 1);
+    Timestamp updatedAt = new Timestamp(createdAt.getTime() + randomOffset);
+
+    ps.setObject(1, article.getId());
+    ps.setObject(2, article.getSource().getId());
+    ps.setString(3, article.getOriginalLink());
+    ps.setString(4, article.getTitle());
+    ps.setTimestamp(5, Timestamp.from(article.getPublishedAt()));
+    ps.setString(6, article.getSummary());
+    ps.setInt(7, article.getCommentCount());
+    ps.setInt(8, article.getViewCount());
+    ps.setString(9, "ACTIVE");
+    ps.setNull(10, java.sql.Types.TIMESTAMP_WITH_TIMEZONE);
+    ps.setTimestamp(11, createdAt);
+    ps.setTimestamp(12, updatedAt);
+  }
+
+  @Override
+  public List<NewsArticle> generate(int totalSize, int chunkSize) {
+    if (sourcePool.isEmpty()) {
+      List<NewsSource> sources = newsSourceRepository.findAll();
+      if (sources.isEmpty()) {
+        throw new IllegalStateException("news_sources가 비어 있습니다. 뉴스기사 생성 전에 source 데이터가 필요합니다.");
+      }
+      this.sourcePool = sources;
+      log.info("뉴스기사 생성용 source {}건 로드 완료", sources.size());
+    }
+
+    return super.generate(totalSize, chunkSize);
+  }
+}


### PR DESCRIPTION

## 관련 이슈
- closes #263 

## 작업 내용
- 뉴스 기사 제너레이터 구현

## 변경 사항
- 주요 변경 사항을 작성해주세요.

## 테스트 내용
- [ ] 테스트 코드 작성
- [ ] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 테스트 데이터 생성 인프라가 뉴스 기사 데이터 셋을 포함하도록 업데이트되었습니다. 이제 배치 처리를 통해 10,000개의 뉴스 기사 샘플 데이터를 생성할 수 있습니다. 데이터 생성 시퀀스가 개선되어 더 포괄적인 테스트 환경을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->