### PR TITLE
refactor: 뉴스기사 수집 배치로 변경

### DIFF
--- a/src/main/java/com/team3/monew/batch/job/ArticleCollectBatchConfig.java
+++ b/src/main/java/com/team3/monew/batch/job/ArticleCollectBatchConfig.java
@@ -1,0 +1,168 @@
+package com.team3.monew.batch.job;
+
+import com.team3.monew.component.news.client.NewsClient;
+import com.team3.monew.component.news.filter.KeywordMatch;
+import com.team3.monew.component.news.record.ParsedNewsArticle;
+import com.team3.monew.entity.InterestKeyword;
+import com.team3.monew.entity.NewsArticle;
+import com.team3.monew.entity.enums.NewsSourceType;
+import com.team3.monew.repository.InterestKeywordRepository;
+import com.team3.monew.service.NewsSaveService;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.annotation.BeforeStep;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import reactor.core.publisher.Flux;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class ArticleCollectBatchConfig {
+
+  private final JobRepository jobRepository;
+  private final PlatformTransactionManager platformTransactionManager;
+
+  private final KeywordMatch keywordMatch;
+  private final InterestKeywordRepository interestKeywordRepository;
+  private final NewsSaveService newsSaveService;
+  private final Map<String, NewsClient> newsClients;
+
+  @Bean
+  public Job articleCollectBatchJob() {
+    return new JobBuilder("articleCollectBatchJob", jobRepository)
+        .start(collectArticleStep())
+        .build();
+  }
+
+  @Bean
+  public Step collectArticleStep() {
+    return new StepBuilder("collectArticleStep", jobRepository)
+        .<List<InterestKeyword>, List<ParsedNewsArticle>>chunk(1, platformTransactionManager)
+        .reader(interestKeywordReader())
+        .processor(newsCollectProcessor())
+        .writer(newsArticleWriter())
+        .build();
+  }
+
+  @Bean
+  @StepScope
+  public ItemReader<List<InterestKeyword>> interestKeywordReader() {
+    return new InterestKeywordReader(interestKeywordRepository, keywordMatch);
+  }
+
+  @RequiredArgsConstructor
+  static class InterestKeywordReader implements ItemReader<List<InterestKeyword>> {
+
+    private final InterestKeywordRepository interestKeywordRepository;
+    private final KeywordMatch keywordMatch;
+    private boolean alreadyRead = false;
+
+    @Override
+    public List<InterestKeyword> read() {
+      if (alreadyRead) {
+        return null;
+      }
+      alreadyRead = true;
+
+      List<InterestKeyword> interestKeywordList = interestKeywordRepository.findAllWithInterest();
+
+      // 관심사와, 키워드를 하나로 묶기
+      Set<String> keywords = interestKeywordList.stream()
+          .flatMap(ik -> Stream.of(ik.getInterest().getName(), ik.getKeyword()))
+          .collect(Collectors.toSet());
+      keywordMatch.refreshKeywords(keywords);
+
+      return interestKeywordList;
+    }
+  }
+
+  @Bean
+  public ItemProcessor<List<InterestKeyword>, List<ParsedNewsArticle>> newsCollectProcessor() {
+    return new NewsCollectProcessor(newsClients);
+  }
+
+  @RequiredArgsConstructor
+  static class NewsCollectProcessor implements
+      ItemProcessor<List<InterestKeyword>, List<ParsedNewsArticle>> {
+
+    private final Map<String, NewsClient> newsClients;
+
+    @Override
+    public List<ParsedNewsArticle> process(List<InterestKeyword> interestKeywords) {
+
+      return Flux.fromIterable(newsClients.values())
+          .flatMap(
+              client -> client.fetchAndProcess(interestKeywords),
+              newsClients.size()
+          )
+          .flatMapIterable(list -> list)
+          .collectList()
+          .map(this::deduplicateByLinkWithNaverPriorityAndOrderByPublishAtDesc)
+          .block();
+    }
+
+    private List<ParsedNewsArticle> deduplicateByLinkWithNaverPriorityAndOrderByPublishAtDesc(
+        List<ParsedNewsArticle> list) {
+      return list.stream()
+          .collect(Collectors.toMap(
+              ParsedNewsArticle::link,               //   key: link
+              article -> article,     // value: ParsedNewsArticle
+              (existing, replacement) ->
+                  // merge function. 중복일 시 Naver우선으로 충돌 해결
+                  NewsSourceType.NAVER.equals(existing.sourceType())
+                      ? existing
+                      : replacement
+          ))
+          .values()
+          .stream()
+          .sorted(Comparator.comparing(ParsedNewsArticle::publishedAt).reversed())
+          .toList();
+    }
+  }
+
+  @Bean
+  public ItemWriter<List<ParsedNewsArticle>> newsArticleWriter() {
+    return new NewsArticleWriter(newsSaveService);
+  }
+
+  @RequiredArgsConstructor
+  static class NewsArticleWriter implements ItemWriter<List<ParsedNewsArticle>> {
+
+    private final NewsSaveService newsSaveService;
+    private StepExecution stepExecution;
+
+    @BeforeStep
+    public void beforeStep(StepExecution stepExecution) {
+      this.stepExecution = stepExecution;
+    }
+
+    @Override
+    public void write(Chunk<? extends List<ParsedNewsArticle>> chunk) {
+      for (List<ParsedNewsArticle> parsedNewsArticles : chunk) {
+        List<NewsArticle> articles = newsSaveService.saveAndNotify(parsedNewsArticles);
+
+        stepExecution.getJobExecution().getExecutionContext()
+            .putLong("savedArticleCount", articles.size());
+      }
+    }
+  }
+}

