### PR TITLE
fix: 뉴스 기사 삭제 시 이벤트 누락 수정

### DIFF
--- a/src/main/java/com/team3/monew/repository/UserActivityRepository.java
+++ b/src/main/java/com/team3/monew/repository/UserActivityRepository.java
@@ -56,4 +56,19 @@ public interface UserActivityRepository extends MongoRepository<UserActivityDocu
   @Query("{ 'commentLikes.commentId': { $in: ?0 } }")
   @Update("{ '$pull': { 'commentLikes': { 'commentId': { $in: ?0 } } } }")
   void removeCommentLikeSummariesByCommentIds(List<UUID> commentIds);
+
+  // articleViews에서 해당 기사 항목 일괄 제거
+  @Query("{ 'articleViews.articleId': ?0 }")
+  @Update("{ '$pull': { 'articleViews': { 'articleId': ?0 } } }")
+  void removeArticleViewSummaryByArticleId(UUID articleId);
+
+  // comments에서 해당 기사 댓글 일괄 제거
+  @Query("{ 'comments.articleId': ?0 }")
+  @Update("{ '$pull': { 'comments': { 'articleId': ?0 } } }")
+  void removeCommentSummaryByArticleId(UUID articleId);
+
+  // commentLikes에서 해당 기사 댓글 좋아요 일괄 제거
+  @Query("{ 'commentLikes.articleId': ?0 }")
+  @Update("{ '$pull': { 'commentLikes': { 'articleId': ?0 } } }")
+  void removeCommentLikeSummaryByArticleId(UUID articleId);
 }

--- a/src/main/java/com/team3/monew/service/ArticleService.java
+++ b/src/main/java/com/team3/monew/service/ArticleService.java
@@ -12,6 +12,7 @@ import com.team3.monew.entity.ArticleBackupJob;
 import com.team3.monew.entity.NewsArticle;
 import com.team3.monew.entity.enums.BackupJobStatus;
 import com.team3.monew.entity.enums.BackupJobType;
+import com.team3.monew.event.ArticleDeletedEvent;
 import com.team3.monew.exception.article.ArticleInvalidPeriodException;
 import com.team3.monew.exception.article.ArticleNotFoundException;
 import com.team3.monew.exception.article.DeletedArticleException;
