### PR TITLE
refactor: JPA 배치 Insert/Update 설정을 통한 쓰기 성능 최적화

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,12 @@ spring:
     open-in-view: false
     hibernate:
       ddl-auto: validate
+    properties:
+      hibernate:
+        jdbc:
+          batch_size: 50
+        order_inserts: true
+        order_updates: true
   batch:
     job:
       enabled: false


### PR DESCRIPTION
## 관련 이슈
- closes #303 

## 작업 내용
- hibernate.jdbc.batch_size를 50으로 설정
- 쿼리 순서 정렬(order_inserts, order_updates) 활성화
- 대량 데이터 저장 시 네트워크 왕복 비용 감소 및 RPS 개선

## 변경 사항
- 주요 변경 사항을 작성해주세요.

## 테스트 내용
- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 최적화

* **Chores**
  * Hibernate JDBC 배치 처리 관련 데이터베이스 설정이 업데이트되었습니다. 배치 크기 구성과 삽입/업데이트 순서 최적화 옵션이 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->