--- a/src/main/java/com/team3/monew/batch/scheduler/ArticleCollectBatchScheduleConfig.java
+++ b/src/main/java/com/team3/monew/batch/scheduler/ArticleCollectBatchScheduleConfig.java
@@ -1,0 +1,52 @@
+package com.team3.monew.batch.scheduler;
+
+import com.team3.monew.monitoring.BatchMetrics;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Slf4j
+@Configuration
+@ConditionalOnProperty(prefix = "app.news", name = "collector-mode", havingValue = "batch")
+@RequiredArgsConstructor
+public class ArticleCollectBatchScheduleConfig {
+
+  private final JobLauncher jobLauncher;
+  private final BatchMetrics batchMetrics;
+  private final Job articleCollectBatchJob;
+
+  @Scheduled(cron = "${app.cron.news-collections:0 0/5 * * * *}")
+  public void runArticleCollect() {
+    long startTime = System.currentTimeMillis();
+    try {
+      log.info("뉴스기사 수집 배치 스케줄러 시작");
+      ZoneId zone = ZoneId.of("Asia/Seoul");
+      JobParameters jobParameters = new JobParametersBuilder()
+          .addLocalDateTime("collectedAt", LocalDateTime.now(zone))
+          .toJobParameters();
+      JobExecution execution = jobLauncher.run(articleCollectBatchJob, jobParameters);
+
+      if (execution.getStatus() == BatchStatus.COMPLETED) {
+        batchMetrics.recordNewsCollectSuccess(System.currentTimeMillis() - startTime,
+            execution.getExecutionContext().getLong("savedArticleCount", 0L));
+        log.info("뉴스기사 수집 배치 스케줄러 완료");
+      } else {
+        batchMetrics.recordNewsCollectFailure(System.currentTimeMillis() - startTime);
+        log.error("뉴스기사 수집 배치 스케줄러 오류 발생 - status={}", execution.getStatus());
+      }
+    } catch (Exception e) {
+      batchMetrics.recordNewsCollectFailure(System.currentTimeMillis() - startTime);
+      log.error("뉴스기사 수집 배치 스케줄러 실행 실패", e);
+    }
+  }
+}