@@ -47,6 +48,7 @@ import java.util.zip.GZIPInputStream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -75,6 +77,7 @@ public class ArticleService {
   private final ArticleMapper articleMapper;
   private final TaskExecutor decompressTaskExecutor;
   private final ObjectMapper backupObjectMapper;
+  private final ApplicationEventPublisher eventPublisher;
 
   @Value("${app.restore.concurrency:3}")
   private int downloadAndDecompressConcurrency;
@@ -170,7 +173,8 @@ public class ArticleService {
     articleViewRepository.deleteAllByArticleId(articleId);
     // 3. Comments 삭제
     commentRepository.deleteAllByArticleId(articleId);
-
+    // 활동 내역 이벤트 발행
+    eventPublisher.publishEvent(new ArticleDeletedEvent(newsArticle.getId()));
     newsArticleRepository.delete(newsArticle);
     log.info("뉴스기사 물리삭제 성공 - articleId={}", articleId);
   }

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -250,13 +250,9 @@ public class UserActivityService {
 
   public void removeArticleViewSummary(UUID articleId) {
     log.debug("사용자 활동 내역 기사 뷰 삭제 시작: articleId={}", articleId);
-    List<UserActivityDocument> userActivityDocuments =
-        userActivityRepository.findAllByArticleViewsArticleId(articleId);
-
-    userActivityDocuments.forEach(userActivityDocument -> {
-      userActivityDocument.removeArticleViewSummary(articleId);
-      userActivityRepository.save(userActivityDocument);
-    });
+    userActivityRepository.removeArticleViewSummaryByArticleId(articleId);
+    userActivityRepository.removeCommentSummaryByArticleId(articleId);
+    userActivityRepository.removeCommentLikeSummaryByArticleId(articleId);
     log.debug("사용자 활동 내역 기사 뷰 삭제 성공: articleId={}", articleId);
   }
 

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -248,6 +248,11 @@ public class UserActivityService {
     log.debug("사용자 활동 내역 댓글 좋아요 삭제 성공: userId={} commentLikeId={}", userId, commentLikeId);
   }
 
+  @Retryable(
+      retryFor = TransientDataAccessException.class,
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 100)
+  )
   public void removeArticleViewSummary(UUID articleId) {
     log.debug("사용자 활동 내역 기사 뷰 삭제 시작: articleId={}", articleId);
     userActivityRepository.removeArticleViewSummaryByArticleId(articleId);

--- a/src/test/java/com/team3/monew/service/ArticleServiceTest.java
+++ b/src/test/java/com/team3/monew/service/ArticleServiceTest.java
@@ -34,6 +34,7 @@ import com.team3.monew.entity.enums.BackupJobStatus;
 import com.team3.monew.entity.enums.BackupJobType;
 import com.team3.monew.entity.enums.DeleteStatus;
 import com.team3.monew.entity.enums.NewsSourceType;
+import com.team3.monew.event.ArticleDeletedEvent;
 import com.team3.monew.exception.article.ArticleInvalidPeriodException;
 import com.team3.monew.exception.article.ArticleNotFoundException;
 import com.team3.monew.exception.article.DeletedArticleException;
@@ -74,6 +75,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.task.SyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.test.context.ActiveProfiles;
@@ -112,6 +114,8 @@ class ArticleServiceTest {
   private ObjectMapper mockedBackupObjectMapper;
   @Mock
   private ArticleBatchService articleBatchService;
+  @Mock
+  ApplicationEventPublisher eventPublisher;
 
   @Spy
   @InjectMocks
@@ -530,6 +534,7 @@ class ArticleServiceTest {
       then(articleViewRepository).should().deleteAllByArticleId(articleId);
       then(commentRepository).should().deleteAllByArticleId(articleId);
       then(newsArticleRepository).should().delete(newsArticle);
+      then(eventPublisher).should().publishEvent(any(ArticleDeletedEvent.class));
     }
   }
 

--- a/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
+++ b/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
@@ -813,47 +813,19 @@ class UserActivityServiceTest {
   }
 
   @Test
-  @DisplayName("뉴스 기사 삭제 시 활동 내역에서 해당 기사 뷰를 삭제합니다.")
-  void shouldRemoveArticleView_whenArticleRemoved() {
-    //given
+  @DisplayName("기사 삭제 시 활동 내역의 기사 뷰, 댓글, 댓글 좋아요를 일괄 제거합니다.")
+  void shouldRemoveAllArticleActivitySummary_whenArticleDeleted() {
+    // given
     UUID articleId = UUID.randomUUID();
-
-    UserActivityDocument document = UserActivityDocument.create(
-        userId,
-        "test@test.com",
-        "tester",
-        createdAt
-    );
-
-    ArticleViewSummary articleViewSummary = new ArticleViewSummary(
-        UUID.randomUUID(),
-        UUID.randomUUID(),
-        Instant.now(),
-        articleId,
-        "source1",
-        "sourceUrl1",
-        "title1",
-        Instant.now(),
-        "summary1",
-        1,
-        100
-    );
-
-    document.addArticleViewSummary(articleViewSummary);
-    given(userActivityRepository.findAllByArticleViewsArticleId(articleId)).willReturn(List.of(document));
 
     // when
     userActivityService.removeArticleViewSummary(articleId);
 
     // then
-    ArgumentCaptor<UserActivityDocument> documentCaptor =
-        ArgumentCaptor.forClass(UserActivityDocument.class);
-    then(userActivityRepository).should().save(documentCaptor.capture());
-
-    UserActivityDocument savedDocument = documentCaptor.getValue();
-    assertNotNull(savedDocument);
-    assertEquals(userId, savedDocument.getId());
-    assertEquals(0, savedDocument.getArticleViews().size());
+    then(userActivityRepository).should().removeArticleViewSummaryByArticleId(articleId);
+    then(userActivityRepository).should().removeCommentSummaryByArticleId(articleId);
+    then(userActivityRepository).should().removeCommentLikeSummaryByArticleId(articleId);
+    then(userActivityRepository).should(never()).save(any());
   }
 
   @Test
@@ -1279,45 +1251,6 @@ class UserActivityServiceTest {
     // then
     then(userActivityRepository).should().save(any(UserActivityDocument.class));
     then(userActivityRepository).should().incrementArticleViewCount(articleId, 1);
-  }
-
-  @Test
-  @DisplayName("기사 삭제 시 기사 뷰 조회수가 감소합니다.")
-  void shouldDecrementArticleViewCount_whenArticleDeleted() {
-    // given
-    UUID articleId = UUID.randomUUID();
-
-    UserActivityDocument userActivityDocument = UserActivityDocument.create(
-        userId,
-        "test@test.com",
-        "tester",
-        createdAt
-    );
-
-    ArticleViewSummary summary = new ArticleViewSummary(
-        UUID.randomUUID(),
-        userId,
-        createdAt,
-        articleId,
-        "NAVER",
-        "https://example.com",
-        "기사 제목",
-        createdAt,
-        "기사 요약",
-        3,
-        100
-    );
-
-    userActivityDocument.addArticleViewSummary(summary);
-
-    given(userActivityRepository.findAllByArticleViewsArticleId(articleId))
-        .willReturn(List.of(userActivityDocument));
-
-    // when
-    userActivityService.removeArticleViewSummary(articleId);
-
-    // then
-    then(userActivityRepository).should().save(any(UserActivityDocument.class));
   }
 
   @Test


### PR DESCRIPTION
## 관련 이슈
- closes #278 

## 작업 내용
- ArticleDeletedEvent 발행 코드 추가
- 삭제 기사의 댓글, 좋아요 한 댓글 삭제 반영 
- 관련 테스트 코드 추가 및 수정 완료

## 변경 사항
- 

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [ ] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 논리 삭제는 댓글 삭제와 마찬가지로 활동 내역에는 표시되게 하였습니다.

## 스크린샷 / 참고 자료
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 게시물 영구삭제 시 삭제 이벤트 발행 추가
  * 배치 기반 기사 수집 작업 및 예약 스케줄러 추가(주기/성공·실패 메트릭 기록)
  * 로드테스트에 댓글 시나리오 및 댓글 태스크 추가

* **버그 수정 / 개선**
  * 게시물 관련 활동 요약(article view, comment, comment like) 일괄 삭제 기능 추가
  * 활동 요약 삭제를 재시도 지원으로 안정성 향상

* **테스트**
  * 배치/스케줄러와 삭제 이벤트·활동 삭제 검증 테스트 추가 및 강화

* **설정**
  * 뉴스 수집 모드 기본 설정을 batch로 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->