### PR TITLE
fix: 등록 시 중복 count 증가 문제 수정

### DIFF
--- a/src/main/java/com/team3/monew/repository/UserActivityRepository.java
+++ b/src/main/java/com/team3/monew/repository/UserActivityRepository.java
@@ -71,4 +71,20 @@ public interface UserActivityRepository extends MongoRepository<UserActivityDocu
   @Query("{ 'commentLikes.articleId': ?0 }")
   @Update("{ '$pull': { 'commentLikes': { 'articleId': ?0 } } }")
   void removeCommentLikeSummaryByArticleId(UUID articleId);
+
+  @Query("{ 'subscriptions.interestId': ?0 }")
+  @Update("{ '$set': { 'subscriptions.$.interestSubscriberCount': ?1 } }")
+  void updateSubscriberCount(UUID interestId, int count);
+
+  @Query("{ 'comments.id': ?0 }")
+  @Update("{ '$set': { 'comments.$.likeCount': ?1 } }")
+  void updateCommentLikeCount(UUID commentId, int count);
+
+  @Query("{ 'commentLikes.commentId': ?0 }")
+  @Update("{ '$set': { 'commentLikes.$.commentLikeCount': ?1 } }")
+  void updateCommentLikeCountInLikes(UUID commentId, int count);
+
+  @Query("{ 'articleViews.articleId': ?0 }")
+  @Update("{ '$set': { 'articleViews.$.articleViewCount': ?1 } }")
+  void updateArticleViewCount(UUID articleId, int count);
 }

--- a/src/main/java/com/team3/monew/service/UserActivityService.java
+++ b/src/main/java/com/team3/monew/service/UserActivityService.java
@@ -70,7 +70,8 @@ public class UserActivityService {
 
     userActivityDocument.addSubscriptionSummary(subscriptionSummary);
     userActivityRepository.save(userActivityDocument);
-    userActivityRepository.incrementSubscriberCount(subscriptionSummary.interestId(), 1);
+    userActivityRepository.updateSubscriberCount(subscriptionSummary.interestId(),
+        subscriptionSummary.interestSubscriberCount());
     log.debug("사용자 활동 내역 구독 업데이트 성공: userId={} interestId={}", userId, subscriptionSummary.interestId());
   }
 
@@ -102,8 +103,8 @@ public class UserActivityService {
       userActivityDocument.addCommentLikeSummary(commentLikeSummary);
       userActivityRepository.save(userActivityDocument);
     }
-    userActivityRepository.incrementCommentLikeCount(commentLikeSummary.commentId(), 1);
-    userActivityRepository.incrementCommentLikeCountInLikes(commentLikeSummary.commentId(), 1);
+    userActivityRepository.updateCommentLikeCount(commentLikeSummary.commentId(), commentLikeSummary.commentLikeCount());
+    userActivityRepository.updateCommentLikeCountInLikes(commentLikeSummary.commentId(), commentLikeSummary.commentLikeCount());
     log.debug("사용자 활동 내역 좋아요 업데이트 성공: userId={} commentLikeId={}", userId, commentLikeSummary.id());
   }
 
@@ -119,7 +120,7 @@ public class UserActivityService {
     userActivityDocument.addArticleViewSummary(articleViewSummary);
     userActivityRepository.save(userActivityDocument);
     if (isFirstView) {
-      userActivityRepository.incrementArticleViewCount(articleViewSummary.articleId(), 1);
+      userActivityRepository.updateArticleViewCount(articleViewSummary.articleId(), articleViewSummary.articleViewCount());
     }
     log.debug("사용자 활동 내역 기사 뷰 업데이트 성공: userId={} articleViewId={}", userId, articleViewSummary.id());
   }

--- a/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
+++ b/src/test/java/com/team3/monew/service/UserActivityServiceTest.java
@@ -1040,7 +1040,7 @@ class UserActivityServiceTest {
   }
 
   @Test