--- a/src/main/java/com/team3/monew/service/NewsCollectService.java
+++ b/src/main/java/com/team3/monew/service/NewsCollectService.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
@@ -23,6 +24,7 @@ import reactor.core.scheduler.Schedulers;
 
 @Slf4j
 @Service
+@ConditionalOnProperty(prefix = "app.news", name = "collector-mode", havingValue = "reactive")
 @RequiredArgsConstructor
 public class NewsCollectService {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,8 @@ app:
   cron:
     # "초 분 시 일 월 요일" (cron)
     news-collections: "0 0 * * * *" # 1시간 마다
+  news:
+    collector-mode: batch   # batch 배치, reactive 비동기
 
 # 배치 크기, 시간 설정
 batch:

--- a/src/test/java/com/team3/monew/batch/job/ArticleCollectBatchConfigTest.java
+++ b/src/test/java/com/team3/monew/batch/job/ArticleCollectBatchConfigTest.java
@@ -1,0 +1,170 @@
+package com.team3.monew.batch.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+import com.team3.monew.component.news.client.ChosunNewsClient;
+import com.team3.monew.component.news.client.NaverNewsClient;
+import com.team3.monew.component.news.client.NewsClient;
+import com.team3.monew.component.news.filter.KeywordMatch;
+import com.team3.monew.component.news.record.ParsedNewsArticle;
+import com.team3.monew.entity.Interest;
+import com.team3.monew.entity.InterestKeyword;
+import com.team3.monew.entity.NewsArticle;
+import com.team3.monew.entity.NewsSource;
+import com.team3.monew.entity.enums.NewsSourceType;
+import com.team3.monew.repository.InterestKeywordRepository;
+import com.team3.monew.service.NewsSaveService;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.test.util.ReflectionTestUtils;
+import reactor.core.publisher.Mono;
+
+@Tag("unit")
+@ExtendWith(MockitoExtension.class)
+class ArticleCollectBatchConfigTest {
+
+  @Nested
+  class InterestKeywordReader {
+
+    @Mock
+    private InterestKeywordRepository interestKeywordRepository;
+    @Mock
+    private KeywordMatch keywordMatch;
+
+    @InjectMocks
+    private ArticleCollectBatchConfig.InterestKeywordReader interestKeywordReader;
+
+    @Test
+    @DisplayName("repository에서 얻은 List로 한번에 반환한다")
+    void shouldReturnKeywordList_whenReadFirstTime() {
+      // given
+      Interest samsungInterest = Interest.create("삼성");
+      InterestKeyword interestKeyword = InterestKeyword.create(samsungInterest, "메모리");
+      List<InterestKeyword> expected = List.of(interestKeyword);
+      given(interestKeywordRepository.findAllWithInterest()).willReturn(expected);
+
+      // when
+      List<InterestKeyword> actual = interestKeywordReader.read();
+
+      // then
+      then(keywordMatch).should().refreshKeywords(anySet());
+      assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("reader를 두 번 호출하면 null을 반환한다")
+    void shouldReturnNull_whenReadCalledSecondTime() {
+      // when
+      interestKeywordReader.read();
+      List<InterestKeyword> actual = interestKeywordReader.read();
+
+      // then
+      assertThat(actual).isNull();
+    }
+  }
+
+  @Nested
+  class NewsCollectProcessor {
+
+    @Mock
+    private NaverNewsClient naverNewsClient;
+    @Mock
+    private ChosunNewsClient chosunNewsClient;
+    @Mock
+    private Map<String, NewsClient> newsClients;
+
+    @InjectMocks
+    private ArticleCollectBatchConfig.NewsCollectProcessor newsCollectProcessor;
+
+    @Test
+    @DisplayName("동일한 링크 기사가 여러 Source에서 수집되면, 네이버 기사를 최우선으로 남긴다")
+    void shouldKeepNaverArticle_whenMultipleSourcesProvideSameLink() {
+      // given
+      Interest samsungInterest = Interest.create("삼성");
+      List<InterestKeyword> interestKeywords = List.of(
+          InterestKeyword.create(samsungInterest, "메모리"));
+      String commonLink = "commonLink";
+      given(newsClients.values()).willReturn(List.of(naverNewsClient, chosunNewsClient));
+      given(newsClients.size()).willReturn(2);
+
+      List<ParsedNewsArticle> naverList = List.of(
+          new ParsedNewsArticle(NewsSourceType.NAVER, commonLink, "제목1", Instant.now(), null,
+              interestKeywords)
+      );
+      given(naverNewsClient.fetchAndProcess(anyList())).willReturn(Mono.just(naverList));
+      List<ParsedNewsArticle> chosunList = List.of(
+          new ParsedNewsArticle(NewsSourceType.CHOSUN, commonLink, "제목1", Instant.now(), null,
+              interestKeywords)
+      );
+      given(chosunNewsClient.fetchAndProcess(anyList())).willReturn(Mono.just(chosunList));
+
+      // when
+      List<ParsedNewsArticle> actual = newsCollectProcessor.process(interestKeywords);
+
+      // then
+      assertThat(actual)
+          .extracting("sourceType")
+          .containsExactly(NewsSourceType.NAVER);
+    }
+  }
+
+  @Nested
+  class NewsArticleWriter {
+
+    @Mock
+    private NewsSaveService newsSaveService;
+    @Mock
+    private StepExecution stepExecution;
+    @Mock
+    private JobExecution jobExecution;
+    @Mock
+    private ExecutionContext executionContext;
+
+    @InjectMocks
+    private ArticleCollectBatchConfig.NewsArticleWriter newsArticleWriter;
+
+    @Test
+    @DisplayName("기사를 저장하고 저장 개수를 execution context에 기록한다")
+    void shouldSaveArticlesAndStoreCount_whenWriteCalled() {
+      // given
+      ParsedNewsArticle parsed = new ParsedNewsArticle(NewsSourceType.NAVER, "link", "title",
+          Instant.now(), "summary", List.of());
+      List<ParsedNewsArticle> parsedNewsArticles = List.of(parsed);
+
+      NewsArticle article = NewsArticle.create(mock(NewsSource.class), "link", "title",
+          Instant.now(), "summary");
+      List<NewsArticle> articles = List.of(article);
+      given(newsSaveService.saveAndNotify(anyList())).willReturn(articles);
+
+      ReflectionTestUtils.setField(newsArticleWriter, "stepExecution", stepExecution);
+      given(stepExecution.getJobExecution()).willReturn(jobExecution);
+      given(jobExecution.getExecutionContext()).willReturn(executionContext);
+
+      // when
+      newsArticleWriter.write(new Chunk<>(List.of(parsedNewsArticles)));
+
+      // then
+      then(executionContext).should()
+          .putLong("savedArticleCount", 1L);
+    }
+
+  }
+}

--- a/src/test/java/com/team3/monew/batch/scheduler/ArticleCollectBatchScheduleConfigTest.java
+++ b/src/test/java/com/team3/monew/batch/scheduler/ArticleCollectBatchScheduleConfigTest.java
@@ -1,0 +1,81 @@
+package com.team3.monew.batch.scheduler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.team3.monew.monitoring.BatchMetrics;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.launch.JobLauncher;
+
+@Tag("unit")
+@ExtendWith(MockitoExtension.class)
+class ArticleCollectBatchScheduleConfigTest {
+
+  @Mock
+  private JobLauncher jobLauncher;
+  @Mock
+  private BatchMetrics batchMetrics;
+
+  @InjectMocks
+  private ArticleCollectBatchScheduleConfig articleCollectBatchScheduleConfig;
+
+  @Test
+  @DisplayName("배치 스케줄러 예외가 발생하면 에러 로그와 metric을 기록한다")
+  void shouldRecordLog_whenSchedulerThrowError() throws Exception {
+    // given
+    given(jobLauncher.run(any(), any())).willThrow(new RuntimeException("스케줄러 에러"));
+
+    // when
+    articleCollectBatchScheduleConfig.runArticleCollect();
+
+    // then
+    then(batchMetrics).should()
+        .recordNewsCollectFailure(anyLong());
+  }
+
+  @Test
+  @DisplayName("배치 스케줄러가 FAILED인 경우 에러 로그와 metric을 기록한다")
+  void shouldRecordLog_whenSchedulerStatusIsFailed() throws Exception {
+    // given
+    JobExecution execution = new JobExecution(22L);
+    execution.setStatus(BatchStatus.FAILED);
+    execution.addFailureException(new RuntimeException("스케줄러 내부 에러"));
+    given(jobLauncher.run(any(), any())).willReturn(execution);
+
+    // when
+    articleCollectBatchScheduleConfig.runArticleCollect();
+
+    // then
+    then(batchMetrics).should()
+        .recordNewsCollectFailure(anyLong());
+  }
+
+  @Test
+  @DisplayName("배치 스케줄러가 COMPLETED인 경우 성공 로그와 metric을 기록한다")
+  void shouldRecordLog_whenSchedulerStatusIsCompleted() throws Exception {
+    // given
+    long savedArticleCount = 500L;
+    JobExecution execution = new JobExecution(22L);
+    execution.setStatus(BatchStatus.COMPLETED);
+    execution.getExecutionContext().putLong("savedArticleCount", savedArticleCount);
+    given(jobLauncher.run(any(), any())).willReturn(execution);
+    
+    // when
+    articleCollectBatchScheduleConfig.runArticleCollect();
+
+    // then
+    then(batchMetrics).should()
+        .recordNewsCollectSuccess(anyLong(), eq(savedArticleCount));
+  }
+}

--- a/src/test/java/com/team3/monew/integration/NewsCollectIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/NewsCollectIntegrationTest.java
@@ -24,11 +24,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.EnabledIf;
 import reactor.test.StepVerifier;
 
 @SpringBootTest
 @ActiveProfiles("test")
 @Tag("external-api")
+@EnabledIf(
+    expression =
+        "#{environment.getProperty('app.news.collector-mode') == 'reactive'}",
+    loadContext = true  // 환경 읽을려면 true해야함
+)
 @TestPropertySource(locations = "file:.env")
 class NewsCollectIntegrationTest extends IntegrationTestSupport {
 

--- a/src/test/java/com/team3/monew/integration/NewsCollectIntegrationTest.java
+++ b/src/test/java/com/team3/monew/integration/NewsCollectIntegrationTest.java
@@ -24,18 +24,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.EnabledIf;
 import reactor.test.StepVerifier;
 
 @SpringBootTest
 @ActiveProfiles("test")
 @Tag("external-api")
-@EnabledIf(
-    expression =
-        "#{environment.getProperty('app.news.collector-mode') == 'reactive'}",
-    loadContext = true  // 환경 읽을려면 true해야함
-)
-@TestPropertySource(locations = "file:.env")
+@TestPropertySource(locations = "file:.env", properties = "app.news.collector-mode=reactive")
 class NewsCollectIntegrationTest extends IntegrationTestSupport {
 
   @Autowired


### PR DESCRIPTION
## 관련 이슈
- #269 

## 작업 내용
- 뉴스기사 수집을 비동기로 구현했었던 것을 배치형태로 전환합니다

## 변경 사항
- application: 뉴스수집 비동기, 배치 분기처리 추가
- NewsCollectService: 분기에 따른 빈 로드기능 추가
- ArticleCollectBatchScheduleConfig: 뉴스기사 수집 배치 스케줄러 추가
  - 단위 테스트 추가
- ArticleCollectBatchConfig: 수집관련 batch, step 추가
  - 단위 테스트 추가

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 뉴스 수집 배치 처리 모드 추가
  * 설정 기반 수집 모드 선택 가능 (배치/반응형)
  * 정기적 스케줄에 따른 자동 배치 작업 실행

* **테스트**
  * 배치 작업 및 스케줄링 관련 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->