### PR TITLE
fix: 배치 작업 시 멀티스레드를 고려한 격리 수준 조정

### DIFF
--- a/src/main/java/com/team3/monew/config/BatchConfig.java
+++ b/src/main/java/com/team3/monew/config/BatchConfig.java
@@ -1,10 +1,16 @@
 package com.team3.monew.config;
 
-import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.support.DefaultBatchConfiguration;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.annotation.Isolation;
 
 @Configuration
-@EnableBatchProcessing
-public class BatchConfig {
+public class BatchConfig extends DefaultBatchConfiguration {
 
+  // PostgreSQL의 SERIALIZABLE 격리 수준에서 발생하는 동시 실행 트랜잭션 충돌방지
+  // 격리 수준을 READ_COMMITTED로 조정 (메타데이터 저장 시의 데드락 방지)
+  @Override
+  protected Isolation getIsolationLevelForCreate() {
+    return Isolation.READ_COMMITTED;
+  }
 }


### PR DESCRIPTION
## 관련 이슈
- closes #287 

## 작업 내용
- BatchConfig 메타데이터 저장 시 격리 수준을 READ_COMMITTED로 조정

## 변경 사항
- 주요 변경 사항을 작성해주세요.

## 테스트 내용
- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 배치 처리 구성을 업데이트하여 데이터베이스 트랜잭션 격리 수준을 조정했습니다. 이를 통해 데이터 처리 안정성이 개선되고 예기치 않은 충돌 현상이 감소합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->