-  @DisplayName("구독 추가 시 다른 유저 문서의 구독자 수가 증가합니다.")
+  @DisplayName("구독 추가 시 모든 유저 문서의 구독자 수를 업데이트합니다.")
   void shouldIncrementSubscriberCount_whenSubscriptionAdded() {
     // given
     UUID interestId = UUID.randomUUID();
@@ -1057,7 +1057,7 @@ class UserActivityServiceTest {
         interestId,
         "경제",
         List.of("금리", "주식"),
-        10,
+        10, // 최신 구독자 수
         createdAt
     );
 
@@ -1068,7 +1068,7 @@ class UserActivityServiceTest {
 
     // then
     then(userActivityRepository).should().save(any(UserActivityDocument.class));
-    then(userActivityRepository).should().incrementSubscriberCount(interestId, 1);
+    then(userActivityRepository).should().updateSubscriberCount(interestId, 10);
   }
 
   @Test
@@ -1107,7 +1107,7 @@ class UserActivityServiceTest {
   }
 
   @Test
-  @DisplayName("댓글 좋아요 추가 시 댓글 작성자 문서의 likeCount와 다른 유저 문서의 commentLikeCount가 증가합니다.")
+  @DisplayName("댓글 좋아요 추가 시 댓글 작성자 문서의 likeCount와 다른 유저 문서의 commentLikeCount를 업데이트합니다.")
   void shouldIncrementCommentLikeCount_whenCommentLikeAdded() {
     // given
     UUID commentId = UUID.randomUUID();
@@ -1128,7 +1128,7 @@ class UserActivityServiceTest {
         UUID.randomUUID(),
         "commentWriter",
         "댓글 내용",
-        1,
+        1, // 최신 좋아요 수
         createdAt
     );
 
@@ -1139,8 +1139,8 @@ class UserActivityServiceTest {
 
     // then
     then(userActivityRepository).should().save(any(UserActivityDocument.class));
-    then(userActivityRepository).should().incrementCommentLikeCount(commentId, 1);
-    then(userActivityRepository).should().incrementCommentLikeCountInLikes(commentId, 1);
+    then(userActivityRepository).should().updateCommentLikeCount(commentId, 1);
+    then(userActivityRepository).should().updateCommentLikeCountInLikes(commentId, 1);
   }
 
   @Test
@@ -1217,7 +1217,7 @@ class UserActivityServiceTest {
   }
 
   @Test
-  @DisplayName("기사 조회 시 기사 뷰 조회수가 증가합니다.")
+  @DisplayName("기사 조회 시 기사 뷰 조회수를 업데이트합니다.")
   void shouldIncrementArticleViewCount_whenArticleViewed() {
     // given
     UUID articleId = UUID.randomUUID();
@@ -1240,7 +1240,7 @@ class UserActivityServiceTest {
         createdAt,
         "기사 요약",
         3,
-        100
+        100 // 최신 조회 수
     );
 
     given(userActivityRepository.findById(userId)).willReturn(Optional.of(userActivityDocument));
@@ -1250,7 +1250,7 @@ class UserActivityServiceTest {
 
     // then
     then(userActivityRepository).should().save(any(UserActivityDocument.class));
-    then(userActivityRepository).should().incrementArticleViewCount(articleId, 1);
+    then(userActivityRepository).should().updateArticleViewCount(articleId, 100);
   }
 
   @Test


### PR DESCRIPTION
## 관련 이슈
- closes #281 

## 작업 내용
- 좋아요 등록 시 좋아요 수 증가가 아닌 set으로 개선
- 기사 뷰 등록 시 조회 수 증가가 아닌 set으로 개선
- 구독 등록 시 구독자 수 증가가 아닌 set으로 개선

## 변경 사항
- 활동 내역 저장 후 count 증가 로직을 set 로직으로 변경했습니다.

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [ ] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [ ] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 이미 증가된 count를 가진 활동 내역을 저장하고 해당 활동 내역도 증가해서 2번 증가한 것으로 파악했습니다.
- 기사 재조회 시 복구 되었던것은 이미 조회된 것을 가장 위로 끌어올리면서 RDS에서 업데이트 되었던것으로 파악했습니다.
- 활동 내역 저장 후 저장한 문서를 접근하지 않는 경우는 우선 증감 로직 유지합니다. 예) 삭제, 댓글 수 증가

## 스크린샷 / 참고 자료
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 구독자 수, 댓글 좋아요 수, 아티클 조회 수 집계가 최신 총합을 반영하도록 수정되어 통계 정확도가 향상되었습니다.

* **Chores**
  * 활동 카운트 업데이트 방식이 일관되게 정리되어 데이터 동기화 신뢰성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->