### PR TITLE
fix: 사용자 삭제 배치 시간 수정

### DIFF
--- a/src/main/java/com/team3/monew/batch/scheduler/UserDeleteScheduler.java
+++ b/src/main/java/com/team3/monew/batch/scheduler/UserDeleteScheduler.java
@@ -22,7 +22,7 @@ public class UserDeleteScheduler {
   private final BatchMetrics batchMetrics;
   private final Job userDeleteJob;
 
-  @Scheduled(cron = "${batch.user.delete.cron:0 0 2 * * *}")
+  @Scheduled(cron = "${batch.user.delete.cron:0 3 2 * * *}", zone = "${batch.user.delete.zone:Asia/Seoul}")
   public void run() {
     long startTime = System.currentTimeMillis();
     try {


### PR DESCRIPTION
## 관련 이슈
- closes #291 

## 작업 내용
- 배치 시간 기준을 asia/seoul로 수정
- 정각 배치와의 충돌 고려해 시간 수정

## 변경 사항
- 
## 테스트 내용
- [ ] 테스트 코드 작성
- [ ] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 기타 테스트 완료

## 체크리스트
- [ ] 코드 컨벤션을 지켰습니다.
- [ ] 불필요한 코드를 제거했습니다.
- [ ] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [ ] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 사용자 삭제 배치 스케줄러의 타임존 설정이 구성 가능해졌습니다. 기본값은 Asia/Seoul입니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->